### PR TITLE
New task & Save enhancements (projects & target branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [3.15.0] 2022-05-11
+
 - Allow to define property **availableProjects** so when user clicks on New task (hardis:work:new), he/she is asked to select a project, that will be used to build the new git branch name
 - When creating new task, store the target branch so it is not prompted again when waiting to save/publish the task.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Allow to define property **availableProjects** so when user clicks on New task (hardis:work:new), he/she is asked to select a project, that will be used to build the new git branch name
+
 ## [3.14.2] 2022-05-03
 
 - More explicit text to ask user if he/she wants to update its selected sandbox while creating a new task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
 - Allow to define property **availableProjects** so when user clicks on New task (hardis:work:new), he/she is asked to select a project, that will be used to build the new git branch name
+- When creating new task, store the target branch so it is not prompted again when waiting to save/publish the task.
 
 ## [3.14.2] 2022-05-03
 

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -64,6 +64,16 @@
       "title": "Minimum apex test coverage %",
       "type": "number"
     },
+    "availableProjects": {
+      "$id": "#/properties/availableProjects",
+      "description": "List of business projects that are managed in the same repository. Will be used to build git branch name when using hardis:work:new",
+      "examples": [["sales_cloud", "service_cloud","community"]],
+      "items": {
+        "type": "string"
+      },
+      "title": "Available projects",
+      "type": "array"
+    },
     "availableTargetBranches": {
       "$id": "#/properties/availableTargetBranches",
       "description": "List of git branches that can be used as target for merge requests",

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -67,7 +67,7 @@
     "availableProjects": {
       "$id": "#/properties/availableProjects",
       "description": "List of business projects that are managed in the same repository. Will be used to build git branch name when using hardis:work:new",
-      "examples": [["sales_cloud", "service_cloud","community"]],
+      "examples": [["sales_cloud", "service_cloud", "community"]],
       "items": {
         "type": "string"
       },

--- a/src/commands/hardis/work/new.ts
+++ b/src/commands/hardis/work/new.ts
@@ -109,17 +109,17 @@ Under the hood, it can:
     const branchPrefixChoices = config.branchPrefixChoices || defaultBranchPrefixChoices;
 
     // Select project if multiple projects are defined in availableProjectList .sfdx-hardis.yml property
-    let projectBranchPart = ""
+    let projectBranchPart = "";
     const availableProjectList = config.availableProjectList || [];
     if (availableProjectList.length > 1) {
-      const projectResponse = await prompts(
-        {
-          type: "select",
-          name: "project",
-          message: c.cyanBright("Please select the project your task is for"),
-          choices: availableProjectList.map((project: string) => { return { title: project, value: project } }),
-        }
-      );
+      const projectResponse = await prompts({
+        type: "select",
+        name: "project",
+        message: c.cyanBright("Please select the project your task is for"),
+        choices: availableProjectList.map((project: string) => {
+          return { title: project, value: project };
+        }),
+      });
       projectBranchPart = projectResponse.project + "/";
     }
 

--- a/src/commands/hardis/work/new.ts
+++ b/src/commands/hardis/work/new.ts
@@ -108,6 +108,21 @@ Under the hood, it can:
     ];
     const branchPrefixChoices = config.branchPrefixChoices || defaultBranchPrefixChoices;
 
+    // Select project if multiple projects are defined in availableProjectList .sfdx-hardis.yml property
+    let projectBranchPart = ""
+    const availableProjectList = config.availableProjectList || [];
+    if (availableProjectList.length > 1) {
+      const projectResponse = await prompts(
+        {
+          type: "select",
+          name: "project",
+          message: c.cyanBright("Please select the project your task is for"),
+          choices: availableProjectList.map((project: string) => { return { title: project, value: project } }),
+        }
+      );
+      projectBranchPart = projectResponse.project + "/";
+    }
+
     // Request info to build branch name. ex features/config/MYTASK
     const response = await prompts([
       {
@@ -136,13 +151,13 @@ Under the hood, it can:
         type: "text",
         name: "taskName",
         message: c.cyanBright(
-          "What is the name of your new task ? (examples: webservice-get-account, flow-process-opportunity...). Please avoid accents or special characters"
+          "What is the name of your new task ? (examples: JIRA123-webservice-get-account, T1000-flow-process-opportunity...). Please avoid accents or special characters"
         ),
       },
     ]);
 
     // Checkout development main branch
-    const branchName = `${response.branch || "features"}/${response.sources || "dev"}/${response.taskName.replace(/\s/g, "-")}`;
+    const branchName = `${projectBranchPart}${response.branch || "features"}/${response.sources || "dev"}/${response.taskName.replace(/\s/g, "-")}`;
     uxLog(this, c.cyan(`Checking out the most recent version of branch ${c.bold(this.targetBranch)} from git server...`));
     await gitCheckOutRemote(this.targetBranch);
     // Pull latest version of target branch

--- a/src/commands/hardis/work/new.ts
+++ b/src/commands/hardis/work/new.ts
@@ -108,7 +108,7 @@ Under the hood, it can:
     ];
     const branchPrefixChoices = config.branchPrefixChoices || defaultBranchPrefixChoices;
 
