### PR TITLE
Use tooling API to retrieve ApexLogs

### DIFF
--- a/src/commands/hardis/org/purge/apexlog.ts
+++ b/src/commands/hardis/org/purge/apexlog.ts
@@ -64,7 +64,7 @@ export default class OrgPurgeFlow extends SfdxCommand {
     const tempDir = "./tmp";
     await fs.ensureDir(tempDir);
     const apexLogsToDeleteCsv = path.join(tempDir, "ApexLogsToDelete_" + Math.random() + ".csv");
-    const queryCommand = `sfdx force:data:soql:query -q "SELECT Id FROM ApexLog" -r "csv" > "${apexLogsToDeleteCsv}"`;
+    const queryCommand = `sfdx force:data:soql:query -q "SELECT Id FROM ApexLog" -t -r "csv" > "${apexLogsToDeleteCsv}"`;
     await execCommand(queryCommand, this, {
       output: true,
       debug: debugMode,


### PR DESCRIPTION
When i tried it without Tooling API the query didn't remove all logs. Supported by this documentation: https://help.salesforce.com/s/articleView?id=sf.code_debug_log_delete.htm&type=5