### PR TITLE
Allow purges to fail without making sfdx command fail 

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -32,6 +32,7 @@
         "VERSIONNUMBER",
         "Vuillamy",
         "WIPO",
+        "allowpurgefailure",
         "apiversion",
         "callincallout",
         "callouts",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install hardis-group/sfdx-hardis@beta`
 
+## [0.5.10] 2021-02-12
+
+- Allow purges to fail without making sfdx command fail
+
 ## [0.5.5] 2021-02-10
 
 - Check if installed sfdx-hardis is the latest version, else display a message to advise the user to upgrade to latest

--- a/messages/org.json
+++ b/messages/org.json
@@ -1,4 +1,5 @@
 {
+  "allowPurgeFailure": "Allows purges to fail without exiting with 1. Use --no-allowpurgefailure to disable",
   "auditCallInCallOut": "Generate list of callIn and callouts from sfdx project",
   "auditRemoteSites": "Generate list of remote sites",
   "debugMode": "Activate debug mode (more logs)",

--- a/src/commands/hardis/org/purge/flow.ts
+++ b/src/commands/hardis/org/purge/flow.ts
@@ -48,6 +48,7 @@ export default class OrgPurgeFlow extends SfdxCommand {
     prompt: flags.boolean({char: 'z', default: true, allowNo: true,  description: messages.getMessage('prompt')}),
     name: flags.string({char: 'n', description: messages.getMessage('nameFilter')}),
     status: flags.string({char: 's', default: 'Obsolete', description: messages.getMessage('statusFilter')}),
+    allowpurgefailure: flags.boolean({char: 'f', default: true, allowNo: true,  description: messages.getMessage('allowPurgeFailure')}),
     sandbox: flags.boolean({ default: false, description: messages.getMessage('sandboxLogin')}),
     instanceurl: flags.string({char: 'r', default: 'https://login.saleforce.com',  description: messages.getMessage('instanceUrl')}),
     debug: flags.boolean({char: 'd', default: false, description: messages.getMessage('debugMode')})
@@ -68,6 +69,7 @@ export default class OrgPurgeFlow extends SfdxCommand {
     const prompt = (this.flags.prompt === false) ? false : true;
     const statusFilter = (this.flags.status) ? this.flags.status.split(',') : ['Obsolete'];
     const nameFilter = this.flags.name || null;
+    const allowPurgeFailure = (this.flags.allowpurgefailure === false) ? false : true;
     const debug = this.flags.debug || false ;
 
     // Check we don't delete active Flows
@@ -134,7 +136,12 @@ export default class OrgPurgeFlow extends SfdxCommand {
     }
 
     if (deleteErrors.length > 0) {
-      throw new SfdxError(`There are been errors while deleting ${deleteErrors.length} records: \n${JSON.stringify(deleteErrors)}`);
+      const errMsg = `[sfdx-hardis] There are been errors while deleting ${deleteErrors.length} records: \n${JSON.stringify(deleteErrors)}`;
+      if (allowPurgeFailure) {
+        console.warn(errMsg);
+      } else {
+        throw new SfdxError(`There are been errors while deleting ${deleteErrors.length} records: \n${JSON.stringify(deleteErrors)}`);
+      }
     }
 
     const summary = (deleted.length > 0) ? `[sfdx-hardis] Deleted the following list of records:\n${columnify(deleted)}` : '[sfdx-hardis] No record deleted';

--- a/src/hooks/init/check-upgrade.ts
+++ b/src/hooks/init/check-upgrade.ts
@@ -10,7 +10,7 @@ export const hook = async (options: any) => {
 
     // Check if an upgrade of sfdx-hardis is required
     // Use promise + then to not block plugin execution during that
-    let pkg = await readPkgUp({cwd: __dirname});
+    const pkg = await readPkgUp({cwd: __dirname});
     const notifier = updateNotifier({
         pkg: pkg.packageJson,
         updateCheckInterval: 900 // check every 15 mn


### PR DESCRIPTION
use --no-allow-purge-failure to force exit code 1 if flows have not been purged