### PR TITLE
Monitoring: Fix crash when a package name contains a slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 - **hardis:lint:metadatastatus**
   - Check inactive validation rules
   - Add js documentation
+- Monitoring: Fix crash when a package name contains a slash
 
 ## [4.19.1] 2023-12-03
 

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -126,8 +126,9 @@ export default class MonitorBackup extends SfdxCommand {
     await fs.ensureDir(packageFolder);
     for (const installedPackage of installedPackages) {
       const fileName = (installedPackage.SubscriberPackageName || installedPackage.SubscriberPackageId) + ".json";
+      const fileNameNoSep = fileName.replace(/\//g, '_') ; // Handle case when package name contains slashes
       delete installedPackage.Id; // Not needed for diffs
-      await fs.writeFile(path.join(packageFolder, fileName), JSON.stringify(installedPackage, null, 2));
+      await fs.writeFile(path.join(packageFolder, fileNameNoSep), JSON.stringify(installedPackage, null, 2));
     }
 
     const diffFiles = await MetadataUtils.listChangedFiles();

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -126,7 +126,7 @@ export default class MonitorBackup extends SfdxCommand {
     await fs.ensureDir(packageFolder);
     for (const installedPackage of installedPackages) {
       const fileName = (installedPackage.SubscriberPackageName || installedPackage.SubscriberPackageId) + ".json";
-      const fileNameNoSep = fileName.replace(/\//g, '_') ; // Handle case when package name contains slashes
+      const fileNameNoSep = fileName.replace(/\//g, "_"); // Handle case when package name contains slashes
       delete installedPackage.Id; // Not needed for diffs
       await fs.writeFile(path.join(packageFolder, fileNameNoSep), JSON.stringify(installedPackage, null, 2));
     }


### PR DESCRIPTION
Fixes https://github.com/hardisgroupcom/sfdx-hardis/issues/517
Co-authored-by: Yamilet Oliva <38166991+yamioliva@users.noreply.github.com>
