### PR TITLE
SFDMU + enhancements

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -253,6 +253,7 @@
         "packagexmltargetorg",
         "parseable",
         "partage",
+        "pascalcase",
         "passin",
         "passout",
         "pckg",

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -10,6 +10,7 @@
     "**/.github/**",
     "**/.idea/**",
     "**/report/**",
+    "**/org/data/import.ts",
     "**/README.md",
     "**/commands/hardis/work/**"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ dataPackages:
 - Propose to update or not default target git branch
 - List target git branches if defined in .sfdx-hardis.json `availableTargetBranches` property
 - **hardis:scratch:delete**: Propose only scratch orgs related to currently selected Dev Hub
+- New command **hardis:org:configure:data** to initialize a SFDMU project, sfdx-hardis flavored
 - Display data package label & description, from SFDMU folder config.json properties `sfdxHardisLabel` and `sfdxHardisDescription`
+- **hardis:org:data:import** & **hardis:org:data:import**: Allow to select current org or another when running data import/export commands
 - Display Dev Hub username when listing orgs for selection
 
 ## [2.31.1] 2021-07-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [2.31.1] 2021-07-06
+
+- **hardis:scratch:create**: Initialize data using SFDMU, if defined in .sfdx-hardis.json `dataPackages` property with `importInScratchOrgs: true`
+  - Example
+
+```yaml
+dataPackages:
+  - dataPath: scripts/data/LightningSchedulerConfig
+    importInScratchOrgs: true
+```
+
+- Propose to update or not default target git branch
+- List target git branches if defined in .sfdx-hardis.json `availableTargetBranches` property
+- **hardis:scratch:delete**: Propose only scratch orgs related to currently selected Dev Hub
+- Display data package label & description, from SFDMU folder config.json properties `sfdxHardisLabel` and `sfdxHardisDescription`
+- Display Dev Hub username when listing orgs for selection
+
 ## [2.31.1] 2021-07-02
 
 - **hardis:scratch:delete** : Display instanceUrl & last usage of scratch orgs displayed before deletion

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ms-teams-webhook": "^1.0.4",
     "open": "^8.0.2",
     "ora": "^5.3.0",
+    "pascalcase": "^1.0.0",
     "prompts": "^2.4.0",
     "psl": "^1.8.0",
     "read-pkg-up": "^7.0.1",

