### PR TITLE
Minor updates about CI , monitoring & config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 ## [4.21] 2023-12-04
 
-- Add feature in access command to verify if an object permission exist twice or more in the same permission set
-- **hardis:lint:access**
-  - Check multiple object permission
+- **hardis:lint:access**: Add feature in access command to verify if an object permission exist twice or more in the same permission set
+- When prompt for login, Suggest custom login URL as first choice by default
+- CICD: Update default gitlab-ci-config.yml
+- Configure Org CI Auth: Do not prevent to use main or master as production branch
 
 ## [4.20.1] 2023-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
-## [4.21] 2023-12-04
+## [4.21.0] 2023-12-06
 
 - **hardis:lint:access**: Add feature in access command to verify if an object permission exist twice or more in the same permission set
+- **hardis:org:monitor:backup**: Allow to exclude more metadata types using env variable MONITORING_BACKUP_SKIP_METADATA_TYPES (example: \`MONITORING_BACKUP_SKIP_METADATA_TYPES=CustomLabel,StaticResource,Translation\`)
 - When prompt for login, Suggest custom login URL as first choice by default
 - CICD: Update default gitlab-ci-config.yml
 - Configure Org CI Auth: Do not prevent to use main or master as production branch

--- a/defaults/ci/.gitlab-ci-config.yml
+++ b/defaults/ci/.gitlab-ci-config.yml
@@ -1,5 +1,5 @@
 # You can customize your pipeline process here
 variables:
-  DEPLOY_BRANCHES: /(developpement|integration|recette|preprod|master)/ # Regex contenant la liste des branches où un push va déclencher un déploiement
+  DEPLOY_BRANCHES: /(development|integration|recette|preprod|main|master)/ # Regex contenant la liste des branches où un push va déclencher un déploiement
   CI_DELETE_SCRATCH_ORG: "true" # Set to "false" only to investigate issues. When solved, always put back this value to "true" !
   USE_SCRATCH_ORGS: "true" # Set to "false" to not use scratch orgs on your Salesforce project

--- a/docs/salesforce-monitoring-config-home.md
+++ b/docs/salesforce-monitoring-config-home.md
@@ -103,4 +103,8 @@ You might want to customize which metadatas types are backuped, because you can'
 
 If there are more than 10000 items, your monitoring job will crash.
 
-In that case, you must manually update file `manifest/package-skip-items.xml` in each git branch corresponding to an org, then commit and push.
+In that case, you can:
+
+- Single Branch scope: Manually update file `manifest/package-skip-items.xml` in the branch corresponding to an org, then commit and push
+- All branches scope: Define CI/CD env var **MONITORING_BACKUP_SKIP_METADATA_TYPES** with the list of additional metadata types you want to skip
+  - example: \`MONITORING_BACKUP_SKIP_METADATA_TYPES=CustomLabel,StaticResource,Translation\`

--- a/src/commands/hardis/org/diagnose/audittrail.ts
+++ b/src/commands/hardis/org/diagnose/audittrail.ts
@@ -67,6 +67,7 @@ Regular setup actions performed in major orgs are filtered.
   - PermSetLicenseAssign
   - PermSetUnassign
   - PermSetLicenseUnassign
+  - registeredUserPhoneNumber
   - resetpassword
   - suOrgAdminLogin
   - suOrgAdminLogout
@@ -215,6 +216,7 @@ monitoringAllowedSectionsActions:
         "PermSetLicenseAssign",
         "PermSetUnassign",
         "PermSetLicenseUnassign",
+        "registeredUserPhoneNumber",
         "resetpassword",
         "suOrgAdminLogin",
         "suOrgAdminLogout",

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -95,12 +95,17 @@ You can remove more metadata types from backup, especially in case you have too 
     // Add more metadata types to ignore using global variable MONITORING_BACKUP_SKIP_METADATA_TYPES
     const additionalSkipMetadataTypes = process.env?.MONITORING_BACKUP_SKIP_METADATA_TYPES;
     if (additionalSkipMetadataTypes) {
-      uxLog(this, c.grey(`En var MONITORING_BACKUP_SKIP_METADATA_TYPES has been found and will also be used to reduce the content of ${packageXmlFullFile} ...`));
+      uxLog(
+        this,
+        c.grey(
+          `En var MONITORING_BACKUP_SKIP_METADATA_TYPES has been found and will also be used to reduce the content of ${packageXmlFullFile} ...`,
+        ),
+      );
       let packageSkipItems = {};
       if (fs.existsSync(packageXmlToRemove)) {
         packageSkipItems = await parsePackageXmlFile(packageXmlToRemove);
       }
-      for (const metadataType of additionalSkipMetadataTypes.split(',')) {
+      for (const metadataType of additionalSkipMetadataTypes.split(",")) {
         packageSkipItems[metadataType] = ["*"];
       }
       packageXmlToRemove = "manifest/package-skip-items-dynamic-do-not-update-manually.xml";

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -93,14 +93,14 @@ You can remove more metadata types from backup, especially in case you have too 
     }
 
     // Add more metadata types to ignore using global variable MONITORING_BACKUP_SKIP_METADATA_TYPES
-    const additionalskipMetadataTypes = process.env?.MONITORING_BACKUP_SKIP_METADATA_TYPES;
-    if (additionalskipMetadataTypes) {
+    const additionalSkipMetadataTypes = process.env?.MONITORING_BACKUP_SKIP_METADATA_TYPES;
+    if (additionalSkipMetadataTypes) {
       uxLog(this, c.grey(`En var MONITORING_BACKUP_SKIP_METADATA_TYPES has been found and will also be used to reduce the content of ${packageXmlFullFile} ...`));
       let packageSkipItems = {};
       if (fs.existsSync(packageXmlToRemove)) {
         packageSkipItems = await parsePackageXmlFile(packageXmlToRemove);
       }
-      for (const metadataType of additionalskipMetadataTypes.split(',')) {
+      for (const metadataType of additionalSkipMetadataTypes.split(',')) {
         packageSkipItems[metadataType] = ["*"];
       }
       packageXmlToRemove = "manifest/package-skip-items-dynamic-do-not-update-manually.xml";

--- a/src/commands/hardis/project/configure/auth.ts
+++ b/src/commands/hardis/project/configure/auth.ts
@@ -108,9 +108,9 @@ export default class ConfigureAuth extends SfdxCommand {
         message: c.cyanBright("What is the name of the git branch you want to configure ? Examples: developpement,recette,production"),
       });
       branchName = branchResponse.value.replace(/\s/g, "-");
-      if (["main", "master"].includes(branchName)) {
+      /* if (["main", "master"].includes(branchName)) {
         throw new SfdxError("You can not use main or master as deployment branch name. Maybe you want to use production ?");
-      }
+      } */
       instanceUrl = await promptInstanceUrl(["login", "test"], `${branchName} related org`, {
         instanceUrl: devHub ? this.hubOrg.getConnection().instanceUrl : this.org.getConnection().instanceUrl,
       });

--- a/src/commands/hardis/project/configure/auth.ts
+++ b/src/commands/hardis/project/configure/auth.ts
@@ -1,6 +1,6 @@
 /* jscpd:ignore-start */
 import { flags, SfdxCommand } from "@salesforce/command";
-import { Messages, SfdxError } from "@salesforce/core";
+import { Messages } from "@salesforce/core";
 import { AnyJson } from "@salesforce/ts-types";
 import * as c from "chalk";
 import { execSfdxJson, generateSSLCertificate, promptInstanceUrl, uxLog } from "../../../../common/utils";

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -142,6 +142,11 @@ export async function checkAppDependency(appName) {
 export async function promptInstanceUrl(orgTypes = ["login", "test"], alias = "default org", defaultOrgChoice: any = null) {
   const allChoices = [
     {
+      title: "Custom login URL",
+      description: "The best choice :) Example: https://myclient--preprod.sandbox.lightning.force.com/",
+      value: "custom",
+    },
+    {
       title: "Sandbox or Scratch org (test.salesforce.com)",
       description: "The org I want to connect is a sandbox",
       value: "https://test.salesforce.com",
@@ -150,11 +155,6 @@ export async function promptInstanceUrl(orgTypes = ["login", "test"], alias = "d
       title: "Other: Dev, Enterprise or DevHub org (login.salesforce.com)",
       description: "The org I want to connect is NOT a sandbox",
       value: "https://login.salesforce.com",
-    },
-    {
-      title: "Custom login URL",
-      description: "When it's not possible to login via login.salesforce.com or test.salesforce.com",
-      value: "custom",
     },
   ];
   const choices = allChoices.filter((choice) => {


### PR DESCRIPTION
- **hardis:org:monitor:backup**: Allow to exclude more metadata types using env variable MONITORING_BACKUP_SKIP_METADATA_TYPES (example: \`MONITORING_BACKUP_SKIP_METADATA_TYPES=CustomLabel,StaticResource,Translation\`)
- When prompt for login, Suggest custom login URL as first choice by default
- CICD: Update default gitlab-ci-config.yml
- Configure Org CI Auth: Do not prevent to use main or master as production branch