### PR TITLE
Force sfdx-cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV PUPPETEER_EXECUTABLE_PATH="${CHROMIUM_PATH}"
 # hadolint ignore=DL3044
 ENV PATH="/node_modules/.bin:${PATH}"
 
-ARG SFDX_CLI_VERSION=latest
+ARG SFDX_CLI_VERSION=7.173.0
 ARG SFDX_HARDIS_VERSION=latest
 
 # Install npm packages +install sfdx plugins & display versions


### PR DESCRIPTION
Force sfdx-cli version to 7.173.0 (latest-rc as of 2022-10-17)