-    // Select project if multiple projects are defined in availableProjectList .sfdx-hardis.yml property
+    // Select project if multiple projects are defined in availableProjects .sfdx-hardis.yml property
     let projectBranchPart = "";
     const availableProjects = config.availableProjects || [];
     if (availableProjects.length > 1) {

--- a/src/commands/hardis/work/new.ts
+++ b/src/commands/hardis/work/new.ts
@@ -109,17 +109,17 @@ Under the hood, it can:
     const branchPrefixChoices = config.branchPrefixChoices || defaultBranchPrefixChoices;
 
     // Select project if multiple projects are defined in availableProjectList .sfdx-hardis.yml property
-    let projectBranchPart = "";
-    const availableProjectList = config.availableProjectList || [];
-    if (availableProjectList.length > 1) {
-      const projectResponse = await prompts({
-        type: "select",
-        name: "project",
-        message: c.cyanBright("Please select the project your task is for"),
-        choices: availableProjectList.map((project: string) => {
-          return { title: project, value: project };
-        }),
-      });
+    let projectBranchPart = ""
+    const availableProjects = config.availableProjects || [];
+    if (availableProjects.length > 1) {
+      const projectResponse = await prompts(
+        {
+          type: "select",
+          name: "project",
+          message: c.cyanBright("Please select the project your task is for"),
+          choices: availableProjects.map((project: string) => { return { title: project, value: project } }),
+        }
+      );
       projectBranchPart = projectResponse.project + "/";
     }
 
@@ -177,6 +177,11 @@ Under the hood, it can:
         await setConfig("user", { developmentBranch: this.targetBranch });
       }
     }
+    // Update local user config files to store the target of the just created branch
+    const currentUserConfig = await getConfig("user");
+    const localStorageBranchTargets = currentUserConfig.localStorageBranchTargets || {};
+    localStorageBranchTargets[branchName] = this.targetBranch;
+    await setConfig("user", { localStorageBranchTargets: localStorageBranchTargets })
 
     // Get allowed work org types from config if possible
     const allowedOrgTypes = config?.allowedOrgTypes || [];

--- a/src/commands/hardis/work/new.ts
+++ b/src/commands/hardis/work/new.ts
@@ -109,17 +109,17 @@ Under the hood, it can:
     const branchPrefixChoices = config.branchPrefixChoices || defaultBranchPrefixChoices;
 
     // Select project if multiple projects are defined in availableProjectList .sfdx-hardis.yml property
-    let projectBranchPart = ""
+    let projectBranchPart = "";
     const availableProjects = config.availableProjects || [];
     if (availableProjects.length > 1) {
-      const projectResponse = await prompts(
-        {
-          type: "select",
-          name: "project",
-          message: c.cyanBright("Please select the project your task is for"),
-          choices: availableProjects.map((project: string) => { return { title: project, value: project } }),
-        }
-      );
+      const projectResponse = await prompts({
+        type: "select",
+        name: "project",
+        message: c.cyanBright("Please select the project your task is for"),
+        choices: availableProjects.map((project: string) => {
+          return { title: project, value: project };
+        }),
+      });
       projectBranchPart = projectResponse.project + "/";
     }
 
