### PR TITLE
add more matchers for duplicate detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ config/user/
 
 megalinter-reports/
 
+.idea


### PR DESCRIPTION
## More duplicate detection rules

- rules for permission sets
- rules for custom labels 
- more rules for profiles

## Duplicate detector command now can fail

When duplicates are detected, return code will be set to 1, which signifies build systems that they should stop processing job.

## Added support for `--json` parameter

Now command returns value, which allows other users to use it in integrations using generated output
```json
{
  "status": 1,
  "result": [
    {
      "file": "./force-app/main/default/profiles/Admin.profile-meta.xml",
      "key": "Profile.fieldPermissions.field",
      "duplicates": [
        "Account.AnnualRevenue",
        "Account.AnnualRevenue"
      ]
    },
    {
      "file": "./force-app/main/default/profiles/Admin.profile-meta.xml",
      "key": "Profile.classAccesses.apexClass",
      "duplicates": [
        "FirstClassTest"
      ]
    }
  ]
}
```

## Fixes and refactors

- fixed fake duplicate detection speed report (there was no await)
- simplified string building by using `join`