### PR TITLE
Added Support for Entitlement Object Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2023-06-07
+
+- To clean entitlement items
+
 ## [beta] (master)
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`

--- a/defaults/clean/entitlement.json
+++ b/defaults/clean/entitlement.json
@@ -1,0 +1,26 @@
+{
+  "items": {
+    "CustomField": [
+      "Entitlement.AssetId",
+      "Entitlement.BusinessHoursId",
+      "Entitlement.CasesPerEntitlement",
+      "Entitlement.ContractLineItemId",
+      "Entitlement.EndDate",
+      "Entitlement.IsPerIncident",
+      "Entitlement.LocationId",
+      "Entitlement.RemainingCases",
+      "Entitlement.ServiceContractId",
+      "Entitlement.SlaProcessId",
+      "Entitlement.StartDate",
+      "Entitlement.Status",
+      "Entitlement.StatusIndicator",
+      "Entitlement.Type"
+    ],
+    "CustomObject": [
+      "Entitlement"
+    ],
+    "CustomTab": [
+      "standard-Entitlement"
+    ]
+  }
+}

--- a/src/commands/hardis/project/clean/references.ts
+++ b/src/commands/hardis/project/clean/references.ts
@@ -37,7 +37,7 @@ export default class CleanReferences extends SfdxCommand {
     type: flags.string({
       char: "t",
       description: "Cleaning type",
-      options: ["all", "caseentitlement", "dashboards", "datadotcom", "destructivechanges", "localfields", "productrequest"],
+      options: ["all", "caseentitlement", "dashboards", "datadotcom", "destructivechanges", "localfields", "productrequest", "entitlement"],
     }),
     config: flags.string({
       char: "c",
@@ -105,6 +105,10 @@ export default class CleanReferences extends SfdxCommand {
     {
       value: "productrequest",
       title: "References to ProductRequest object",
+    },
+    {
+      value: "entitlement",
+      title: "References to Entitlement object",
     },
     {
       value: "systemDebug",


### PR DESCRIPTION
In this pull request,  support for a new cleanup type specific to the **'Entitlement'** object has been added.

Here are the specifics of the changes:

1. A new configuration file has been created **'entitlement.json'** within the **'defaults/clean'** directory. This file will specify the elements to be deleted during the cleanup of the **'Entitlement'** object.

2. A new entry has been added in the reference list in the **'references.ts'** file (line 40 and 109-112) located in the **'src\commands\hardis\project\clean'** path of the repository.
