### PR TITLE
availableTargetBranches + git push fix for save + deployTips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 ## [2.75.0] 2022-03-28
 
 - Property `availableTargetBranches` can be defined in `.sfdx-hardis.yml` to list the possible target branches for merge requests
+- fix hardis:work:save to propose a git push when the current branch is ahead of origin branch
+- New deployTips
+  - XML item appears more than once
 
 ## [2.74.2] 2022-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [2.75.0] 2022-03-28
+
+- Property `availableTargetBranches` can be defined in `.sfdx-hardis.yml` to list the possible target branches for merge requests
+
 ## [2.74.2] 2022-03-26
 
 - Update legacy API detection labels

--- a/README.md
+++ b/README.md
@@ -2165,7 +2165,7 @@ Calls the related storage service to request api keys and secrets that allows a 
 
 ```
 USAGE
-  $ sfdx hardis:scratch:pool:localauth [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json] 
+  $ sfdx hardis:scratch:pool:localauth [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json]
   [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2197,7 +2197,7 @@ Create enough scratch orgs to fill the pool
 
 ```
 USAGE
-  $ sfdx hardis:scratch:pool:refresh [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json] 
+  $ sfdx hardis:scratch:pool:refresh [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json]
   [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2229,7 +2229,7 @@ Reset scratch org pool (delete all scratches in the pool)
 
 ```
 USAGE
-  $ sfdx hardis:scratch:pool:reset [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json] 
+  $ sfdx hardis:scratch:pool:reset [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json]
   [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2261,7 +2261,7 @@ Displays all stored content of project scratch org pool if defined
 
 ```
 USAGE
-  $ sfdx hardis:scratch:pool:view [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx hardis:scratch:pool:view [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2293,7 +2293,7 @@ Pull scratch org updates from scratch org to local git branch
 
 ```
 USAGE
-  $ sfdx hardis:scratch:pull [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx hardis:scratch:pull [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2325,7 +2325,7 @@ Push local updates in git branch to scratch org
 
 ```
 USAGE
-  $ sfdx hardis:scratch:push [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx hardis:scratch:push [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2357,9 +2357,9 @@ sfdx-hardis wrapper for sfdx force:source:deploy that displays tips to solve dep
 
 ```
 USAGE
-  $ sfdx hardis:source:deploy [--soapdeploy] [-w <minutes>] [-q <id> | -x <filepath> | -m <array> | -p <array> | -c | -l 
-  NoTestRun|RunSpecifiedTests|RunLocalTests|RunAllTestsInOrg | -r <array> | -o | -g] [--predestructivechanges <filepath> 
-  ] [--postdestructivechanges <filepath> ] [--debug] [--websocket <string>] [-u <string>] [--apiversion <string>] 
+  $ sfdx hardis:source:deploy [--soapdeploy] [-w <minutes>] [-q <id> | -x <filepath> | -m <array> | -p <array> | -c | -l
+  NoTestRun|RunSpecifiedTests|RunLocalTests|RunAllTestsInOrg | -r <array> | -o | -g] [--predestructivechanges <filepath>
+  ] [--postdestructivechanges <filepath> ] [--debug] [--websocket <string>] [-u <string>] [--apiversion <string>]
   [--verbose] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2400,8 +2400,8 @@ OPTIONS
   --websocket=websocket                                                             websocket
 
 DESCRIPTION
-  See documentation at 
-  https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_sourc
+  See documentation at
+  <https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_sourc>
   e.htm#cli_reference_force_source_deploy
 ```
 
@@ -2413,7 +2413,7 @@ sfdx-hardis wrapper for sfdx force:source:push that displays tips to solve deplo
 
 ```
 USAGE
-  $ sfdx hardis:source:push [-f] [-w <minutes>] [-g] [--debug] [--websocket <string>] [-u <string>] [--apiversion 
+  $ sfdx hardis:source:push [-f] [-w <minutes>] [-g] [--debug] [--websocket <string>] [-u <string>] [--apiversion
   <string>] [--quiet] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2440,8 +2440,8 @@ OPTIONS
   --websocket=websocket                                                             websocket
 
 DESCRIPTION
-  See documentation at 
-  https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_sourc
+  See documentation at
+  <https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_sourc>
   e.htm#cli_reference_force_source_push
 ```
 
@@ -2453,7 +2453,7 @@ New work task
 
 ```
 USAGE
-  $ sfdx hardis:work:new [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx hardis:work:new [-d] [--websocket <string>] [-v <string>] [--apiversion <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2485,7 +2485,7 @@ Make my local branch and my scratch org up to date with the most recent sources
 
 ```
 USAGE
-  $ sfdx hardis:work:refresh [-n] [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx hardis:work:refresh [-n] [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2520,7 +2520,7 @@ Process again the selection of the items that you want to publish to upper level
 
 ```
 USAGE
-  $ sfdx hardis:work:resetselection [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json] 
+  $ sfdx hardis:work:resetselection [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json]
   [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2552,7 +2552,7 @@ When a work task is completed, guide user to create a merge request
 
 ```
 USAGE
-  $ sfdx hardis:work:save [-n] [-g] [-c] [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json] 
+  $ sfdx hardis:work:save [-n] [-g] [-c] [-d] [--websocket <string>] [-u <string>] [--apiversion <string>] [--json]
   [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -2594,7 +2594,7 @@ Technical calls to WebSocket functions
 
 ```
 USAGE
-  $ sfdx hardis:work:ws [-e <string>] [-d] [--websocket <string>] [--json] [--loglevel 
+  $ sfdx hardis:work:ws [-e <string>] [-d] [--websocket <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -42,6 +42,16 @@
       "title": "Minimum apex test coverage %",
       "type": "number"
     },
+    "availableTargetBranches": {
+      "$id": "#/properties/availableTargetBranches",
+      "description": "List of git branches that can be used as target for merge requests",
+      "examples": [["develop", "develop_next"]],
+      "items": {
+        "type": "string"
+      },
+      "title": "Available target branches",
+      "type": "array"
+    },
     "dataPackages": {
       "$id": "#/properties/dataPackages",
       "description": "List of data packages",

--- a/src/commands/hardis/project/create.ts
+++ b/src/commands/hardis/project/create.ts
@@ -97,8 +97,8 @@ export default class ProjectCreate extends SfdxCommand {
       const devBranchRes = await prompts({
         type: "text",
         name: "devBranch",
-        message: "What is the name of your development branch ?",
-        initial: "developpement",
+        message: "What is the name of your default development branch ?",
+        initial: "develop",
       });
       await setConfig("project", { developmentBranch: devBranchRes.devBranch });
     }

--- a/src/commands/hardis/work/refresh.ts
+++ b/src/commands/hardis/work/refresh.ts
@@ -55,6 +55,13 @@ export default class RefreshTask extends SfdxCommand {
 
   /* jscpd:ignore-end */
   public async run(): Promise<AnyJson> {
+    const config = await getConfig("project");
+    if (config.get("EXPERIMENTAL", "") !== "true") {
+      const msg = "This command is not stable enough to be used. Use EXPERIMENTAL=true to use it anyway";
+      uxLog(this, c.yellow(msg));
+      return { outputString: msg };
+    }
+
     this.noPull = this.flags.nopull || false;
     uxLog(this, c.cyan("This command will refresh your git branch and your org with the content of another git branch"));
     // Verify that the user saved his/her work before merging another branch
@@ -74,7 +81,6 @@ export default class RefreshTask extends SfdxCommand {
       process.exit(0);
     }
     // Select branch to merge
-    const config = await getConfig("project");
     const localBranch = await getCurrentGitBranch();
     const branchSummary = await git().branch(["-r"]);
     const branchChoices = [

--- a/src/commands/hardis/work/save.ts
+++ b/src/commands/hardis/work/save.ts
@@ -173,6 +173,7 @@ export default class SaveTask extends SfdxCommand {
     // Request user to select what he/she wants to commit
     let interactiveGitAllPerformed = false;
     let gitStatus: any = {};
+    let commitManuallyDone = false ;
     if (this.noGit) {
       uxLog(this, c.cyan(`[Expert mode] Skipped interactive git add: must be done manually`));
     } else {
@@ -207,6 +208,9 @@ export default class SaveTask extends SfdxCommand {
           uxLog(this, c.cyan(`Committing files in local git branch ${c.green(currentGitBranch)}...`));
           await git().commit(commitResponse.commitText || "Updated by sfdx-hardis");
         }
+      }
+      else {
+        commitManuallyDone = true ;
       }
     }
 
@@ -427,7 +431,8 @@ export default class SaveTask extends SfdxCommand {
     if (
       ((interactiveGitAllPerformed === true && gitStatus?.staged?.length > 0) ||
         gitStatusWithConfig.staged.length > 0 ||
-        gitStatusAfterDeployPlan.staged.length > 0) &&
+        gitStatusAfterDeployPlan.staged.length > 0 ||
+        commitManuallyDone === true) &&
       !this.noGit
     ) {
       const pushResponse = await prompts({

--- a/src/commands/hardis/work/save.ts
+++ b/src/commands/hardis/work/save.ts
@@ -100,13 +100,11 @@ export default class SaveTask extends SfdxCommand {
     let config = await getConfig("project");
     const localBranch = await getCurrentGitBranch();
 
-    const targetBranch = await selectTargetBranch({message: "Please select the target branch of your Merge Request"});
+    const targetBranch = await selectTargetBranch({ message: "Please select the target branch of your Merge Request" });
 
     uxLog(
       this,
-      c.cyan(
-        `This script will prepare the merge request from your local branch ${c.green(localBranch)} to remote ${c.green(targetBranch)}`
-      )
+      c.cyan(`This script will prepare the merge request from your local branch ${c.green(localBranch)} to remote ${c.green(targetBranch)}`)
     );
 
     if (this.noGit) {
@@ -173,7 +171,7 @@ export default class SaveTask extends SfdxCommand {
     // Request user to select what he/she wants to commit
     let interactiveGitAllPerformed = false;
     let gitStatus: any = {};
-    let commitManuallyDone = false ;
+    let commitManuallyDone = false;
     if (this.noGit) {
       uxLog(this, c.cyan(`[Expert mode] Skipped interactive git add: must be done manually`));
     } else {
@@ -208,9 +206,8 @@ export default class SaveTask extends SfdxCommand {
           uxLog(this, c.cyan(`Committing files in local git branch ${c.green(currentGitBranch)}...`));
           await git().commit(commitResponse.commitText || "Updated by sfdx-hardis");
         }
-      }
-      else {
-        commitManuallyDone = true ;
+      } else {
+        commitManuallyDone = true;
       }
     }
 
@@ -229,9 +226,7 @@ export default class SaveTask extends SfdxCommand {
     const toCommitMessage = toCommit ? toCommit.message : "";
     uxLog(
       this,
-      c.cyan(
-        `Calculating package.xml diff from [${c.green(targetBranch)}] to [${c.green(currentGitBranch)} - ${c.green(toCommitMessage)}]`
-      )
+      c.cyan(`Calculating package.xml diff from [${c.green(targetBranch)}] to [${c.green(currentGitBranch)} - ${c.green(toCommitMessage)}]`)
     );
     const tmpDir = await createTempDir();
     const packageXmlCommand = `sfdx sgd:source:delta --from ${masterBranchLatestCommit} --to ${

--- a/src/common/utils/deployTipsList.ts
+++ b/src/common/utils/deployTipsList.ts
@@ -450,5 +450,13 @@ Please check https://help.salesforce.com/articleView?id=sf.fs_enable.htm&type=5`
       expressionString: ["Fix the sfdcDigest node errors and then upload the file again"],
       tip: `Go to the target org, open profile "Analytics Cloud Integration User" and add READ rights to the missing object fields `,
     },
+    {
+      name: "XML item appears more than once",
+      label: "XML item appears more than once",
+      expressionRegex: [/Error (.*) Field:(.*), value:(.*) appears more than once/gm],
+      tip: `You probably made an error while merging conflicts
+Look for {3} in the XML of {1}
+If you see two {2} XML blocks with {3}, please decide which one you keep and remove the other one`,
+    },
   ];
 }

--- a/src/common/utils/gitUtils.ts
+++ b/src/common/utils/gitUtils.ts
@@ -1,0 +1,34 @@
+import { getConfig } from "../../config";
+import { prompts } from "./prompts";
+import * as c from "chalk";
+import { uxLog } from ".";
+
+export async function selectTargetBranch(options: { message?: string } = {}) {
+  const message =
+    options.message ||
+    "What will be the target branch of your new task ? (the branch where you will make your merge request after the task is completed)";
+  const config = await getConfig("user");
+  const availableTargetBranches = config.availableTargetBranches || null;
+  // There is only once choice so return it
+  if (availableTargetBranches === null && config.developmentBranch) {
+    uxLog(this, c.cyan(`Selected target branch is ${c.green(config.developmentBranch)}`));
+    return config.developmentBranch;
+  }
+
+  // Request info to build branch name. ex features/config/MYTASK
+  const response = await prompts([
+    {
+      type: availableTargetBranches ? "select" : "text",
+      name: "targetBranch",
+      message: c.cyanBright(message),
+      choices: availableTargetBranches
+        ? availableTargetBranches.map((branch) => {
+            return { title: branch, value: branch };
+          })
+        : [],
+      initial: config.developmentBranch || "developpement",
+    },
+  ]);
+  const targetBranch = response.targetBranch || "developpement";
+  return targetBranch;
+}


### PR DESCRIPTION
- Property `availableTargetBranches` can be defined in `.sfdx-hardis.yml` to list the possible target branches for merge requests
- fix hardis:work:save to propose a git push when the current branch is ahead of origin branch
- New deployTips
  - XML item appears more than once