### PR TITLE
Quick fixes hardis:doc:plugin:generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 - Quick fixes hardis:doc:plugin:generate
   - Handle when command.title or command.description is empty
-  - Add `# Commands` to the README.md truncate markers 
+  - Add `# Commands` to the README.md truncate markers
 
 ## [2.51.0] 2021-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Quick fixes hardis:doc:plugin:generate
+  - Handle when command.title or command.description is empty
+  - Add `# Commands` to the README.md truncate markers 
+
 ## [2.51.0] 2021-08-31
 
 - Update hardis:doc:plugin:generate so main README part is displayed on doc index.md

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ sfdx plugins:install sfdmu sfdx-git-delta sfdx-essentials sfpowerkit shane-sfdx-
 
 ### Docker
 
-You can use docker image [**hardisgroupcom/sfdx-hardis**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis)
+You can use sfdx-hardis docker images to run in CI
+
+- [**hardisgroupcom/sfdx-hardis:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with latest sfdx-cli version)
+- [**hardisgroupcom/sfdx-hardis:latest-sfdx-stable**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with stable sfdx-cli version)
+
+_See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 ## Usage
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Use this section to tell people about which versions of your project are
 currently being supported with security updates.
 
 | Version | Supported          |
-| ------- | ------------------ |
+|---------|--------------------|
 | 5.1.x   | :white_check_mark: |
 | 5.0.x   | :x:                |
 | 4.0.x   | :white_check_mark: |

--- a/src/commands/hardis/doc/plugin/generate.ts
+++ b/src/commands/hardis/doc/plugin/generate.ts
@@ -128,7 +128,7 @@ At each merge into master/main branch, the GitHub Action build-deploy-docs will 
     const readme = await fs.readFile(path.join(process.cwd(), "README.md"), "utf8");
     let reusableReadmePartFound = false;
     // Try to find README content until auto-generated commands
-    const limitStrings = ["## Commands", "## COMMANDS", "<!-- commands -->"];
+    const limitStrings = ["# Commands", "## Commands", "## COMMANDS", "<!-- commands -->"];
     for (const limitString of limitStrings) {
       if (readme.indexOf(limitString) > 0) {
         lines.push(...readme.substring(0, readme.indexOf(limitString)).split(/\r?\n/));
@@ -169,7 +169,7 @@ At each merge into master/main branch, the GitHub Action build-deploy-docs will 
     const titleLines = [`# ${command.id}`, ""];
     lines.push(...titleLines);
     // Description
-    const descriptionLines = [`## Description`, "", ...command.description.split("\n"), ""];
+    const descriptionLines = [`## Description`, "", ...(command.description || "").split("\n"), ""];
     lines.push(...descriptionLines);
     // Flags
     const flagLines = [
@@ -198,7 +198,7 @@ At each merge into master/main branch, the GitHub Action build-deploy-docs will 
     const exampleLines = [
       `## Examples`,
       "",
-      ...(command.examples || []).map((example: string) => ["```shell", ...example.split("\n"), "```", ""]).flat(),
+      ...(command.examples || []).map((example: string) => ["```shell", ...(example || "").split("\n"), "```", ""]).flat(),
       "",
     ];
     lines.push(...exampleLines);


### PR DESCRIPTION
- Quick fixes hardis:doc:plugin:generate
  - Handle when command.title or command.description is empty
  - Add `# Commands` to the README.md truncate markers 