--- a/src/commands/hardis/org/configure/data.ts
+++ b/src/commands/hardis/org/configure/data.ts
@@ -1,0 +1,129 @@
+/* jscpd:ignore-start */
+import { flags, SfdxCommand } from "@salesforce/command";
+import { Messages, SfdxError } from "@salesforce/core";
+import { AnyJson } from "@salesforce/ts-types";
+import * as c from "chalk";
+import * as fs from 'fs-extra';
+import * as pascalcase from "pascalcase";
+import * as path from "path";
+import { uxLog } from "../../../../common/utils";
+import { dataFolderRoot } from "../../../../common/utils/dataUtils";
+import { prompts } from "../../../../common/utils/prompts";
+import { WebSocketClient } from "../../../../common/websocketClient";
+import { getConfig, setConfig } from "../../../../config";
+
+// Initialize Messages with the current plugin directory
+Messages.importMessagesDirectory(__dirname);
+
+// Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
+// or any library that is using the messages framework can also be loaded this way.
+const messages = Messages.loadMessages("sfdx-hardis", "org");
+
+export default class ConfigureData extends SfdxCommand {
+  public static title = "Configure Data project";
+
+  public static description = "Configure Data Export/Import with a SFDMU Project";
+
+  public static examples = ["$ sfdx hardis:org:configure:data"];
+
+  protected static flagsConfig = {
+    debug: flags.boolean({
+      char: "d",
+      default: false,
+      description: messages.getMessage("debugMode"),
+    }),
+    websocket: flags.string({
+      description: messages.getMessage("websocket"),
+    }),
+  };
+
+  // Comment this out if your command does not require an org username
+  protected static requiresUsername = false;
+
+  // Comment this out if your command does not support a hub org username
+  // protected static supportsDevhubUsername = true;
+
+  // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
+  protected static requiresProject = false;
+
+  // List required plugins, their presence will be tested before running the command
+  protected static requiresSfdxPlugins = ["sfdmu"];
+
+  /* jscpd:ignore-end */
+
+  public async run(): Promise<AnyJson> {
+    // Request info to build sfdmu workspace
+    const resp = await prompts([
+      {
+        type: "text",
+        name: "dataPath",
+        message: c.cyanBright('Please input the SFDMU folder name (PascalCase format). Ex: "ProductsActive"'),
+      },
+      {
+        type: "text",
+        name: "sfdxHardisLabel",
+        message: c.cyanBright('Please input the SFDMU config label. Ex: "Active Products"'),
+      },
+      {
+        type: "text",
+        name: "sfdxHardisDescription",
+        message: c.cyanBright(
+          'Please input the SFDMU config description. Ex: "Active products are used for scratch org initialization and in deployments"'
+        ),
+      },
+      {
+        type: "confirm",
+        name: "importInScratchOrgs",
+        message: c.cyanBright("Do you want this SFDMU config to be used to import data when initializing a new scratch org ?"),
+        default: false
+      },
+    ]);
+
+    // Collect / reformat data
+    const dataPath = pascalcase(resp.dataPath) ;
+    const sfdxHardisLabel = resp.sfdxHardisLabel ;
+    const sfdxHardisDescription = resp.sfdxHardisDescription ;
+    const importInScratchOrgs = resp.importInScratchOrgs ;
+    const sfdmuConfig = {
+      sfdxHardisLabel: sfdxHardisLabel,
+      sfdxHardisDescription: sfdxHardisDescription,
+      objects: [
+        {
+          "query": "SELECT all FROM Account WHERE Name='sfdx-hardis'",
+          "operation": "Upsert",
+          "externalId": "Name"
+        },
+      ]
+    }
+
+    // Check if not already existing
+    const sfdmuProjectFolder = path.join(dataFolderRoot,dataPath);
+    if (fs.existsSync(sfdmuProjectFolder)) {
+      throw new SfdxError(`[sfdx-hardis]${c.red(`Folder ${c.bold(sfdmuProjectFolder)} already exists`)}`);
+    }
+
+    // Create folder & export.json
+    await fs.ensureDir(sfdmuProjectFolder);
+    const exportJsonFile = path.join(sfdmuProjectFolder,"export.json");
+    await fs.writeFile(exportJsonFile,JSON.stringify(sfdmuConfig,null,2));
+
+    // Manage dataPackages if importInScratchOrgs is true
+    if (importInScratchOrgs === true) {
+      const config = await getConfig("project");
+      const dataPackages = config.dataPackages || [];
+      dataPackages.push({dataPath: sfdmuProjectFolder.replace(/\\/g, "/"), importInScratchOrgs: true});
+      await setConfig("project",{dataPackages: dataPackages});
+    }
+
+    // Trigger command to open SFDMU config file in VsCode extension
+    WebSocketClient.sendMessage({ event: "openFile", file: exportJsonFile.replace(/\\/g, "/") });
+
+    // Set bac initial cwd
+    const message = c.cyan(`Successfully initialized sfdmu project ${c.green(sfdmuProjectFolder)}, with ${c.green("export.json")} file.
+You can now configure it using SFDMU documentation: https://help.sfdmu.com/plugin-basics/basic-usage/minimal-configuration
+If you don't have unique field to identify an object, use composite external ids: https://help.sfdmu.com/full-documentation/advanced-features/composite-external-id-keys
+`);
+    uxLog(this, message);
+    return { outputString: message };
+  }
+}

--- a/src/commands/hardis/org/data/export.ts
+++ b/src/commands/hardis/org/data/export.ts
@@ -3,7 +3,9 @@ import { flags, SfdxCommand } from "@salesforce/command";
 import { Messages } from "@salesforce/core";
 import { AnyJson } from "@salesforce/ts-types";
 import * as c from "chalk";
+import { isCI, uxLog } from "../../../../common/utils";
 import { exportData, selectDataWorkspace } from "../../../../common/utils/dataUtils";
