### PR TITLE
New ENV variables to override default wait on retrieve/deploy/test commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- New ENV variables to override default wait on retrieve/deploy/test commands
+  - SFDX_RETRIEVE_WAIT_MINUTES
+  - SFDX_DEPLOY_WAIT_MINUTES
+  - SFDX_TEST_WAIT_MINUTES
+
 ## [3.15.0] 2022-05-11
 
 - Allow to define property **availableProjects** so when user clicks on New task (hardis:work:new), he/she is asked to select a project, that will be used to build the new git branch name

--- a/src/commands/hardis/org/retrieve/sources/metadata.ts
+++ b/src/commands/hardis/org/retrieve/sources/metadata.ts
@@ -27,7 +27,11 @@ export default class DxSources extends SfdxCommand {
 
   public static description = messages.getMessage("retrieveDx");
 
-  public static examples = ["$ sfdx hardis:org:retrieve:sources:metadata"];
+  public static examples = [
+    "$ sfdx hardis:org:retrieve:sources:metadata",
+    "$ SFDX_RETRIEVE_WAIT_MINUTES=200 sfdx hardis:org:retrieve:sources:metadata"
+  
+  ];
 
   protected static flagsConfig = {
     folder: flags.string({

--- a/src/commands/hardis/org/test/apex.ts
+++ b/src/commands/hardis/org/test/apex.ts
@@ -23,6 +23,8 @@ If following configuration is defined, it will fail if apex coverage target is n
 
 - Env \`APEX_TESTS_MIN_COVERAGE_ORG_WIDE\` or \`.sfdx-hardis\` property \`apexTestsMinCoverageOrgWide\`
 - Env \`APEX_TESTS_MIN_COVERAGE_ORG_WIDE\` or \`.sfdx-hardis\` property \`apexTestsMinCoverageOrgWide\`
+
+You can override env var SFDX_TEST_WAIT_MINUTES to wait more than 60 minutes
 `;
 
   public static examples = ["$ sfdx hardis:org:test:apex"];
@@ -72,7 +74,7 @@ If following configuration is defined, it will fail if apex coverage target is n
       " --codecoverage" +
       " --resultformat human" +
       ` --outputdir ${reportDir}` +
-      " --wait 60" +
+      ` --wait ${process.env.SFDX_TEST_WAIT_MINUTES || "60"}` +
       ` --testlevel ${testlevel}` +
       (check ? " --checkonly" : "") +
       (debugMode ? " --verbose" : "");

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -619,7 +619,7 @@ class MetadataUtils {
         "sfdx force:mdapi:retrieve" +
         ` --retrievetargetdir ${metadataFolder}` +
         ` --unpackaged ${packageXml}` +
-        " --wait 60" +
+        ` --wait ${process.env.SFDX_RETRIEVE_WAIT_MINUTES || "60"}` +
         (debug ? " --verbose" : "");
       const retrieveRes = await execSfdxJson(retrieveCommand, this, {
         output: false,

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -539,7 +539,7 @@ export async function deployDestructiveChanges(packageDeletedXmlFile: string, op
   await fs.copy(packageDeletedXmlFile, path.join(tmpDir, "destructiveChanges.xml"));
   const deployDelete =
     `sfdx force:mdapi:deploy -d ${tmpDir}` +
-    " --wait 60" +
+    ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || "60"}` +
     ` --testlevel ${options.testLevel || "NoTestRun"}` +
     " --ignorewarnings" + // So it does not fail in case metadata is already deleted
     (options.targetUsername ? ` --targetusername ${options.targetUsername}` : "") +
@@ -593,7 +593,7 @@ export async function deployMetadatas(
   const deployCommand =
     "sfdx force:mdapi:deploy" +
     ` --deploydir ${options.deployDir || "."}` +
-    " --wait 60" +
+    ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || "60"}` +
     ` --testlevel ${options.testlevel || "RunLocalTests"}` +
     ` --apiversion ${options.apiVersion || CONSTANTS.API_VERSION}` +
     (options.soap ? " --soapdeploy" : "") +


### PR DESCRIPTION
  - SFDX_RETRIEVE_WAIT_MINUTES
  - SFDX_DEPLOY_WAIT_MINUTES
  - SFDX_TEST_WAIT_MINUTES