### PR TITLE
Many many things

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -48,6 +48,7 @@
         "failiferror",
         "filteredmetadatas",
         "flowwww",
+        "forcenew",
         "genrsa",
         "globby",
         "hardis",

--- a/.github/workflows/deploy-ALPHA.yml
+++ b/.github/workflows/deploy-ALPHA.yml
@@ -51,5 +51,5 @@ jobs:
           name: hardisgroupcom/sfdx-hardis
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          buildargs: SFDX_HARDIS_VERSION=beta
+          buildargs: SFDX_HARDIS_VERSION=alpha
           tags: "alpha"

--- a/.github/workflows/deploy-ALPHA.yml
+++ b/.github/workflows/deploy-ALPHA.yml
@@ -1,0 +1,55 @@
+---
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#######################################
+# Start the job on all push to master #
+#######################################
+name: "Build & Deploy - ALPHA"
+on:
+  push:
+    branches:
+      - "alpha"
+
+###############
+# Set the Job #
+###############
+jobs:
+  deploy:
+    name: Deploy alpha
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+          always-auth: true
+          # Defaults to the user or organization that owns the workflow file
+          scope: "hardisgroupcom"
+      - run: yarn install --frozen-lockfile
+      - run: tsc
+      - run: yarn config set version-git-tag false
+      - run: BETAID=$(date '+%Y%m%d%H%M') && yarn version --prepatch --preid="alpha$BETAID"
+      - run: yarn publish --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  push_beta_to_registry:
+    name: Push Beta Docker image to Docker Hub
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Publish beta to Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: hardisgroupcom/sfdx-hardis
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          buildargs: SFDX_HARDIS_VERSION=beta
+          tags: "alpha"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image
 - #24: Change the way of listing installed packages
 - #26: New command sfdx hardis:project:configure:deployments to configure Connected app
 - #27: Check in manifest folder for package.xml
+- Auto-generate **alpha** version of plugin package and associated docker image when publishing from branch **alpha**
+- Manage cache storage for CI dependent jobs (cache, artifacts)
+  - .cache/sfdx-hardis/.sfdx
+  - .sfdx
+  - config/user
+- Improve org authentication
+- New command **hardis:org:test**
+  - Test org coverage and fail if < 75%
+- Installed package management
+  - Factorize method
+  - Install packages during hardis:project:deploy:sources:dx
+- Allow to reuse scratch org if previous creation failed. Force using --forcenew
+- Improve auto-update of local project sfdx-hardis files
+- Improve console logs
+- Allow to store DevHubSfdxClientId in user sfdx-hardis.yml ( in /user folder)
 
 ## [1.1.3] 2021-02-17
 

--- a/messages/org.json
+++ b/messages/org.json
@@ -21,6 +21,7 @@
   "retrieveDx": "Retrieve Salesforce DX project from org",
   "retrieveMetadatas": "Retrieve metadatas from an org with package.xml manifest",
   "sandboxLogin": "Use if the environment is a sandbox",
+  "scratch": "Scratch org",
   "scratchCreate": "Create and initialize a scratch org so it is ready to use",
   "statusFilter": "Filter according to Status criteria",
   "tempFolder": "Temporary folder",

--- a/messages/org.json
+++ b/messages/org.json
@@ -11,6 +11,7 @@
   "failIfError": "Fails (exit code 1) if an error is found",
   "filteredMetadatas": "Comma separated list of Metadatas keys to remove from PackageXml file",
   "folder": "Folder",