+import { promptOrgUsernameDefault } from "../../../../common/utils/orgUtils";
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
@@ -41,7 +43,7 @@ export default class DataExport extends SfdxCommand {
   // protected static supportsDevhubUsername = true;
 
   // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
-  protected static requiresProject = true;
+  protected static requiresProject = false;
 
   // List required plugins, their presence will be tested before running the command
   protected static requiresSfdxPlugins = ["sfdmu"];
@@ -57,14 +59,20 @@ export default class DataExport extends SfdxCommand {
       sfdmuPath = await selectDataWorkspace();
     }
 
+    // Select org
+    let orgUsername = this.org.getUsername();
+    if (!isCI) {
+      orgUsername = await promptOrgUsernameDefault(this, orgUsername, { devHub: false, setDefault: false });
+    }
+
     // Export data from org
     await exportData(sfdmuPath, this, {
-      sourceUsername: this.org.getUsername(),
+      sourceUsername: orgUsername,
     });
 
-    // Set bac initial cwd
-    const message = `[sfdx-hardis] Successfully exported data from sfdmu workspace ${sfdmuPath}`;
-    this.ux.log(c.green(message));
-    return { orgId: this.org.getOrgId(), outputString: message };
+    // Output message
+    const message = `Successfully exported data from sfdmu project ${c.green(sfdmuPath)} from org ${c.green(orgUsername)}`;
+    uxLog(this,c.cyan(message));
+    return { outputString: message };
   }
 }

--- a/src/commands/hardis/org/data/export.ts
+++ b/src/commands/hardis/org/data/export.ts
@@ -59,7 +59,7 @@ export default class DataExport extends SfdxCommand {
       sfdmuPath = await selectDataWorkspace();
     }
 