@@ -181,7 +181,7 @@ Under the hood, it can:
     const currentUserConfig = await getConfig("user");
     const localStorageBranchTargets = currentUserConfig.localStorageBranchTargets || {};
     localStorageBranchTargets[branchName] = this.targetBranch;
-    await setConfig("user", { localStorageBranchTargets: localStorageBranchTargets })
+    await setConfig("user", { localStorageBranchTargets: localStorageBranchTargets });
 
     // Get allowed work org types from config if possible
     const allowedOrgTypes = config?.allowedOrgTypes || [];

--- a/src/commands/hardis/work/save.ts
+++ b/src/commands/hardis/work/save.ts
@@ -143,6 +143,12 @@ autoRemoveUserPermissions:
     this.gitUrl = await git().listRemote(["--get-url"]);
     this.currentBranch = await getCurrentGitBranch();
     if (this.targetBranch == null) {
+      const userConfig = await getConfig("user");
+      if (userConfig?.localStorageBranchTargets[localBranch]) {
+        this.targetBranch = userConfig?.localStorageBranchTargets[localBranch];
+      }
+    }
+    if (this.targetBranch == null) {
       this.targetBranch = await selectTargetBranch({ message: "Please select the target branch of your Merge Request" });
     }
     // User log info
@@ -297,9 +303,8 @@ autoRemoveUserPermissions:
       c.cyan(`Calculating package.xml diff from [${c.green(this.targetBranch)}] to [${c.green(this.currentBranch)} - ${c.green(toCommitMessage)}]`)
     );
     const tmpDir = await createTempDir();
-    const packageXmlCommand = `sfdx sgd:source:delta --from ${masterBranchLatestCommit} --to ${
-      toCommit ? toCommit.hash : masterBranchLatestCommit
-    } --output ${tmpDir}`;
+    const packageXmlCommand = `sfdx sgd:source:delta --from ${masterBranchLatestCommit} --to ${toCommit ? toCommit.hash : masterBranchLatestCommit
+      } --output ${tmpDir}`;
     const packageXmlResult = await execSfdxJson(packageXmlCommand, this, {
       output: true,
       fail: false,
@@ -323,7 +328,7 @@ autoRemoveUserPermissions:
       uxLog(
         this,
         c.bold(c.cyan(`destructiveChanges.xml diff to be merged within ${c.green(localDestructiveChangesXml)}:\n`)) +
-          c.red(destructivePackageXmlDiffStr)
+        c.red(destructivePackageXmlDiffStr)
       );
       const appendDestructivePackageXmlCommand =
         "sfdx essentials:packagexml:append" +

--- a/src/commands/hardis/work/save.ts
+++ b/src/commands/hardis/work/save.ts
@@ -303,8 +303,9 @@ autoRemoveUserPermissions:
       c.cyan(`Calculating package.xml diff from [${c.green(this.targetBranch)}] to [${c.green(this.currentBranch)} - ${c.green(toCommitMessage)}]`)
     );
     const tmpDir = await createTempDir();
-    const packageXmlCommand = `sfdx sgd:source:delta --from ${masterBranchLatestCommit} --to ${toCommit ? toCommit.hash : masterBranchLatestCommit
-      } --output ${tmpDir}`;
+    const packageXmlCommand = `sfdx sgd:source:delta --from ${masterBranchLatestCommit} --to ${
+      toCommit ? toCommit.hash : masterBranchLatestCommit
+    } --output ${tmpDir}`;
     const packageXmlResult = await execSfdxJson(packageXmlCommand, this, {
       output: true,
       fail: false,
@@ -328,7 +329,7 @@ autoRemoveUserPermissions:
       uxLog(
         this,
         c.bold(c.cyan(`destructiveChanges.xml diff to be merged within ${c.green(localDestructiveChangesXml)}:\n`)) +
-        c.red(destructivePackageXmlDiffStr)
+          c.red(destructivePackageXmlDiffStr)
       );
       const appendDestructivePackageXmlCommand =
         "sfdx essentials:packagexml:append" +


### PR DESCRIPTION
- Allow to define property **availableProjects** so when user clicks on New task (hardis:work:new), he/she is asked to select a project, that will be used to build the new git branch name


Fixes https://github.com/hardisgroupcom/sfdx-hardis/issues/369