### PR TITLE
maxScratchOrgsNumberToCreateOnce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [2.71.1] 2022-03-17
+
 - Update JSON schema for customCommands (used by VsCode SFDX Hardis)
+- New property for scratch org pool config: maxScratchOrgsNumberToCreateOnce (max number of scratch orgs to create during one CI job)
 
 ## [2.71.0] 2022-03-15
 

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -42,29 +42,6 @@
       "title": "Minimum apex test coverage %",
       "type": "number"
     },
-    "customCommands": {
-      "$id": "#/properties/customCommands",
-      "description": "List of custom commands for VsCode SFDX Hardis (see documentation)",
-      "examples": [
-        [
-          {
-            "id": "custom-menu",
-            "label": "Custom menu",
-            "commands": [
-              {
-                "id": "some-command",
-                "label": "Some commands",
-                "tooltip": "Run some commands tooltip",
-                "icon": "old.svg",
-                "command": "echo 'This is my custom command'"
-              }
-            ]
-          }
-        ]
-      ],
-      "title": "Custom commands for VsCode SFDX Hardis",
-      "type": "array"
-    },
     "dataPackages": {
       "$id": "#/properties/dataPackages",
       "description": "List of data packages",
@@ -372,12 +349,7 @@
     "poolConfig": {
       "$id": "#/properties/poolConfig",
       "description": "Configuration allowing to generate and fetch scratch orgs from scratch org pool",
-      "examples": [
-        {
-          "maxScratchOrgsNumber": 10,
-          "storageService": "kvdb.io"
-        }
-      ],
+      "examples": [{ "maxScratchOrgsNumber": 10, "storageService": "kvdb.io" }],
       "title": "Scratch org pool configuration",
       "type": "object",
       "properties": {
@@ -392,6 +364,12 @@
           "$id": "#/properties/poolConfig/maxScratchOrgsNumber",
           "description": "Maximum number of active scratch orgs in the scratch org pool",
           "title": "Maximum number of scratch orgs",
+          "type": "number"
+        },
+        "maxScratchOrgsNumberToCreateOnce": {
+          "$id": "#/properties/poolConfig/maxScratchOrgsNumberToCreateOnce",
+          "description": "Maximum number of scratch orgs to create in one CI job",
+          "title": "Maximum number of scratch orgs to create once",
           "type": "number"
         },
         "storageService": {

--- a/src/common/utils/deployTips.ts
+++ b/src/common/utils/deployTips.ts
@@ -172,6 +172,12 @@ Update the formula to use a field compliant with formulas.
 More details at https://help.salesforce.com/articleView?id=sf.tips_on_building_formulas.htm&type=5`,
     },
     {
+      name: "flow-must-be-deleted-manually",
+      label: "Flow must be deleted manually",
+      expressionRegex: [/.flow (.*) insufficient access rights on cross-reference id/gm],
+      tip: `Flows can not be deleted using deployments, please delete them manually in the target org`,
+    },
+    {
       name: "invalid-scope-mine",
       label: "Invalid scope:Mine, not allowed",
       expressionString: ["Invalid scope:Mine, not allowed"],


### PR DESCRIPTION
New property for scratch org pool config: maxScratchOrgsNumberToCreateOnce (max number of scratch orgs to create during one CI job)