-    // Select org
+    // Select org that will be used to export records
     let orgUsername = this.org.getUsername();
     if (!isCI) {
       orgUsername = await promptOrgUsernameDefault(this, orgUsername, { devHub: false, setDefault: false });

--- a/src/commands/hardis/org/data/import.ts
+++ b/src/commands/hardis/org/data/import.ts
@@ -52,14 +52,13 @@ export default class DataExport extends SfdxCommand {
 
   public async run(): Promise<AnyJson> {
     let sfdmuPath = this.flags.path || null;
-    //const debugMode = this.flags.debug || false;
 
     // Identify sfdmu workspace if not defined
     if (sfdmuPath == null) {
       sfdmuPath = await selectDataWorkspace();
     }
 
-    // Select org
+    // Select org that where records will be imported
     let orgUsername = this.org.getUsername();
     if (!isCI) {
       orgUsername = await promptOrgUsernameDefault(this, orgUsername, { devHub: false, setDefault: false });

--- a/src/commands/hardis/org/data/import.ts
+++ b/src/commands/hardis/org/data/import.ts
@@ -3,6 +3,7 @@ import { flags, SfdxCommand } from "@salesforce/command";
 import { Messages } from "@salesforce/core";
 import { AnyJson } from "@salesforce/ts-types";
 import * as c from "chalk";
+import { uxLog } from "../../../../common/utils";
 import { importData, selectDataWorkspace } from "../../../../common/utils/dataUtils";
 
 // Initialize Messages with the current plugin directory
@@ -63,8 +64,8 @@ export default class DataExport extends SfdxCommand {
     });
 
     // Set bac initial cwd
-    const message = `[sfdx-hardis] Successfully imported data from sfdmu workspace ${sfdmuPath}`;
-    this.ux.log(c.green(message));
+    const message = `[sfdx-hardis] Successfully imported data from sfdmu workspace ${c.bold(sfdmuPath)}`;
+    uxLog(this, c.green(message));
     return { orgId: this.org.getOrgId(), outputString: message };
   }
 }

--- a/src/commands/hardis/scratch/delete.ts
+++ b/src/commands/hardis/scratch/delete.ts
@@ -69,7 +69,7 @@ export default class ScratchDelete extends SfdxCommand {
     const scratchToDeleteRes = await prompts({
       type: "multiselect",
       name: "value",
-      message: c.cyanBright("What references do you want to clean from your SFDX project sources ?"),
+      message: c.cyanBright("Please select the list of scratch orgs you want to delete"),
       choices: scratchOrgChoices,
     });
 

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -398,14 +398,14 @@ class MetadataUtils {
   }
 
   // List local orgs for user
-  public static async listLocalOrgs(type = "any") {
+  public static async listLocalOrgs(type = "any",options: any = {}) {
     const orgListResult = await execSfdxJson("sfdx force:org:list", this);
     if (type === "any") {
       return orgListResult?.result || [];
     } else if (type === "scratch") {
       return (
         orgListResult?.result?.scratchOrgs?.filter((org: any) => {
-          return org.status === "Active";
+          return org.status === "Active" && ((options.devHubUsername && org.devHubUsername !== options.devHubUsername)? false: true);
         }) || []
       );
     }

--- a/src/common/utils/orgUtils.ts
+++ b/src/common/utils/orgUtils.ts
@@ -123,6 +123,20 @@ export async function promptOrg(commandThis: any, options: any = { devHub: false
   return orgResponse.org;
 }
 
+export async function promptOrgUsernameDefault(commandThis: any,defaultOrg: string, options: any = { devHub: false, setDefault: true }) {
+  const defaultOrgRes = await prompts({
+    type: "confirm",
+    message: `Do you want to use org ${defaultOrg}`
+  });
+  if (defaultOrgRes.value === true) {
+    return defaultOrg;
+  }
+  else {
+    const selectedOrg = await promptOrg(commandThis, options);
+    return selectedOrg.username ;
+  }
+}
+
 // Add package installation to project .sfdx-hardis.yml
 export async function managePackageConfig(installedPackages, packagesToInstallCompleted) {
   const config = await getConfig("project");

--- a/src/common/utils/orgUtils.ts
+++ b/src/common/utils/orgUtils.ts
@@ -51,7 +51,7 @@ export async function promptOrg(commandThis: any, options: any = { devHub: false
   // List all local orgs and request to user
   const orgListResult = await MetadataUtils.listLocalOrgs("any");
   const orgList = [
-    ...sortArray(orgListResult?.scratchOrgs || [], { by: ["username", "alias", "instanceUrl"], order: ["asc", "asc", "asc"] }),
+    ...sortArray(orgListResult?.scratchOrgs || [], { by: ["devHubUsername","username", "alias", "instanceUrl"], order: ["asc", "asc", "asc"] }),
     ...sortArray(orgListResult?.nonScratchOrgs || [], { by: ["username", "alias", "instanceUrl"], order: ["asc", "asc", "asc"] }),
     { username: "Connect to another org", otherOrg: true },
     { username: "Cancel", cancel: true },
@@ -62,11 +62,11 @@ export async function promptOrg(commandThis: any, options: any = { devHub: false
     name: "org",
     message: c.cyanBright("Please select an org"),
     choices: orgList.map((org: any) => {
-      const title = org.username || org.alias || org.instanceUrl;
-      const description = title !== org.instanceUrl ? org.instanceUrl : "";
+      const title = (org.username || org.alias || org.instanceUrl);
+      const description = (title !== org.instanceUrl ? org.instanceUrl : "")+(org.devHubUsername?` (Hub: ${org.devHubUsername})`:'');
       return {
         title: c.cyan(title),
-        description: description,
+        description: description || "-",
         value: org,
       };
     }),

--- a/src/common/utils/prompts.ts
+++ b/src/common/utils/prompts.ts
@@ -24,6 +24,10 @@ export async function prompts(options) {
       ];
       question.initial = question.initial === false ? 1 : 0;
     }
+    // Default output value "value"
+    if (question.name === null || question.name === undefined) {
+      question.name = "value";
+    }
     // Add exit option when possible
     if (question.type === "select") {
       question.choices.push({ title: "⛔ Exit this script", value: "exitNow" });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3414,6 +3414,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+pascalcase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-1.0.0.tgz#d2fd7d73f2969606d2b56e17f5261be41c43c381"
+  integrity sha512-BSExi0rRnCHReJys6NocaK+cfTXNinAegfWBvr0JD3hiaEG7Nuc7r0CIdOJunXrs8gU/sbHQ9dxVAtiVQisjmg==
+
 password-prompt@^1.0.7, password-prompt@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/password-prompt/-/password-prompt-1.1.2.tgz#85b2f93896c5bd9e9f2d6ff0627fa5af3dc00923"


### PR DESCRIPTION
- **hardis:scratch:create**: Initialize data using SFDMU, if defined in .sfdx-hardis.json `dataPackages` property with `importInScratchOrgs: true`
  - Example

```yaml
dataPackages:
  - dataPath: scripts/data/LightningSchedulerConfig
    importInScratchOrgs: true
```

- Propose to update or not default target git branch
- List target git branches if defined in .sfdx-hardis.json `availableTargetBranches` property
- **hardis:scratch:delete**: Propose only scratch orgs related to currently selected Dev Hub
- Display data package label & description, from SFDMU folder config.json properties `sfdxHardisLabel` and `sfdxHardisDescription`
- Display Dev Hub username when listing orgs for selection