### PR TITLE
Enhance deployment command to have support for runtests and dynamic RunRepositoryTests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Added new option --testlevel RunRepositoryTests which will dynamically detect all GIT repository test classes and runs the deployment with found tests. This will speed up the validation/deployment on cases where GIT repository module contains subset of all tests found in the org
+- Added --runtests support in order to pass certain APEX test classes when --testlevel RunSpecifiedTests is used
+
 ## [4.5.1] 2023-09-11
 
 - GitHub Integration: Fix Quick Deploy on Pull Requests

--- a/docs/hardis/project/deploy/sources/dx.md
+++ b/docs/hardis/project/deploy/sources/dx.md
@@ -101,18 +101,19 @@ ENV PUPPETEER_EXECUTABLE_PATH="$\{CHROMIUM_PATH}" // remove \ before {
 
 ## Parameters
 
-| Name                  |  Type   | Description                                                          |    Default    | Required |                                Options                                 |
-|:----------------------|:-------:|:---------------------------------------------------------------------|:-------------:|:--------:|:----------------------------------------------------------------------:|
-| apiversion            | option  | override the api version used for api requests made by this command  |               |          |                                                                        |
-| check<br/>-c          | boolean | Only checks the deployment, there is no impact on target org         |               |          |                                                                        |
-| debug<br/>-d          | boolean | Activate debug mode (more logs)                                      |               |          |                                                                        |
-| json                  | boolean | format output as json                                                |               |          |                                                                        |
-| loglevel              | option  | logging level for this command invocation                            |     warn      |          |         trace<br/>debug<br/>info<br/>warn<br/>error<br/>fatal          |
-| packagexml<br/>-p     | option  | Path to package.xml containing what you want to deploy in target org |               |          |                                                                        |
-| skipauth              | boolean | Skip authentication check when a default username is required        |               |          |                                                                        |
-| targetusername<br/>-u | option  | username or alias for the target org; overrides default target org   |               |          |                                                                        |
-| testlevel<br/>-l      | option  | Level of tests to apply to validate deployment                       | RunLocalTests |          | NoTestRun<br/>RunSpecifiedTests<br/>RunLocalTests<br/>RunAllTestsInOrg |
-| websocket             | option  | Websocket host:port for VsCode SFDX Hardis UI integration            |               |          |                                                                        |
+| Name                  |  Type   | Description                                                          |    Default    | Required |                                Options                                                        |
+|:----------------------|:-------:|:---------------------------------------------------------------------|:-------------:|:--------:|:---------------------------------------------------------------------------------------------:|
+| apiversion            | option  | override the api version used for api requests made by this command  |               |          |                                                                                               |
+| check<br/>-c          | boolean | Only checks the deployment, there is no impact on target org         |               |          |                                                                                               |
+| debug<br/>-d          | boolean | Activate debug mode (more logs)                                      |               |          |                                                                                               |
+| json                  | boolean | format output as json                                                |               |          |                                                                                               |
+| loglevel              | option  | logging level for this command invocation                            |     warn      |          |         trace<br/>debug<br/>info<br/>warn<br/>error<br/>fatal                                 |
+| packagexml<br/>-p     | option  | Path to package.xml containing what you want to deploy in target org |               |          |                                                                                               |
+| skipauth              | boolean | Skip authentication check when a default username is required        |               |          |                                                                                               |
+| targetusername<br/>-u | option  | username or alias for the target org; overrides default target org   |               |          |                                                                                               |
+| testlevel<br/>-l      | option  | Level of tests to apply to validate deployment                       | RunLocalTests |          | NoTestRun<br/>RunSpecifiedTests<br/>RunRepositoryTests<br/>RunLocalTests<br/>RunAllTestsInOrg |
+| runtests<br/>-r       | option  | Apex test classes to run if --testlevel is RunSpecifiedTests         |               |          |                                                                                               |
+| websocket             | option  | Websocket host:port for VsCode SFDX Hardis UI integration            |               |          |                                                                                               |
 
 ## Examples
 
@@ -122,6 +123,11 @@ sfdx hardis:project:deploy:sources:dx
 
 ```shell
 sfdx hardis:project:deploy:sources:dx --check
+```
+
+Validate deployment by running all APEX test classes found within your GIT repository
+```shell
+sfdx hardis:project:deploy:sources:dx --check --testlevel RunRepositoryTests
 ```
 
 

--- a/messages/org.json
+++ b/messages/org.json
@@ -46,6 +46,8 @@
   "statusFilter": "Filter according to Status criteria",
   "tempFolder": "Temporary folder",
   "testLevel": "Level of tests to apply to validate deployment",
+  "testLevelExtended": "Level of tests to validate deployment. RunRepositoryTests auto-detect and run all repository test classes",
   "websocket": "Websocket host:port for VsCode SFDX Hardis UI integration",
