### PR TITLE
Added bash to support project level scripts within Hardis image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL maintainer="Nicolas VUILLAMY <nicolas.vuillamy@hardis-group.com>"
 RUN apk add --update --no-cache \
             chromium \
             git \
+            bash \
             nodejs \
             npm
 


### PR DESCRIPTION
My customer project has few bash scripts which I will use in CI/CD steps. Using official SFDX Hardis image, hence want to have bash support