### PR TITLE
Fix hardis:org:retrieve:sources:dx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [2.51.1] 2021-08-31
+
 - Quick fixes hardis:doc:plugin:generate
   - Handle when command.title or command.description is empty
   - Add `# Commands` to the README.md truncate markers
+- Fix hardis:org:retrieve:sources:dx
+  - Empty temp directories at the beginning of the command
+  - Add ForecastingType in the list of ignored metadatas for conversion to sfdx sources
 
 ## [2.51.0] 2021-08-31
 

--- a/src/commands/hardis/org/retrieve/sources/dx.ts
+++ b/src/commands/hardis/org/retrieve/sources/dx.ts
@@ -91,11 +91,14 @@ export default class DxSources extends SfdxCommand {
     // Create working temp folders and define it as cwd
     const prevCwd = process.cwd();
     await fs.ensureDir(tempFolder);
+    await fs.emptyDir(tempFolder);
     process.chdir(tempFolder);
     const metadataFolder = path.join(tempFolder, "mdapipkg");
     await fs.ensureDir(metadataFolder);
+    await fs.emptyDir(metadataFolder);
     const sfdxFolder = path.join(tempFolder, "sfdx-project");
     await fs.ensureDir(sfdxFolder);
+    await fs.emptyDir(sfdxFolder);
 
     // Retrieve metadatas
     const retrieveOptions: any = { filterManagedItems: true, removeStandard: false };
@@ -108,7 +111,9 @@ export default class DxSources extends SfdxCommand {
     // Create sfdx project
     if (fs.readdirSync(sfdxFolder).length === 0) {
       uxLog(this, c.cyan("Creating SFDX project..."));
-      const createProjectRes = await exec('sfdx force:project:create --projectname "sfdx-project"', { maxBuffer: 1024 * 2000 });
+      const projectCreateCommand = 'sfdx force:project:create --projectname "sfdx-project"';
+      uxLog(this,`[command] ${c.bold(c.grey(projectCreateCommand))}`)
+      const createProjectRes = await exec(projectCreateCommand, { maxBuffer: 1024 * 2000 });
       if (debug) {
         this.ux.log(createProjectRes.stdout + createProjectRes.stderr);
       }
@@ -117,8 +122,10 @@ export default class DxSources extends SfdxCommand {
     // Converting metadatas to sfdx
     uxLog(this, c.cyan(`Converting metadatas into SFDX sources in ${c.green(sfdxFolder)}...`));
     process.chdir(sfdxFolder);
+    const mdapiConvertCommand = `sfdx force:mdapi:convert --rootdir ${path.join(metadataFolder, "unpackaged")} ${debug ? "--verbose" : ""}`;
+    uxLog(this,`[command] ${c.bold(c.grey(mdapiConvertCommand))}`)
     try {
-      const convertRes = await exec(`sfdx force:mdapi:convert --rootdir ${path.join(metadataFolder, "unpackaged")} ${debug ? "--verbose" : ""}`, {
+      const convertRes = await exec(mdapiConvertCommand, {
         maxBuffer: 10000 * 10000,
       });
       if (debug) {

--- a/src/commands/hardis/org/retrieve/sources/dx.ts
+++ b/src/commands/hardis/org/retrieve/sources/dx.ts
@@ -112,7 +112,7 @@ export default class DxSources extends SfdxCommand {
     if (fs.readdirSync(sfdxFolder).length === 0) {
       uxLog(this, c.cyan("Creating SFDX project..."));
       const projectCreateCommand = 'sfdx force:project:create --projectname "sfdx-project"';
-      uxLog(this,`[command] ${c.bold(c.grey(projectCreateCommand))}`)
+      uxLog(this, `[command] ${c.bold(c.grey(projectCreateCommand))}`);
       const createProjectRes = await exec(projectCreateCommand, { maxBuffer: 1024 * 2000 });
       if (debug) {
         this.ux.log(createProjectRes.stdout + createProjectRes.stderr);
@@ -123,7 +123,7 @@ export default class DxSources extends SfdxCommand {
     uxLog(this, c.cyan(`Converting metadatas into SFDX sources in ${c.green(sfdxFolder)}...`));
     process.chdir(sfdxFolder);
     const mdapiConvertCommand = `sfdx force:mdapi:convert --rootdir ${path.join(metadataFolder, "unpackaged")} ${debug ? "--verbose" : ""}`;
-    uxLog(this,`[command] ${c.bold(c.grey(mdapiConvertCommand))}`)
+    uxLog(this, `[command] ${c.bold(c.grey(mdapiConvertCommand))}`);
     try {
       const convertRes = await exec(mdapiConvertCommand, {
         maxBuffer: 10000 * 10000,

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -374,6 +374,7 @@ class MetadataUtils {
       "BlacklistedConsumer",
       "ConnectedApp",
       "CustomIndex",
+      "ForecastingType",
       "IframeWhiteListUrlSettings",
       "ManagedContentType",
       "NotificationTypeConfig",


### PR DESCRIPTION
- Empty temp directories at the beginning of the command
- Add ForecastingType in the list of ignored metadatas for conversion to sfdx sources