-  "withDevHub": "Also connect associated DevHub"
+  "withDevHub": "Also connect associated DevHub",
+  "runtests": "Apex test classes to run if --testlevel is RunSpecifiedTests"
 }

--- a/src/commands/hardis/project/deploy/sources/dx.ts
+++ b/src/commands/hardis/project/deploy/sources/dx.ts
@@ -196,7 +196,7 @@ If you need to increase the deployment waiting time (force:source:deploy --wait 
     // Auto-detect all APEX test classes within project in order to do RunSpecifiedTests deployment
     if(givenTestlevel == 'RunRepositoryTests') {
       testClassList = await getTestClasses();
-      this.flags.testlevel = testClassList.length ? 'RunSpecifiedTests' : 'RunLocalTests';
+      this.flags.testlevel = Array.isArray(testClassList) && testClassList.length ? 'RunSpecifiedTests' : 'RunLocalTests';
       uxLog(this, "Detected APEX test classes: " + testClassList);
     }
 

--- a/src/common/utils/classUtils.ts
+++ b/src/common/utils/classUtils.ts
@@ -1,0 +1,8 @@
+import { uxLog } from ".";
+import * as c from "chalk";
+
+// Detect all test classes under the repository
+export async function getTestClasses() {
+  uxLog(this, c.grey("Finding all repository test classes"));
+  return [];
+}

--- a/src/common/utils/classUtils.ts
+++ b/src/common/utils/classUtils.ts
@@ -1,8 +1,48 @@
 import { uxLog } from ".";
 import * as c from "chalk";
+import * as readFilesRecursive from "fs-readdir-recursive";
+import * as path from "path";
+import * as fs from 'fs';
+
+function findSubstringInFile(filePath: string, substring: string): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    fs.readFile(filePath, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      const content = data.toLowerCase();
+      substring = substring.toLowerCase();
+
+      resolve(content.indexOf(substring) !== -1);
+    });
+  });
+}
+
 
 // Detect all test classes under the repository
-export async function getTestClasses() {
-  uxLog(this, c.grey("Finding all repository test classes"));
-  return [];
+export async function getApexTestClasses() {
+  const pathToBrowser = process.cwd();
+  uxLog(this, c.grey(`Finding all repository APEX tests in ${c.bold(pathToBrowser)}`));
+
+  // Find all APEX classes
+  const testClasses = [];
+  const allFiles = await readFilesRecursive(pathToBrowser)
+    .filter((file) => !file.includes("node_modules") && file.includes("classes") && file.endsWith(".cls"))
+    .map((file) => {
+      return { fullPath: file, fileName: path.basename(file) };
+    });
+
+  // Detect test classes
+  for (const entry of allFiles) {
+    const isTestClass = await findSubstringInFile(entry.fullPath, '@IsTest');
+    if(isTestClass) {
+      const className = entry.fileName.substring(0,entry.fileName.length - 4);
+      testClasses.push(className);
+    }
+  }
+
+  uxLog(this, c.grey(`Found APEX tests: ${c.bold(testClasses.join())}`));
+  return testClasses;
 }

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -238,7 +238,7 @@ export async function forceSourceDeploy(
         ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || "60"}` +
         " --ignorewarnings" + // So it does not fail in for objectTranslations stuff
         ` --testlevel ${testlevel}` +
-        (options.testClassList && options.testClassList.length > 0 ? ` --runtests ${options.testClassList.join()}` : "") +
+        (options.testClasses ? ` --runtests ${options.testClasses}` : "") +
         (options.preDestructiveChanges ? ` --predestructivechanges ${options.postDestructiveChanges}` : "") +
         (options.postDestructiveChanges ? ` --postdestructivechanges ${options.postDestructiveChanges}` : "") +
         (options.targetUsername ? ` --targetusername ${options.targetUsername}` : "") +

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -238,6 +238,7 @@ export async function forceSourceDeploy(
         ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || "60"}` +
         " --ignorewarnings" + // So it does not fail in for objectTranslations stuff
         ` --testlevel ${testlevel}` +
+        (options.testClassList && options.testClassList.length > 0 ? ` --runtests ${options.testClassList.join()}` : "") +
         (options.preDestructiveChanges ? ` --predestructivechanges ${options.postDestructiveChanges}` : "") +
         (options.postDestructiveChanges ? ` --postdestructivechanges ${options.postDestructiveChanges}` : "") +
         (options.targetUsername ? ` --targetusername ${options.targetUsername}` : "") +


### PR DESCRIPTION
- Added new option `--testlevel RunRepositoryTests` which will dynamically detect all GIT repository test classes and runs the deployment with found tests. This will speed up the validation/deployment on cases where GIT repository module contains subset of all tests found in the org
- Added `--runtests` support in order to pass certain APEX test classes when `--testlevel RunSpecifiedTests` is used