+  "forceNewScratch": "If an existing scratch org exists, do not reuse it but create a new one",
   "instanceUrl": "URL of org instance",
   "loginToOrg": "Login to salesforce org",
   "minimumApiVersion": "Minimum allowed API version",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
         "./lib/hooks/prerun/auth"
       ],
       "postrun": [
-        "./lib/hooks/postrun/notify"
+        "./lib/hooks/postrun/notify",
+        "./lib/hooks/postrun/store-cache"
       ]
     },
     "topics": {

--- a/src/commands/hardis/auth/login.ts
+++ b/src/commands/hardis/auth/login.ts
@@ -25,7 +25,7 @@ export default class Login extends SfdxCommand {
   protected static flagsConfig = {
     instanceurl: flags.string({ char: 'r', description: messages.getMessage('instanceUrl') }),
     devhub: flags.boolean({ char: 'h', default: false, description: messages.getMessage('withDevHub') }),
-    scratch: flags.boolean({ char: 's', default: false, description: messages.getMessage('scratch') }),
+    scratchorg: flags.boolean({ char: 's', default: false, description: messages.getMessage('scratch') }),
     debug: flags.boolean({ char: 'd', default: false, description: messages.getMessage('debugMode') })
   };
 
@@ -42,7 +42,7 @@ export default class Login extends SfdxCommand {
 
   public async run(): Promise<AnyJson> {
     const devHub = this.flags.devhub || false;
-    const scratch = this.flags.scratch || false;
+    const scratch = this.flags.scratchorg || false;
     await this.config.runHook('auth', { checkAuth: !devHub, Command: this, devHub, scratch });
 
     // Return an object to be displayed with --json

--- a/src/commands/hardis/auth/login.ts
+++ b/src/commands/hardis/auth/login.ts
@@ -26,7 +26,7 @@ export default class Login extends SfdxCommand {
     // flag with a value (-n, --name=VALUE)
     instanceurl: flags.string({ char: 'r', description: messages.getMessage('instanceUrl') }),
     devhub: flags.boolean({ char: 'h', default: false, description: messages.getMessage('withDevHub') }),
-    scratch: flags.boolean({ char: 's', default: false, description: 'Login to scratch org' }),
+    scratch: flags.boolean({ char: 's', default: false, description: messages.getMessage('scratch') }),
     debug: flags.boolean({ char: 'd', default: false, description: messages.getMessage('debugMode') })
   };
 

--- a/src/commands/hardis/auth/login.ts
+++ b/src/commands/hardis/auth/login.ts
@@ -23,7 +23,6 @@ export default class Login extends SfdxCommand {
   // public static args = [{name: 'file'}];
 
   protected static flagsConfig = {
-    // flag with a value (-n, --name=VALUE)
     instanceurl: flags.string({ char: 'r', description: messages.getMessage('instanceUrl') }),
     devhub: flags.boolean({ char: 'h', default: false, description: messages.getMessage('withDevHub') }),
     scratch: flags.boolean({ char: 's', default: false, description: messages.getMessage('scratch') }),

--- a/src/commands/hardis/auth/login.ts
+++ b/src/commands/hardis/auth/login.ts
@@ -17,16 +17,17 @@ export default class Login extends SfdxCommand {
   public static description = messages.getMessage('loginToOrg');
 
   public static examples = [
-  '$ sfdx hardis:auth:login'
+    '$ sfdx hardis:auth:login'
   ];
 
   // public static args = [{name: 'file'}];
 
   protected static flagsConfig = {
     // flag with a value (-n, --name=VALUE)
-    instanceurl: flags.string({char: 'r', description: messages.getMessage('instanceUrl')}),
-    devhub: flags.boolean({char: 'h', default: false, description: messages.getMessage('withDevHub')}),
-    debug: flags.boolean({char: 'd', default: false, description: messages.getMessage('debugMode')})
+    instanceurl: flags.string({ char: 'r', description: messages.getMessage('instanceUrl') }),
+    devhub: flags.boolean({ char: 'h', default: false, description: messages.getMessage('withDevHub') }),
+    scratch: flags.boolean({ char: 's', default: false, description: 'Login to scratch org' }),
+    debug: flags.boolean({ char: 'd', default: false, description: messages.getMessage('debugMode') })
   };
 
   // Comment this out if your command does not require an org username
@@ -38,13 +39,12 @@ export default class Login extends SfdxCommand {
   // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
   protected static requiresProject = false;
 
-  protected devHub = false;
-
   /* jscpd:ignore-end */
 
   public async run(): Promise<AnyJson> {
-    this.devHub = this.flags.devhub || false;
-    await this.config.runHook('auth', {checkAuth: !this.devHub, Command: this, devHub: this.devHub});
+    const devHub = this.flags.devhub || false;
+    const scratch = this.flags.scratch || false;
+    await this.config.runHook('auth', { checkAuth: !devHub, Command: this, devHub, scratch });
 
     // Return an object to be displayed with --json
     return { outputString: 'Logged to Salesforce org' };

--- a/src/commands/hardis/org/test/apex.ts
+++ b/src/commands/hardis/org/test/apex.ts
@@ -53,13 +53,13 @@ export default class OrgTestApex extends SfdxCommand {
     const debug = this.flags.debug || false;
 
     this.configInfo = await getConfig('branch');
-    const deployCommand = 'sfdx force:apex:test:run' +
+    const testCommand = 'sfdx force:apex:test:run' +
       ' --codecoverage' +
       ' --wait 60' +
       ` --testlevel ${testlevel}` +
       (check ? ' --checkonly' : '') +
       (debug ? ' --verbose' : '') ;
-    const testRes = await execSfdxJson(deployCommand, this, {output: true, debug, fail: false});
+    const testRes = await execSfdxJson(testCommand, this, {output: true, debug, fail: false});
     let message = '';
     if (testRes.status === 0) {
       message = '[sfdx-hardis] Successfully tested orgs';

--- a/src/commands/hardis/org/test/apex.ts
+++ b/src/commands/hardis/org/test/apex.ts
@@ -59,7 +59,7 @@ export default class OrgTestApex extends SfdxCommand {
       ` --testlevel ${testlevel}` +
       (check ? ' --checkonly' : '') +
       (debug ? ' --verbose' : '') ;
-    const testRes = await execSfdxJson(testCommand, this, {output: true, debug, fail: false});
+    const testRes = await execSfdxJson(testCommand, this, {output: true, debug, fail: true});
     let message = '';
     if (testRes.status === 0) {
       message = '[sfdx-hardis] Successfully tested orgs';

--- a/src/commands/hardis/org/test/apex.ts
+++ b/src/commands/hardis/org/test/apex.ts
@@ -55,11 +55,13 @@ export default class OrgTestApex extends SfdxCommand {
     this.configInfo = await getConfig('branch');
     const testCommand = 'sfdx force:apex:test:run' +
       ' --codecoverage' +
+      ' --resultformat human' +
+      ' --outputdir ./hardis-report' +
       ' --wait 60' +
       ` --testlevel ${testlevel}` +
       (check ? ' --checkonly' : '') +
-      (debug ? ' --verbose' : '') ;
-    const testRes = await execSfdxJson(testCommand, this, {output: true, debug, fail: true});
+      (debug ? ' --verbose' : '');
+    const testRes = await execSfdxJson(testCommand, this, { output: true, debug, fail: true });
     let message = '';
     if (testRes.status === 0) {
       message = '[sfdx-hardis] Successfully tested orgs';

--- a/src/commands/hardis/org/test/apex.ts
+++ b/src/commands/hardis/org/test/apex.ts
@@ -1,4 +1,3 @@
-/* jscpd:ignore-start */
 import { flags, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
@@ -44,8 +43,6 @@ export default class OrgTestApex extends SfdxCommand {
   // protected static requiresProject = true;
 
   protected configInfo: any = {};
-
-  /* jscpd:ignore-end */
 
   public async run(): Promise<AnyJson> {
     const check = this.flags.check || false;

--- a/src/commands/hardis/org/test/apex.ts
+++ b/src/commands/hardis/org/test/apex.ts
@@ -2,6 +2,7 @@ import { flags, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
 import * as c from 'chalk';
+import * as fs from 'fs-extra';
 import { execSfdxJson } from '../../../../common/utils';
 import { getConfig } from '../../../../config';
 
@@ -50,6 +51,8 @@ export default class OrgTestApex extends SfdxCommand {
     const debug = this.flags.debug || false;
 
     this.configInfo = await getConfig('branch');
+
+    await fs.ensureDir('./hardis-report');
     const testCommand = 'sfdx force:apex:test:run' +
       ' --codecoverage' +
       ' --resultformat human' +

--- a/src/commands/hardis/project/configure/auth.ts
+++ b/src/commands/hardis/project/configure/auth.ts
@@ -19,14 +19,14 @@ Messages.importMessagesDirectory(__dirname);
 // or any library that is using the messages framework can also be loaded this way.
 const messages = Messages.loadMessages('sfdx-hardis', 'org');
 
-export default class ConfigureDeployment extends SfdxCommand {
+export default class ConfigureAuth extends SfdxCommand {
 
-    public static title = 'Configure deployments';
+    public static title = 'Configure authentication';
 
-    public static description = 'Configure deployments from git branch to target org';
+    public static description = 'Configure authentication from git branch to target org';
 
     public static examples = [
-        '$ sfdx hardis:project:configure:deployments'
+        '$ sfdx hardis:project:configure:auth'
     ];
 
     // public static args = [{name: 'file'}];
@@ -122,6 +122,6 @@ export default class ConfigureDeployment extends SfdxCommand {
         this.ux.log(`[sfdx-hardis] Use ${c.green(crtFile)} as certificate on Connected App configuration page, ${c.bold(`then delete ${crtFile} for security`)}`);
         this.ux.log(`[sfdx-hardis] Then, configure CI variable ${c.green(`SFDX_CLIENT_ID_${((devHub) ? config.devHubAlias : branchName).toUpperCase()}`)} with value of ConsumerKey on Connected App configuration page`);
         // Return an object to be displayed with --json
-        return { outputString: 'Configured branch for deployment' };
+        return { outputString: 'Configured branch for authentication' };
     }
 }

--- a/src/commands/hardis/project/configure/deployment.ts
+++ b/src/commands/hardis/project/configure/deployment.ts
@@ -114,13 +114,13 @@ export default class ConfigureDeployment extends SfdxCommand {
                 `./config/.jwt/${config.devHubAlias}.key` :
                 `./config/branches/.jwt/${branchName}.key`);
         // Copy certificate file in user home project
-        const crtFile = path.join(require('os').homedir(), `${branchName}.crt`);
+        const crtFile = path.join(require('os').homedir(), (devHub) ?`${config.devHubAlias}.crt`:`${branchName}.crt`);
         await fs.copy(path.join(tmpDir, 'server.crt'), crtFile);
         await fs.remove(tmpDir);
         this.ux.log('[sfdx-hardis] Now you can configure the sfdx connected app');
+        this.ux.log(`[sfdx-hardis] Follow instructions here: ${c.bold('https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_connected_app.htm')}`);
         this.ux.log(`[sfdx-hardis] Use ${c.green(crtFile)} as certificate on Connected App configuration page, ${c.bold(`then delete ${crtFile} for security`)}`);
-        this.ux.log('[sfdx-hardis] Follow instructions here: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_connected_app.htm');
-        this.ux.log(`[sfdx-hardis] Then configure CI variable ${c.green(`SFDX_CLIENT_ID_${((devHub) ? config.devHubAlias : branchName).toUpperCase()}`)} with value of ConsumerKey on Connected App configuration page`);
+        this.ux.log(`[sfdx-hardis] Then, configure CI variable ${c.green(`SFDX_CLIENT_ID_${((devHub) ? config.devHubAlias : branchName).toUpperCase()}`)} with value of ConsumerKey on Connected App configuration page`);
         // Return an object to be displayed with --json
         return { outputString: 'Configured branch for deployment' };
     }

--- a/src/commands/hardis/project/configure/deployment.ts
+++ b/src/commands/hardis/project/configure/deployment.ts
@@ -114,7 +114,7 @@ export default class ConfigureDeployment extends SfdxCommand {
                 `./config/.jwt/${config.devHubAlias}.key` :
                 `./config/branches/.jwt/${branchName}.key`);
         // Copy certificate file in user home project
-        const crtFile = path.join(require('os').homedir(), (devHub) ?`${config.devHubAlias}.crt`:`${branchName}.crt`);
+        const crtFile = path.join(require('os').homedir(), (devHub) ? `${config.devHubAlias}.crt` : `${branchName}.crt`);
         await fs.copy(path.join(tmpDir, 'server.crt'), crtFile);
         await fs.remove(tmpDir);
         this.ux.log('[sfdx-hardis] Now you can configure the sfdx connected app');

--- a/src/commands/hardis/project/deploy/sources/dx.ts
+++ b/src/commands/hardis/project/deploy/sources/dx.ts
@@ -6,6 +6,7 @@ import * as c from 'chalk';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
+import { MetadataUtils } from '../../../../../common/metadata-utils';
 import { execCommand } from '../../../../../common/utils';
 import { CONSTANTS, getConfig } from '../../../../../config';
 
@@ -60,6 +61,12 @@ export default class DxSources extends SfdxCommand {
     const testlevel = this.flags.testlevel || 'RunLocalTests';
     const debug = this.flags.debug || false;
 
+    this.configInfo = await getConfig('branch');
+
+    // Install packages
+    const packages = this.configInfo.installedPackages || [];
+    await MetadataUtils.installPackagesOnOrg(packages, null, this);
+
     // Deploy destructive changes
     const packageDeletedXmlFile =
       process.env.PACKAGE_XML_TO_DELETE ||
@@ -98,7 +105,6 @@ export default class DxSources extends SfdxCommand {
     }
 
     // Deploy sources
-    this.configInfo = await getConfig('branch');
     const packageXmlFile =
       process.env.PACKAGE_XML_TO_DEPLOY ||
       this.configInfo.packageXmlToDeploy ||

--- a/src/commands/hardis/project/deploy/sources/dx.ts
+++ b/src/commands/hardis/project/deploy/sources/dx.ts
@@ -1,4 +1,5 @@
 /* jscpd:ignore-start */
+
 import { flags, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
@@ -46,9 +47,6 @@ export default class DxSources extends SfdxCommand {
   // Comment this out if your command does not require an org username
   protected static requiresUsername = true;
 
-  // Comment this out if your command does not support a hub org username
-  // protected static supportsDevhubUsername = true;
-
   // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
   protected static requiresProject = true;
 
@@ -60,7 +58,6 @@ export default class DxSources extends SfdxCommand {
     const check = this.flags.check || false;
     const testlevel = this.flags.testlevel || 'RunLocalTests';
     const debug = this.flags.debug || false;
-
     this.configInfo = await getConfig('branch');
 
     // Install packages
@@ -70,9 +67,9 @@ export default class DxSources extends SfdxCommand {
     // Deploy destructive changes
     const packageDeletedXmlFile =
       process.env.PACKAGE_XML_TO_DELETE ||
-      this.configInfo.packageXmlToDelete ||
-      (fs.existsSync('./manifest/destructiveChanges.xml')) ? './manifest/destructiveChanges.xml' :
-      './config/destructiveChanges.xml';
+        this.configInfo.packageXmlToDelete ||
+        (fs.existsSync('./manifest/destructiveChanges.xml')) ? './manifest/destructiveChanges.xml' :
+        './config/destructiveChanges.xml';
     if (fs.existsSync(packageDeletedXmlFile)) {
       // Create empty deployment file because of sfdx limitation
       // cf https://gist.github.com/benahm/b590ecf575ff3c42265425233a2d727e
@@ -92,7 +89,7 @@ export default class DxSources extends SfdxCommand {
         ' --ignorewarnings' + // So it does not fail in case metadata is already deleted
         (check ? ' --checkonly' : '') +
         (debug ? ' --verbose' : '');
-      const deployDeleteRes = await execCommand(deployDelete, this, {output: true, debug, fail: true});
+      const deployDeleteRes = await execCommand(deployDelete, this, { output: true, debug, fail: true });
       await fs.remove(tmpDir);
       let deleteMsg = '';
       if (deployDeleteRes.status === 0) {
@@ -107,15 +104,15 @@ export default class DxSources extends SfdxCommand {
     // Deploy sources
     const packageXmlFile =
       process.env.PACKAGE_XML_TO_DEPLOY ||
-      this.configInfo.packageXmlToDeploy ||
-      (fs.existsSync('./manifest/package.xml')) ? './manifest/package.xml' :
-      './config/package.xml';
+        this.configInfo.packageXmlToDeploy ||
+        (fs.existsSync('./manifest/package.xml')) ? './manifest/package.xml' :
+        './config/package.xml';
     const deployCommand = `sfdx force:source:deploy -x ${packageXmlFile}` +
       ' --wait 60' +
       ` --testlevel ${testlevel}` +
       (check ? ' --checkonly' : '') +
       (debug ? ' --verbose' : '');
-    const deployRes = await execCommand(deployCommand, this, {output: true, debug, fail: true});
+    const deployRes = await execCommand(deployCommand, this, { output: true, debug, fail: true });
     let message = '';
     if (deployRes.status === 0) {
       message = '[sfdx-hardis] Successfully deployed sfdx project sources to Salesforce org';

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -162,23 +162,10 @@ export default class ScratchCreate extends SfdxCommand {
         this.ux.log(`[sfdx-hardis] Created scratch org ${c.green(this.scratchOrgAlias)} with user ${c.green(this.scratchOrgUsername)}`);
     }
 
-    // Install managed packages
+    // Install packages
     public async installPackages() {
         const packages = this.configInfo.installedPackages || [];
-        const alreadyInstalled = await MetadataUtils.listInstalledPackages(null, this);
-        for (const package1 of packages) {
-            if (alreadyInstalled.filter((installedPackage: any) =>
-                package1.SubscriberPackageVersionId === installedPackage.SubscriberPackageVersionId).length === 0) {
-                this.ux.log(`[sfdx-hardis] Installing package ${package1.SubscriberPackageName} ${package1.SubscriberPackageVersionName}`);
-                if (package1.SubscriberPackageVersionId == null) {
-                    throw new SfdxError(c.red(`[sfdx-hardis] You must define ${c.bold('SubscriberPackageVersionId')} in .sfdx-hardis.yml (in installedPackages property)`));
-                }
-                const packageInstallCommand = `sfdx force:package:install --package ${package1.SubscriberPackageVersionId} -u ${this.scratchOrgAlias} --noprompt --securitytype AllUsers -w 60`;
-                await execCommand(packageInstallCommand, this, { fail: true, output: true });
-            } else {
-                this.ux.log(`[sfdx-hardis] Skip installation of ${package1.SubscriberPackageName} as it is already installed`);
-            }
-        }
+        await MetadataUtils.installPackagesOnOrg(packages, this.scratchOrgAlias, this);
     }
 
     // Push or deploy metadatas to the scratch org

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -148,7 +148,7 @@ export default class ScratchCreate extends SfdxCommand {
 
         if (process.env.CI) {
             const displayOrgCommand = `sfdx force:org:display -u ${this.scratchOrgAlias} --verbose`;
-            const displayResult = await execSfdxJson(displayOrgCommand, this, {fail: true, output: true, debug: this.debugMode});
+            const displayResult = await execSfdxJson(displayOrgCommand, this, {fail: true, output: false, debug: this.debugMode});
             await setConfig('user', {
                 scratchOrgAuthUrl: displayResult.sfdxAuthUrl
             });

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -84,7 +84,7 @@ export default class ScratchCreate extends SfdxCommand {
         this.configInfo = await getConfig('user');
         this.gitBranch = await getCurrentGitBranch({ formatted: true });
         this.scratchOrgAlias = process.env.SCRATCH_ORG_ALIAS || this.configInfo.scratchOrgAlias ||
-            os.userInfo().username + '-' + this.gitBranch.replace('/', '-') + moment().format('YYYY-MM-DD_hh-mm');
+            os.userInfo().username + '-' + this.gitBranch.replace('/', '-') + '_' + moment().format('YYYY-MM-DD_hh-mm');
         if (process.env.CI && !this.scratchOrgAlias.startsWith('CI-')) {
             this.scratchOrgAlias = 'CI-' + this.scratchOrgAlias;
         }
@@ -157,7 +157,7 @@ export default class ScratchCreate extends SfdxCommand {
             }
         } else {
             // Open scratch org for user if not in CI
-            await execSfdxJson('sfdx force:org:open', this, {fail: true, output: false, debug: this.debugMode});
+            await execSfdxJson('sfdx force:org:open', this, { fail: true, output: false, debug: this.debugMode });
         }
         this.ux.log(`[sfdx-hardis] Created scratch org ${c.green(this.scratchOrgAlias)} with user ${c.green(this.scratchOrgUsername)}`);
     }

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -147,13 +147,17 @@ export default class ScratchCreate extends SfdxCommand {
         });
 
         if (process.env.CI) {
+            // Try to store sfdxAuthUrl for scratch org reuse during CI
             const displayOrgCommand = `sfdx force:org:display -u ${this.scratchOrgAlias} --verbose`;
-            const displayResult = await execSfdxJson(displayOrgCommand, this, {fail: true, output: false, debug: this.debugMode});
-            await setConfig('user', {
-                scratchOrgAuthUrl: displayResult.sfdxAuthUrl
-            });
+            const displayResult = await execSfdxJson(displayOrgCommand, this, { fail: true, output: false, debug: this.debugMode });
+            if (displayResult.sfdxAuthUrl) {
+                await setConfig('user', {
+                    scratchOrgAuthUrl: displayResult.sfdxAuthUrl
+                });
+            }
         } else {
-            await execSfdxJson('sfdx force:org:open', this);
+            // Open scratch org for user if not in CI
+            await execSfdxJson('sfdx force:org:open', this, {fail: true, output: false, debug: this.debugMode});
         }
         this.ux.log(`[sfdx-hardis] Created scratch org ${c.green(this.scratchOrgAlias)} with user ${c.green(this.scratchOrgUsername)}`);
     }

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -3,6 +3,7 @@ import { flags, SfdxCommand } from '@salesforce/command';
 import { Messages, SfdxError } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
 import * as c from 'chalk';
+import { assert } from 'console';
 import * as EmailValidator from 'email-validator';
 import * as fs from 'fs-extra';
 import * as glob from 'glob-promise';
@@ -149,7 +150,10 @@ export default class ScratchCreate extends SfdxCommand {
             `--setalias ${this.scratchOrgAlias} ` +
             `--targetdevhubusername ${this.devHubAlias} ` +
             `-d ${this.scratchOrgDuration}`;
-        const createResult = await execSfdxJson(createCommand, this, { fail: true, output: true, debug: this.debugMode });
+        const createResult = await execSfdxJson(createCommand, this, { fail: false, output: false, debug: this.debugMode });
+        assert(createResult.status === 0,
+            c.red(`[sfdx-hardis] Error creating scratch org. Maybe try ${c.yellow(c.bold('sfdx hardis:scratch:create --forcenew'))} ?\n${JSON.stringify(createResult, null, 2)}`)
+        );
         this.scratchOrgInfo = createResult.result;
         this.scratchOrgUsername = this.scratchOrgInfo.username;
         await setConfig('user', {

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -159,7 +159,7 @@ export default class ScratchCreate extends SfdxCommand {
                 package1.SubscriberPackageVersionId === installedPackage.SubscriberPackageVersionId).length === 0) {
                 this.ux.log(`[sfdx-hardis] Installing package ${package1.SubscriberPackageName} ${package1.SubscriberPackageVersionName}`);
                 if (package1.SubscriberPackageVersionId == null) {
-                    throw new SfdxError(c.red('[sfdx-hardis] You must define PackageInstallId in .sfdx-hardis.yml'));
+                    throw new SfdxError(c.red(`[sfdx-hardis] You must define ${c.bold('SubscriberPackageVersionId')} in .sfdx-hardis.yml (in installedPackages property)`));
                 }
                 const packageInstallCommand = `sfdx force:package:install --package ${package1.SubscriberPackageVersionId} -u ${this.scratchOrgAlias} --noprompt --securitytype AllUsers -w 60`;
                 await execCommand(packageInstallCommand, this, { fail: true, output: true });

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -147,13 +147,11 @@ export default class ScratchCreate extends SfdxCommand {
         });
 
         if (process.env.CI) {
-            console.error('WE ARE HERE')
             const displayOrgCommand = `sfdx force:org:display -u ${this.scratchOrgAlias} --verbose`;
             const displayResult = await execSfdxJson(displayOrgCommand, this, {fail: true, output: true, debug: this.debugMode});
             await setConfig('user', {
                 scratchOrgAuthUrl: displayResult.sfdxAuthUrl
             });
-            console.error('WE ARE HERE2')
         } else {
             await execSfdxJson('sfdx force:org:open', this);
         }

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -112,7 +112,10 @@ export default class ScratchCreate extends SfdxCommand {
     // Create a new scratch org or reuse existing one
     public async createScratchOrg() {
         const orgListResult = await execSfdxJson('sfdx force:org:list', this);
-        const matchingScratchOrgs = (orgListResult?.result?.scratchOrgs.filter((org: any) => org.alias === this.scratchOrgAlias)) || [];
+        const matchingScratchOrgs = (orgListResult?.result?.scratchOrgs.filter((org: any) => {
+            return org.alias === this.scratchOrgAlias &&
+                org.status === 'Active'
+        })) || [];
         // Reuse existing scratch org
         if (matchingScratchOrgs?.length > 0) {
             this.scratchOrgInfo = matchingScratchOrgs[0];

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -114,7 +114,7 @@ export default class ScratchCreate extends SfdxCommand {
         const orgListResult = await execSfdxJson('sfdx force:org:list', this);
         const matchingScratchOrgs = (orgListResult?.result?.scratchOrgs.filter((org: any) => {
             return org.alias === this.scratchOrgAlias &&
-                org.status === 'Active'
+                org.status === 'Active';
         })) || [];
         // Reuse existing scratch org
         if (matchingScratchOrgs?.length > 0) {

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -147,11 +147,13 @@ export default class ScratchCreate extends SfdxCommand {
         });
 
         if (process.env.CI) {
+            console.error('WE ARE HERE')
             const displayOrgCommand = `sfdx force:org:display -u ${this.scratchOrgAlias} --verbose`;
-            const displayResult = await execSfdxJson(displayOrgCommand, this, {fail: true, output: false, debug: this.debugMode});
+            const displayResult = await execSfdxJson(displayOrgCommand, this, {fail: true, output: true, debug: this.debugMode});
             await setConfig('user', {
                 scratchOrgAuthUrl: displayResult.sfdxAuthUrl
             });
+            console.error('WE ARE HERE2')
         } else {
             await execSfdxJson('sfdx force:org:open', this);
         }

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -2,6 +2,7 @@ import Amplitude = require('@amplitude/node');
 import Debug from 'debug';
 import os = require('os');
 import path = require('path');
+import { isCI } from './utils';
 const debug = Debug('sfdx-essentials');
 
 /* analytics not implemented yet */
@@ -48,7 +49,7 @@ function buildEventPayload(eventType: string, data: any) {
     data.appVersion = pkgJson.version;
     data.osPlatform = os.platform();
     data.osRelease = os.release();
-    data.ci = process.env.CI ? true : false;
+    data.ci = isCI ? true : false;
     data.statsVersion = STATS_VERSION;
     data.command = eventType;
     return data;

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as sfdx from 'sfdx-node';
 import * as util from 'util';
-import { execSfdxJson, filterPackageXml } from '../../common/utils';
+import { execSfdxJson, filterPackageXml, uxLog } from '../../common/utils';
 import { CONSTANTS } from '../../config';
 const exec = util.promisify(child.exec);
 
@@ -158,15 +158,15 @@ class MetadataUtils {
                                         filteredMetadatas: string[], options: any = {}, commandThis: any, debug: boolean) {
 
     // Build package.xml for all org
-    commandThis.ux.log(`[sfdx-hardis] Generating full package.xml from ${commandThis.org.getUsername()}...`);
+    uxLog(commandThis,`[sfdx-hardis] Generating full package.xml from ${commandThis.org.getUsername()}...`);
     const manifestRes = await exec('sfdx sfpowerkit:org:manifest:build -o package.xml');
     if (debug) {
-      commandThis.ux.log(manifestRes.stdout + manifestRes.stderr);
+      uxLog(commandThis,manifestRes.stdout + manifestRes.stderr);
     }
 
     // Filter managed items if requested
     if (options.filterManagedItems) {
-      commandThis.ux.log('[sfdx-hardis] Filtering managed items from package.Xml manifest');
+      uxLog(commandThis,'[sfdx-hardis] Filtering managed items from package.Xml manifest');
       // List installed packages & collect managed namespaces
       const installedPackages = await this.listInstalledPackages(null, commandThis);
       const namespaces = [];
@@ -186,16 +186,16 @@ class MetadataUtils {
         removeFromPackageXmlFile: packageXmlToRemove,
         updateApiVersion: CONSTANTS.API_VERSION
       });
-      commandThis.ux.log(filterNamespaceRes.message);
+      uxLog(commandThis,filterNamespaceRes.message);
     }
 
     // Filter package XML to remove identified metadatas
     const filterRes = await filterPackageXml(packageXml, packageXml, { removeMetadatas: filteredMetadatas });
-    commandThis.ux.log(filterRes.message);
+    uxLog(commandThis,filterRes.message);
 
     // Retrieve metadatas
     if (fs.readdirSync(metadataFolder).length === 0 || checkEmpty === false) {
-      commandThis.ux.log(`[sfdx-hardis] Retrieving metadatas in ${metadataFolder}...`);
+      uxLog(commandThis,`[sfdx-hardis] Retrieving metadatas in ${metadataFolder}...`);
       const retrieveRes = await sfdx.mdapi.retrieve({
         retrievetargetdir: metadataFolder,
         unpackaged: packageXml,
@@ -205,10 +205,10 @@ class MetadataUtils {
         _rejectOnError: true
       });
       if (debug) {
-        commandThis.ux.log(retrieveRes);
+        uxLog(commandThis,retrieveRes);
       }
       // Unzip metadatas
-      commandThis.ux.log('[sfdx-hardis] Unzipping metadatas...');
+      uxLog(commandThis,'[sfdx-hardis] Unzipping metadatas...');
       await extractZip(path.join(metadataFolder, 'unpackaged.zip'), { dir: metadataFolder });
       await fs.unlink(path.join(metadataFolder, 'unpackaged.zip'));
     }

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -158,15 +158,15 @@ class MetadataUtils {
                                         filteredMetadatas: string[], options: any = {}, commandThis: any, debug: boolean) {
 
     // Build package.xml for all org
-    uxLog(commandThis,`[sfdx-hardis] Generating full package.xml from ${commandThis.org.getUsername()}...`);
+    uxLog(commandThis, `[sfdx-hardis] Generating full package.xml from ${commandThis.org.getUsername()}...`);
     const manifestRes = await exec('sfdx sfpowerkit:org:manifest:build -o package.xml');
     if (debug) {
-      uxLog(commandThis,manifestRes.stdout + manifestRes.stderr);
+      uxLog(commandThis, manifestRes.stdout + manifestRes.stderr);
     }
 
     // Filter managed items if requested
     if (options.filterManagedItems) {
-      uxLog(commandThis,'[sfdx-hardis] Filtering managed items from package.Xml manifest');
+      uxLog(commandThis, '[sfdx-hardis] Filtering managed items from package.Xml manifest');
       // List installed packages & collect managed namespaces
       const installedPackages = await this.listInstalledPackages(null, commandThis);
       const namespaces = [];
@@ -186,16 +186,16 @@ class MetadataUtils {
         removeFromPackageXmlFile: packageXmlToRemove,
         updateApiVersion: CONSTANTS.API_VERSION
       });
-      uxLog(commandThis,filterNamespaceRes.message);
+      uxLog(commandThis, filterNamespaceRes.message);
     }
 
     // Filter package XML to remove identified metadatas
     const filterRes = await filterPackageXml(packageXml, packageXml, { removeMetadatas: filteredMetadatas });
-    uxLog(commandThis,filterRes.message);
+    uxLog(commandThis, filterRes.message);
 
     // Retrieve metadatas
     if (fs.readdirSync(metadataFolder).length === 0 || checkEmpty === false) {
-      uxLog(commandThis,`[sfdx-hardis] Retrieving metadatas in ${metadataFolder}...`);
+      uxLog(commandThis, `[sfdx-hardis] Retrieving metadatas in ${metadataFolder}...`);
       const retrieveRes = await sfdx.mdapi.retrieve({
         retrievetargetdir: metadataFolder,
         unpackaged: packageXml,
@@ -205,10 +205,10 @@ class MetadataUtils {
         _rejectOnError: true
       });
       if (debug) {
-        uxLog(commandThis,retrieveRes);
+        uxLog(commandThis, retrieveRes);
       }
       // Unzip metadatas
-      uxLog(commandThis,'[sfdx-hardis] Unzipping metadatas...');
+      uxLog(commandThis, '[sfdx-hardis] Unzipping metadatas...');
       await extractZip(path.join(metadataFolder, 'unpackaged.zip'), { dir: metadataFolder });
       await fs.unlink(path.join(metadataFolder, 'unpackaged.zip'));
     }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -2,7 +2,6 @@ import * as c from 'chalk';
 import * as child from 'child_process';
 import * as csvStringify from 'csv-stringify/lib/sync';
 import * as fs from 'fs-extra';
-import * as os from 'os';
 import * as path from 'path';
 import * as util from 'util';
 import * as xml2js from 'xml2js';

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -2,6 +2,7 @@ import * as c from 'chalk';
 import * as child from 'child_process';
 import * as csvStringify from 'csv-stringify/lib/sync';
 import * as fs from 'fs-extra';
+import * as os from 'os';
 import * as path from 'path';
 import * as util from 'util';
 import * as xml2js from 'xml2js';
@@ -362,6 +363,7 @@ export async function copyLocalSfdxInfo() {
   if (fs.existsSync(SFDX_LOCAL_FOLDER)) {
     await fs.ensureDir(path.dirname(TMP_COPY_FOLDER));
     await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { overwrite: true });
+    fs.chownSync(TMP_COPY_FOLDER,os.userInfo().username)
     uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
   }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -350,10 +350,11 @@ export function uxLog(commandThis: any, text: string) {
 }
 
 // Caching methods
-const SFDX_LOCAL_FOLDER = '/root/.sfdx';
-const TMP_COPY_FOLDER = 'tmp/sfdx-hardis-local';
+const SFDX_LOCAL_FOLDER = '~/root/.sfdx';
+const TMP_COPY_FOLDER = './tmp/sfdx-hardis-local';
 let RESTORED = false;
 
+// Put local sfdx folder in tmp/sfdx-hardis-local for CI tools needing cache/artifacts to be within repo dir
 export async function copyLocalSfdxInfo() {
   if (!process.env.CI) {
     return;
@@ -365,8 +366,9 @@ export async function copyLocalSfdxInfo() {
   }
 }
 
+// Restore only once local Sfdx folder
 export async function restoreLocalSfdxInfo() {
-  if (!process.env.CI || RESTORED) {
+  if ((!process.env.CI) || RESTORED === true) {
     return;
   }
   if (fs.existsSync(TMP_COPY_FOLDER)) {

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -350,8 +350,8 @@ export function uxLog(commandThis: any, text: string) {
 }
 
 // Caching methods
-const SFDX_LOCAL_FOLDER = '~/root/.sfdx';
-const TMP_COPY_FOLDER = './tmp/sfdx-hardis-local';
+const SFDX_LOCAL_FOLDER = '/root/.sfdx';
+const TMP_COPY_FOLDER = 'tmp/sfdx-hardis-local';
 let RESTORED = false;
 
 // Put local sfdx folder in tmp/sfdx-hardis-local for CI tools needing cache/artifacts to be within repo dir

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -362,9 +362,9 @@ export async function copyLocalSfdxInfo() {
   if (fs.existsSync(SFDX_LOCAL_FOLDER)) {
     await fs.ensureDir(path.dirname(TMP_COPY_FOLDER));
     await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { dereference: true , overwrite: true });
-    uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
-    const files = fs.readdirSync(TMP_COPY_FOLDER, {withFileTypes: true}).map(item => item.name);
-    uxLog(this, '[cache]' + JSON.stringify(files));
+    //uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
+    //const files = fs.readdirSync(TMP_COPY_FOLDER, {withFileTypes: true}).map(item => item.name);
+    //uxLog(this, '[cache]' + JSON.stringify(files));
   }
 }
 
@@ -375,9 +375,9 @@ export async function restoreLocalSfdxInfo() {
   }
   if (fs.existsSync(TMP_COPY_FOLDER)) {
     await fs.copy(TMP_COPY_FOLDER, SFDX_LOCAL_FOLDER, { dereference: true, overwrite: false });
-    uxLog(this, '[cache] Restored cache for CI');
-    const files = fs.readdirSync(SFDX_LOCAL_FOLDER, {withFileTypes: true}).map(item => item.name);
-    uxLog(this, '[cache]' + JSON.stringify(files));
+    //uxLog(this, '[cache] Restored cache for CI');
+    //const files = fs.readdirSync(SFDX_LOCAL_FOLDER, {withFileTypes: true}).map(item => item.name);
+    //uxLog(this, '[cache]' + JSON.stringify(files));
     RESTORED = true;
   }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -348,3 +348,29 @@ export function uxLog(commandThis: any, text: string) {
     console.log(text);
   }
 }
+
+export async function copyLocalSfdxInfo() {
+  if (!process.env.CI) {
+    return;
+  }
+  const sfdxLocalFolder = '/root/.sfdx';
+  const tmpCopyFolder = '/tmp/hardis-sfdx-local';
+  if (fs.existsSync(sfdxLocalFolder)) {
+    await fs.copy(sfdxLocalFolder, tmpCopyFolder, { overwrite: true });
+  }
+}
+
+let RESTORED = false;
+
+export async function restoreLocalSfdxInfo() {
+  if (!process.env.CI || RESTORED) {
+    return;
+  }
+  const sfdxLocalFolder = '/root/.sfdx';
+  const tmpCopyFolder = '/tmp/hardis-sfdx-local';
+  if (fs.existsSync(tmpCopyFolder)) {
+    await fs.copy(tmpCopyFolder, sfdxLocalFolder, { overwrite: false });
+    uxLog(this, 'Restored cache for CI');
+    RESTORED = true;
+  }
+}

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -362,9 +362,9 @@ export async function copyLocalSfdxInfo() {
   if (fs.existsSync(SFDX_LOCAL_FOLDER)) {
     await fs.ensureDir(path.dirname(TMP_COPY_FOLDER));
     await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { dereference: true , overwrite: true });
-    //uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
-    //const files = fs.readdirSync(TMP_COPY_FOLDER, {withFileTypes: true}).map(item => item.name);
-    //uxLog(this, '[cache]' + JSON.stringify(files));
+    // uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
+    // const files = fs.readdirSync(TMP_COPY_FOLDER, {withFileTypes: true}).map(item => item.name);
+    // uxLog(this, '[cache]' + JSON.stringify(files));
   }
 }
 
@@ -375,9 +375,9 @@ export async function restoreLocalSfdxInfo() {
   }
   if (fs.existsSync(TMP_COPY_FOLDER)) {
     await fs.copy(TMP_COPY_FOLDER, SFDX_LOCAL_FOLDER, { dereference: true, overwrite: false });
-    //uxLog(this, '[cache] Restored cache for CI');
-    //const files = fs.readdirSync(SFDX_LOCAL_FOLDER, {withFileTypes: true}).map(item => item.name);
-    //uxLog(this, '[cache]' + JSON.stringify(files));
+    // uxLog(this, '[cache] Restored cache for CI');
+    // const files = fs.readdirSync(SFDX_LOCAL_FOLDER, {withFileTypes: true}).map(item => item.name);
+    // uxLog(this, '[cache]' + JSON.stringify(files));
     RESTORED = true;
   }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -363,7 +363,6 @@ export async function copyLocalSfdxInfo() {
   if (fs.existsSync(SFDX_LOCAL_FOLDER)) {
     await fs.ensureDir(path.dirname(TMP_COPY_FOLDER));
     await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { dereference: true , overwrite: true });
-    fs.chownSync(TMP_COPY_FOLDER,os.userInfo().username)
     uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
   }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -17,6 +17,8 @@ if (isGitRepo()) {
 
 let pluginsStdout = null;
 
+export const isCI = process.env.CI != null;
+
 export function isGitRepo() {
   const isInsideWorkTree = child.spawnSync(
     'git',
@@ -356,7 +358,7 @@ let RESTORED = false;
 
 // Put local sfdx folder in tmp/sfdx-hardis-local for CI tools needing cache/artifacts to be within repo dir
 export async function copyLocalSfdxInfo() {
-  if (!process.env.CI) {
+  if (!isCI) {
     return;
   }
   if (fs.existsSync(SFDX_LOCAL_FOLDER)) {
@@ -370,7 +372,7 @@ export async function copyLocalSfdxInfo() {
 
 // Restore only once local Sfdx folder
 export async function restoreLocalSfdxInfo() {
-  if ((!process.env.CI) || RESTORED === true) {
+  if ((!isCI) || RESTORED === true) {
     return;
   }
   if (fs.existsSync(TMP_COPY_FOLDER)) {

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -363,6 +363,8 @@ export async function copyLocalSfdxInfo() {
     await fs.ensureDir(path.dirname(TMP_COPY_FOLDER));
     await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { dereference: true , overwrite: true });
     uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
+    const files = fs.readdirSync(TMP_COPY_FOLDER, {withFileTypes: true}).map(item => item.name);
+    uxLog(this,'[cache]'+ JSON.stringify(files));
   }
 }
 
@@ -374,6 +376,8 @@ export async function restoreLocalSfdxInfo() {
   if (fs.existsSync(TMP_COPY_FOLDER)) {
     await fs.copy(TMP_COPY_FOLDER, SFDX_LOCAL_FOLDER, { dereference: true, overwrite: false });
     uxLog(this, '[cache] Restored cache for CI');
+    const files = fs.readdirSync(SFDX_LOCAL_FOLDER, {withFileTypes: true}).map(item => item.name);
+    uxLog(this,'[cache]'+ JSON.stringify(files));
     RESTORED = true;
   }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -362,7 +362,7 @@ export async function copyLocalSfdxInfo() {
   }
   if (fs.existsSync(SFDX_LOCAL_FOLDER)) {
     await fs.ensureDir(path.dirname(TMP_COPY_FOLDER));
-    await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { overwrite: true });
+    await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { dereference: true , overwrite: true });
     fs.chownSync(TMP_COPY_FOLDER,os.userInfo().username)
     uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
   }
@@ -374,7 +374,7 @@ export async function restoreLocalSfdxInfo() {
     return;
   }
   if (fs.existsSync(TMP_COPY_FOLDER)) {
-    await fs.copy(TMP_COPY_FOLDER, SFDX_LOCAL_FOLDER, { overwrite: false });
+    await fs.copy(TMP_COPY_FOLDER, SFDX_LOCAL_FOLDER, { dereference: true, overwrite: false });
     uxLog(this, '[cache] Restored cache for CI');
     RESTORED = true;
   }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -364,7 +364,7 @@ export async function copyLocalSfdxInfo() {
     await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { dereference: true , overwrite: true });
     uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
     const files = fs.readdirSync(TMP_COPY_FOLDER, {withFileTypes: true}).map(item => item.name);
-    uxLog(this,'[cache]'+ JSON.stringify(files));
+    uxLog(this, '[cache]' + JSON.stringify(files));
   }
 }
 
@@ -377,7 +377,7 @@ export async function restoreLocalSfdxInfo() {
     await fs.copy(TMP_COPY_FOLDER, SFDX_LOCAL_FOLDER, { dereference: true, overwrite: false });
     uxLog(this, '[cache] Restored cache for CI');
     const files = fs.readdirSync(SFDX_LOCAL_FOLDER, {withFileTypes: true}).map(item => item.name);
-    uxLog(this,'[cache]'+ JSON.stringify(files));
+    uxLog(this, '[cache]' + JSON.stringify(files));
     RESTORED = true;
   }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -351,7 +351,7 @@ export function uxLog(commandThis: any, text: string) {
 
 // Caching methods
 const SFDX_LOCAL_FOLDER = '/root/.sfdx';
-const TMP_COPY_FOLDER = 'tmp/sfdx-hardis-local';
+const TMP_COPY_FOLDER = '.cache/sfdx-hardis/sfdx';
 let RESTORED = false;
 
 // Put local sfdx folder in tmp/sfdx-hardis-local for CI tools needing cache/artifacts to be within repo dir

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -351,7 +351,7 @@ export function uxLog(commandThis: any, text: string) {
 
 // Caching methods
 const SFDX_LOCAL_FOLDER = '/root/.sfdx';
-const TMP_COPY_FOLDER = '.cache/sfdx-hardis/sfdx';
+const TMP_COPY_FOLDER = '.cache/sfdx-hardis/.sfdx';
 let RESTORED = false;
 
 // Put local sfdx folder in tmp/sfdx-hardis-local for CI tools needing cache/artifacts to be within repo dir

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -97,7 +97,7 @@ export async function execCommand(
     debug: false
   }
 ): Promise<any> {
-  uxLog(commandThis,`[sfdx-hardis][command] ${c.bold(c.grey(command))}`);
+  uxLog(commandThis, `[sfdx-hardis][command] ${c.bold(c.grey(command))}`);
   let commandResult = null;
   // Call command (disable color before for json parsing)
   const prevForceColor = process.env.FORCE_COLOR;
@@ -119,7 +119,7 @@ export async function execCommand(
   }
   // Display output if requested, for better user unrstanding of the logs
   if (options.output || options.debug) {
-    uxLog(commandThis,`[commandresult] ${commandResult.stdout}`);
+    uxLog(commandThis, `[commandresult] ${commandResult.stdout}`);
   }
   // Return status 0 if not --json
   process.env.FORCE_COLOR = prevForceColor;
@@ -343,9 +343,8 @@ export async function generateReports(
 export function uxLog(commandThis: any, text: string) {
   text = (text.includes('[sfdx-hardis]')) ? text : '[sfdx-hardis] ' + text;
   if (commandThis?.ux) {
-    commandThis.ux.log(text)
-  }
-  else {
+    commandThis.ux.log(text);
+  } else {
     console.log(text);
   }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -97,7 +97,7 @@ export async function execCommand(
     debug: false
   }
 ): Promise<any> {
-  commandThis.ux.log(`[sfdx-hardis][command] ${c.bold(c.grey(command))}`);
+  uxLog(commandThis,`[sfdx-hardis][command] ${c.bold(c.grey(command))}`);
   let commandResult = null;
   // Call command (disable color before for json parsing)
   const prevForceColor = process.env.FORCE_COLOR;
@@ -119,7 +119,7 @@ export async function execCommand(
   }
   // Display output if requested, for better user unrstanding of the logs
   if (options.output || options.debug) {
-    commandThis.ux.log(`[sfdx-hardis][commandresult] ${commandResult.stdout}`);
+    uxLog(commandThis,`[commandresult] ${commandResult.stdout}`);
   }
   // Return status 0 if not --json
   process.env.FORCE_COLOR = prevForceColor;
@@ -279,8 +279,8 @@ export async function catchMatches(
         catcherLabel
       });
       if (commandThis.debug) {
-        commandThis.ux.log(
-          `[sfdx-hardis] [${fileName}]: Match [${matches}] occurences of [${catcher.type}/${catcher.name}] with catcher [${catcherLabel}]`
+        uxLog(commandThis,
+          `[${fileName}]: Match [${matches}] occurences of [${catcher.type}/${catcher.name}] with catcher [${catcherLabel}]`
         );
       }
     }
@@ -331,11 +331,21 @@ export async function generateReports(
     columns
   });
   await fs.writeFile(reportFileExcel, excel, 'utf8');
-  commandThis.ux.log('[sfdx-hardis] Generated report files:');
-  commandThis.ux.log(`[sfdx-hardis] - CSV: ${reportFile}`);
-  commandThis.ux.log(`[sfdx-hardis] - XLS: ${reportFileExcel}`);
+  uxLog(commandThis, 'Generated report files:');
+  uxLog(commandThis, `- CSV: ${reportFile}`);
+  uxLog(commandThis, `- XLS: ${reportFileExcel}`);
   return [
     { type: 'csv', file: reportFile },
     { type: 'xls', file: reportFileExcel }
   ];
+}
+
+export function uxLog(commandThis: any, text: string) {
+  text = (text.includes('[sfdx-hardis]')) ? text : '[sfdx-hardis] ' + text;
+  if (commandThis?.ux) {
+    commandThis.ux.log(text)
+  }
+  else {
+    console.log(text);
+  }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -349,27 +349,28 @@ export function uxLog(commandThis: any, text: string) {
   }
 }
 
+// Caching methods
+const SFDX_LOCAL_FOLDER = '/root/.sfdx';
+const TMP_COPY_FOLDER = 'tmp/sfdx-hardis-local';
+let RESTORED = false;
+
 export async function copyLocalSfdxInfo() {
   if (!process.env.CI) {
     return;
   }
-  const sfdxLocalFolder = '/root/.sfdx';
-  const tmpCopyFolder = '/tmp/hardis-sfdx-local';
-  if (fs.existsSync(sfdxLocalFolder)) {
-    await fs.copy(sfdxLocalFolder, tmpCopyFolder, { overwrite: true });
+  if (fs.existsSync(SFDX_LOCAL_FOLDER)) {
+    await fs.ensureDir(path.dirname(TMP_COPY_FOLDER));
+    await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { overwrite: true });
+    uxLog(this, '[cache] Copied sfdx cache for later reuse');
   }
 }
-
-let RESTORED = false;
 
 export async function restoreLocalSfdxInfo() {
   if (!process.env.CI || RESTORED) {
     return;
   }
-  const sfdxLocalFolder = '/root/.sfdx';
-  const tmpCopyFolder = '/tmp/hardis-sfdx-local';
-  if (fs.existsSync(tmpCopyFolder)) {
-    await fs.copy(tmpCopyFolder, sfdxLocalFolder, { overwrite: false });
+  if (fs.existsSync(TMP_COPY_FOLDER)) {
+    await fs.copy(TMP_COPY_FOLDER, SFDX_LOCAL_FOLDER, { overwrite: false });
     uxLog(this, 'Restored cache for CI');
     RESTORED = true;
   }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -341,7 +341,7 @@ export async function generateReports(
 }
 
 export function uxLog(commandThis: any, text: string) {
-  text = (text.includes('[sfdx-hardis]')) ? text : '[sfdx-hardis] ' + text;
+  text = (text.includes('[sfdx-hardis]')) ? text : '[sfdx-hardis]' + (text.startsWith('[') ? '' : ' ') + text;
   if (commandThis?.ux) {
     commandThis.ux.log(text);
   } else {
@@ -362,7 +362,7 @@ export async function copyLocalSfdxInfo() {
   if (fs.existsSync(SFDX_LOCAL_FOLDER)) {
     await fs.ensureDir(path.dirname(TMP_COPY_FOLDER));
     await fs.copy(SFDX_LOCAL_FOLDER, TMP_COPY_FOLDER, { overwrite: true });
-    uxLog(this, '[cache] Copied sfdx cache for later reuse');
+    uxLog(this, `[cache] Copied sfdx cache in ${TMP_COPY_FOLDER} for later reuse`);
   }
 }
 
@@ -373,7 +373,7 @@ export async function restoreLocalSfdxInfo() {
   }
   if (fs.existsSync(TMP_COPY_FOLDER)) {
     await fs.copy(TMP_COPY_FOLDER, SFDX_LOCAL_FOLDER, { overwrite: false });
-    uxLog(this, 'Restored cache for CI');
+    uxLog(this, '[cache] Restored cache for CI');
     RESTORED = true;
   }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -94,7 +94,7 @@ export async function setInConfigFile(searchPlaces: string[], propValues: any, c
     doc = Object.assign(doc, propValues);
     await fs.ensureDir(path.dirname(configFile));
     await fs.writeFile(configFile, yaml.dump(doc));
-    if (explorer == null) {
+    if (explorer != null) {
         explorer.clearCaches();
     }
     console.log(c.cyan(`[sfdx-hardis] Updated config file ${configFile} with values ${JSON.stringify(propValues)}`));

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -56,7 +56,7 @@ export const getConfig = async (layer: string = 'user'): Promise<any> => {
         return branchConfig;
     }
     let userConfig = await loadFromConfigFile(userConfigFiles);
-    userConfig = Object.assign(defaultConfig, userConfig);
+    userConfig = Object.assign(branchConfig, userConfig);
     return userConfig;
 };
 

--- a/src/hooks/init/check-local-sfdx-hardis-files.ts
+++ b/src/hooks/init/check-local-sfdx-hardis-files.ts
@@ -1,6 +1,7 @@
 import * as c from 'chalk';
 import * as fs from 'fs-extra';
 import * as prompts from 'prompts';
+import { isCI } from '../../common/utils';
 
 export const hook = async (options: any) => {
     // Skip hooks from other commands than hardis:scratch commands
@@ -22,7 +23,7 @@ async function managePackageJson(commandId: string) {
         const packageJson = JSON.parse(text);
         const hardisPackageJsonContent = await getSfdxHardisPackageJsonContent();
         packageJson['scripts'] = Object.assign(packageJson['scripts'], hardisPackageJsonContent['scripts']);
-        if (JSON.stringify(packageJson) !== JSON.stringify(JSON.parse(text)) && !process.env.CI) {
+        if (JSON.stringify(packageJson) !== JSON.stringify(JSON.parse(text)) && !isCI) {
             const confirm = await prompts({
                 type: 'confirm',
                 name: 'value',
@@ -59,7 +60,7 @@ async function manageGitIgnore(commandId: string) {
                 updated = true;
             }
         }
-        if (updated && !process.env.CI) {
+        if (updated && !isCI) {
             const confirm = await prompts({
                 type: 'confirm',
                 name: 'value',

--- a/src/hooks/init/check-local-sfdx-hardis-files.ts
+++ b/src/hooks/init/check-local-sfdx-hardis-files.ts
@@ -5,36 +5,36 @@ import * as prompts from 'prompts';
 export const hook = async (options: any) => {
     // Skip hooks from other commands than hardis:scratch commands
     const commandId = options?.id || '';
-    // No await there because it can be processed while other commands
-    // tslint:disable no-floating-promises
-    managePackageJson(commandId);
-    manageGitIgnore(commandId);
-    // tslint:enable no-floating-promises
 
+    await managePackageJson(commandId);
+    await manageGitIgnore(commandId);
 };
 
 // Add utility scripts if they are not present
 async function managePackageJson(commandId: string) {
-    if (!commandId.startsWith('hardis:scratch') || !commandId.startsWith('hardis:project:configure')) {
+    if (!commandId.startsWith('hardis:scratch') && !commandId.startsWith('hardis:project:configure')) {
         return;
     }
     const packageJsonFile = './package.json';
     if (fs.existsSync(packageJsonFile)) {
         // Update existing package.json to define sfdx utility scripts
-        fs.readFile(packageJsonFile, 'utf8').then(async (text: string) => {
-            const packageJson = JSON.parse(text);
-            const hardisPackageJsonContent = await getSfdxHardisPackageJsonContent();
-            packageJson['scripts'] = Object.assign(hardisPackageJsonContent['scripts'], packageJson['scripts']);
-            if (JSON.stringify(packageJson) !== JSON.stringify(JSON.parse(text)) &&
-                !process.env.CI && (await prompts({
-                    type: 'confirm',
-                    name: 'update',
-                    message: 'Your package.json is deprecated, do you agree to upgrade it ? (If you hesitate, just trust us and accept)'
-                })).value === true) {
+        const text = await fs.readFile(packageJsonFile, 'utf8')
+        const packageJson = JSON.parse(text);
+        const hardisPackageJsonContent = await getSfdxHardisPackageJsonContent();
+        packageJson['scripts'] = Object.assign(packageJson['scripts'], hardisPackageJsonContent['scripts']);
+        if (JSON.stringify(packageJson) !== JSON.stringify(JSON.parse(text)) && !process.env.CI) {
+            const confirm = await prompts({
+                type: 'confirm',
+                name: 'value',
+                initial: true,
+                message: 'Your package.json is deprecated, do you agree to upgrade it ? (If you hesitate, just trust us and accept)'
+            });
+            if (confirm.value === true) {
                 await fs.writeFile(packageJsonFile, JSON.stringify(packageJson, null, 2));
                 console.log(c.cyan('[sfdx-hardis] Updated package.json with sfdx-hardis content'));
             }
-        });
+        }
+
     } else {
         // Create package.json to define sfdx utility scripts
         const hardisPackageJsonContent = await getSfdxHardisPackageJsonContent();
@@ -59,15 +59,18 @@ async function manageGitIgnore(commandId: string) {
                 updated = true;
             }
         }
-        if (updated && !process.env.CI && (await prompts({
-            type: 'confirm',
-            name: 'update',
-            message: 'Your .gitignore is deprecated, do you agree to upgrade it ? (If you hesitate, just trust us and accept)'
-        })).value === true) {
-            await fs.writeFile(gitIgnoreFile, gitIgnoreLines.join('\n') + '\n', 'utf-8');
-            console.log(c.cyan('[sfdx-hardis] Updated .gitignore'));
+        if (updated && !process.env.CI) {
+            const confirm = await prompts({
+                type: 'confirm',
+                name: 'value',
+                initial: true,
+                message: 'Your .gitignore is deprecated, do you agree to upgrade it ? (If you hesitate, just trust us and accept)'
+            });
+            if (confirm.value === true) {
+                await fs.writeFile(gitIgnoreFile, gitIgnoreLines.join('\n') + '\n', 'utf-8');
+                console.log(c.cyan('[sfdx-hardis] Updated .gitignore'));
+            }
         }
-
     }
 }
 

--- a/src/hooks/init/check-local-sfdx-hardis-files.ts
+++ b/src/hooks/init/check-local-sfdx-hardis-files.ts
@@ -14,7 +14,7 @@ export const hook = async (options: any) => {
 
 // Add utility scripts if they are not present
 async function managePackageJson(commandId: string) {
-    if (!commandId.startsWith('hardis:scratch')) {
+    if (!commandId.startsWith('hardis:scratch') || !commandId.startsWith('hardis:project:configure')) {
         return;
     }
     const packageJsonFile = './package.json';

--- a/src/hooks/init/check-local-sfdx-hardis-files.ts
+++ b/src/hooks/init/check-local-sfdx-hardis-files.ts
@@ -80,8 +80,8 @@ async function getSfdxHardisPackageJsonContent() {
             'org:test:apex': 'sfdx hardis:org:test:apex',
             'scratch:create': 'sfdx hardis:scratch:create',
             'login:reset': 'sfdx auth:logout --noprompt || true && sfdx config:unset defaultusername defaultdevhubusername -g && sfdx config:unset defaultusername defaultdevhubusername || true',
-            'configure:org:devhub': 'sfdx hardis:project:configure:deployments --devhub',
-            'configure:org:deployment': 'sfdx hardis:project:configure:deployments'
+            'configure:auth:devhub': 'sfdx hardis:project:configure:auth --devhub',
+            'configure:auth:deployment': 'sfdx hardis:project:configure:auth'
         }
     };
     return hardisPackageJsonContent;

--- a/src/hooks/init/check-local-sfdx-hardis-files.ts
+++ b/src/hooks/init/check-local-sfdx-hardis-files.ts
@@ -92,6 +92,7 @@ async function getSfdxHardisPackageJsonContent() {
 
 async function getHardisGitRepoIgnoreContent() {
     const gitIgnoreContent = [
+        '.cache/',
         'config/user/',
         'hardis-report/',
         'tmp/'

--- a/src/hooks/init/check-local-sfdx-hardis-files.ts
+++ b/src/hooks/init/check-local-sfdx-hardis-files.ts
@@ -18,7 +18,7 @@ async function managePackageJson(commandId: string) {
     const packageJsonFile = './package.json';
     if (fs.existsSync(packageJsonFile)) {
         // Update existing package.json to define sfdx utility scripts
-        const text = await fs.readFile(packageJsonFile, 'utf8')
+        const text = await fs.readFile(packageJsonFile, 'utf8');
         const packageJson = JSON.parse(text);
         const hardisPackageJsonContent = await getSfdxHardisPackageJsonContent();
         packageJson['scripts'] = Object.assign(packageJson['scripts'], hardisPackageJsonContent['scripts']);

--- a/src/hooks/postrun/notify.ts
+++ b/src/hooks/postrun/notify.ts
@@ -1,6 +1,6 @@
 import * as changedGitFiles from 'changed-git-files';
 import { IncomingWebhook } from 'ms-teams-webhook';
-import { copyLocalSfdxInfo, isGitRepo } from '../../common/utils';
+import { isGitRepo } from '../../common/utils';
 import { getConfig } from '../../config';
 
 export const hook = async (options: any) => {
@@ -9,9 +9,6 @@ export const hook = async (options: any) => {
     if (!commandId.startsWith('hardis')) {
         return;
     }
-
-    // Copy local SFDX info for CI
-    await copyLocalSfdxInfo();
 
     // Send hook to microsoft ?teams if MS_TEAMS_WEBHOOK_URL env var is set, or msTeamsWebhookUrl in config
     const config = await getConfig('user');

--- a/src/hooks/postrun/notify.ts
+++ b/src/hooks/postrun/notify.ts
@@ -1,6 +1,6 @@
 import * as changedGitFiles from 'changed-git-files';
 import { IncomingWebhook } from 'ms-teams-webhook';
-import { isGitRepo } from '../../common/utils';
+import { copyLocalSfdxInfo, isGitRepo } from '../../common/utils';
 import { getConfig } from '../../config';
 
 export const hook = async (options: any) => {
@@ -9,6 +9,10 @@ export const hook = async (options: any) => {
     if (!commandId.startsWith('hardis')) {
         return;
     }
+
+    // Copy local SFDX info for CI
+    await copyLocalSfdxInfo();
+
     // Send hook to microsoft ?teams if MS_TEAMS_WEBHOOK_URL env var is set, or msTeamsWebhookUrl in config
     const config = await getConfig('user');
     const msTeamsWebhookUrl = process.env.MS_TEAMS_WEBHOOK_URL || config.msTeamsWebhookUrl ;

--- a/src/hooks/postrun/store-cache.ts
+++ b/src/hooks/postrun/store-cache.ts
@@ -1,0 +1,13 @@
+import { copyLocalSfdxInfo } from '../../common/utils';
+
+export const hook = async (options: any) => {
+    // Skip hooks from other commands than hardis commands
+    const commandId = options?.Command?.id || '';
+    if (!commandId.startsWith('hardis')) {
+        return;
+    }
+
+    // Copy local SFDX cache for CI
+    await copyLocalSfdxInfo();
+    return;
+};

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -71,6 +71,7 @@ async function authOrg(orgAlias: string, options: any) {
             orgInfoResult.result &&
             ((orgInfoResult.result.connectedStatus &&
                 orgInfoResult.result.connectedStatus.includes('Connected')) ||
+                (options.scratch && orgInfoResult.result.connectedStatus.includes('Unknown')) ||
                 (orgInfoResult.result.alias === orgAlias && orgInfoResult.result.id != null) ||
                 (isDevHub && orgInfoResult.result.id != null))
         ) {

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -34,7 +34,7 @@ export const hook = async (options: any) => {
     if (
         (options.Command && options.Command.requiresUsername === true) || options.checkAuth === true
     ) {
-        console.warn("CONFIG INFOOOO "+JSON.stringify(configInfo,null,2));
+        console.warn('CONFIG INFOOOO ' + JSON.stringify(configInfo, null, 2));
         const orgAlias =
             (process.env.ORG_ALIAS) ? process.env.ORG_ALIAS :
                 (process.env.CI && configInfo.scratchOrgAlias) ? configInfo.scratchOrgAlias :

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -95,7 +95,7 @@ async function authOrg(orgAlias: string, options: any) {
                     (isDevHub) ? config.devHubUsername : config.targetUsername;
         if (username == null && process.env.CI) {
             const gitBranchFormatted = await getCurrentGitBranch({ formatted: true });
-            console.error(c.red(`[sfdx-hardis][ERROR] You may have to define ${c.bold(
+            console.error(c.yellow(`[sfdx-hardis][WARNING] You may have to define ${c.bold(
                 isDevHub ?
                     'devHubUsername in .sfdx-hardis.yml' :
                     (options.scratch) ?

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -34,6 +34,7 @@ export const hook = async (options: any) => {
     if (
         (options.Command && options.Command.requiresUsername === true) || options.checkAuth === true
     ) {
+        console.warn("CONFIG INFOOOO "+JSON.stringify(configInfo,null,2));
         const orgAlias =
             (process.env.ORG_ALIAS) ? process.env.ORG_ALIAS :
                 (process.env.CI && configInfo.scratchOrgAlias) ? configInfo.scratchOrgAlias :
@@ -65,7 +66,7 @@ async function authOrg(orgAlias: string, options: any) {
         if (orgAlias !== 'MY_ORG') {
             orgDisplayCommand += ' --targetusername ' + orgAlias;
         }
-        const orgInfoResult = await execSfdxJson(orgDisplayCommand, this, { fail: false });
+        const orgInfoResult = await execSfdxJson(orgDisplayCommand, this, { fail: false, output: true });
         if (
             orgInfoResult.result &&
             ((orgInfoResult.result.connectedStatus &&
@@ -91,10 +92,12 @@ async function authOrg(orgAlias: string, options: any) {
                     (isDevHub) ? config.devHubUsername : config.targetUsername;
         if (username == null && process.env.CI) {
             const gitBranchFormatted = await getCurrentGitBranch({ formatted: true });
-            console.error(c.red(`[sfdx-hardis][ERROR] You may have to define ${c.bold(isDevHub ?
-                'devHubUsername in .sfdx-hardis.yml' : (options.scratch) ?
-                    'cache between your CI jobs: folder ".cache/sfdx-hardis/.sfdx"' :
-                    `targetUsername in config/branches/.sfdx-hardis.${gitBranchFormatted}.yml`)} `));
+            console.error(c.red(`[sfdx-hardis][ERROR] You may have to define ${c.bold(
+                isDevHub ?
+                    'devHubUsername in .sfdx-hardis.yml' :
+                    (options.scratch) ?
+                        'cache between your CI jobs: folder ".cache/sfdx-hardis/.sfdx"' :
+                        `targetUsername in config/branches/.sfdx-hardis.${gitBranchFormatted}.yml`)} `));
             process.exit(1);
         }
         const instanceUrl =

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -93,7 +93,7 @@ async function authOrg(orgAlias: string, options: any) {
             const gitBranchFormatted = await getCurrentGitBranch({ formatted: true });
             console.error(c.red(`[sfdx-hardis][ERROR] You may have to define ${c.bold(isDevHub ?
                 'devHubUsername in .sfdx-hardis.yml' : (options.scratch) ?
-                    'cache between your CI jobs (.sfdx  and config/user/)' :
+                    'cache between your CI jobs: folder ".cache/sfdx-hardis/.sfdx"' :
                     `targetUsername in config/branches/.sfdx-hardis.${gitBranchFormatted}.yml`)} `));
             process.exit(1);
         }

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -190,6 +190,7 @@ async function authOrg(orgAlias: string, options: any) {
 
 // Get clientId for SFDX connected app
 async function getSfdxClientId(orgAlias: string, config: any) {
+    // Try to find in global variables
     const sfdxClientIdVarName = `SFDX_CLIENT_ID_${orgAlias}`;
     if (process.env[sfdxClientIdVarName]) {
         return process.env[sfdxClientIdVarName];
@@ -203,6 +204,10 @@ async function getSfdxClientId(orgAlias: string, config: any) {
             c.yellow(`[sfdx-hardis] If you use CI on multiple branches & orgs, you should better define ${sfdxClientIdVarNameUpper} than SFDX_CLIENT_ID`)
         );
         return process.env.SFDX_CLIENT_ID;
+    }
+    // Try to find in config files ONLY IN LOCAL MODE (in CI, it's supposed to be a CI variable)
+    if (!process.env.CI && config.devHubSfdxClientId) {
+        return config.devHubSfdxClientId;
     }
     if (process.env.CI) {
         console.error(

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -66,7 +66,7 @@ async function authOrg(orgAlias: string, options: any) {
         // Check if we are already authenticated
         let orgDisplayCommand = 'sfdx force:org:display';
         if (orgAlias !== 'MY_ORG') {
-            orgDisplayCommand += '--targetusername ' + orgAlias;
+            orgDisplayCommand += ' --targetusername ' + orgAlias;
         }
         const orgInfoResult = await execSfdxJson(orgDisplayCommand, this, {fail: false});
         if (

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -34,7 +34,6 @@ export const hook = async (options: any) => {
     if (
         (options.Command && options.Command.requiresUsername === true) || options.checkAuth === true
     ) {
-        console.warn('CONFIG INFOOOO ' + JSON.stringify(configInfo, null, 2));
         const orgAlias =
             (process.env.ORG_ALIAS) ? process.env.ORG_ALIAS :
                 (process.env.CI && configInfo.scratchOrgAlias) ? configInfo.scratchOrgAlias :
@@ -66,7 +65,7 @@ async function authOrg(orgAlias: string, options: any) {
         if (orgAlias !== 'MY_ORG') {
             orgDisplayCommand += ' --targetusername ' + orgAlias;
         }
-        const orgInfoResult = await execSfdxJson(orgDisplayCommand, this, { fail: false, output: true });
+        const orgInfoResult = await execSfdxJson(orgDisplayCommand, this, { fail: false, output: false, debug: options.debug });
         if (
             orgInfoResult.result &&
             ((orgInfoResult.result.connectedStatus &&

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -3,7 +3,7 @@ import * as c from 'chalk';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { execCommand, execSfdxJson, getCurrentGitBranch, uxLog } from '../../common/utils';
+import { execCommand, execSfdxJson, getCurrentGitBranch, restoreLocalSfdxInfo, uxLog } from '../../common/utils';
 import { checkConfig, getConfig } from '../../config';
 
 export const hook = async (options: any) => {
@@ -16,6 +16,7 @@ export const hook = async (options: any) => {
     if (typeof global.it === 'function') {
         return;
     }
+    await restoreLocalSfdxInfo();
     let configInfo = await getConfig('user');
     // Manage authentication if DevHub is required but current user is disconnected
     if (

--- a/src/hooks/prerun/auth.ts
+++ b/src/hooks/prerun/auth.ts
@@ -74,6 +74,9 @@ async function authOrg(orgAlias: string, options: any) {
                 (orgInfoResult.result.alias === orgAlias && orgInfoResult.result.id != null) ||
                 (isDevHub && orgInfoResult.result.id != null))
         ) {
+            // Set as default username or devhubusername
+            const setDefaultUsernameCommand = `sfdx config:set ${isDevHub ? 'defaultdevhubusername' : 'defaultusername'}=${orgInfoResult.result.username}`;
+            await execCommand(setDefaultUsernameCommand, this, {});
             doConnect = false;
             console.log(
                 `[sfdx-hardis] You are already ${c.green('connected')} to org ${c.green(orgAlias)}: ${c.green(orgInfoResult.result.instanceUrl)}`


### PR DESCRIPTION
- Auto-generate **alpha** version of plugin package and associated docker image when publishing from branch **alpha**
- Manage cache storage for CI dependent jobs (cache, artifacts)
  - .cache/sfdx-hardis/.sfdx
  - .sfdx
  - config/user
- Improve org authentication
- New command **hardis:org:test**
  - Test org coverage and fail if < 75%
- Installed package management
  - Factorize method
  - Install packages during hardis:project:deploy:sources:dx
- Allow to reuse scratch org if previous creation failed. Force using --forcenew
- Improve auto-update of local project sfdx-hardis files
- Improve console logs
- Allow to store DevHubSfdxClientId in user sfdx-hardis.yml ( in /user folder)