### PR TITLE
Skip post-deployment notifications when empty package.xml, simplify JIRA error logging

### DIFF
--- a/src/commands/hardis/project/deploy/sources/dx.ts
+++ b/src/commands/hardis/project/deploy/sources/dx.ts
@@ -378,7 +378,7 @@ If you need to increase the deployment waiting time (force:source:deploy --wait 
     }
 
     // Process deployment (or deployment check)
-    const { messages, quickDeploy } = await forceSourceDeploy(
+    const { messages, quickDeploy, deployXmlCount } = await forceSourceDeploy(
       packageXmlFile,
       this.checkOnly,
       testlevel,
@@ -387,13 +387,15 @@ If you need to increase the deployment waiting time (force:source:deploy --wait 
       forceSourceDeployOptions,
     );
 
+    const deployExecuted = !this.checkOnly && deployXmlCount > 0 ? true : false;
+
     // Set ListViews to scope Mine if defined in .sfdx-hardis.yml
-    if (this.configInfo.listViewsToSetToMine && this.checkOnly === false) {
+    if (this.configInfo.listViewsToSetToMine && deployExecuted) {
       await restoreListViewMine(this.configInfo.listViewsToSetToMine, this.org.getConnection(), { debug: this.debugMode });
     }
 
     // Send notification of deployment success
-    if (!this.checkOnly) {
+    if (deployExecuted) {
       const pullRequestInfo = await GitProvider.getPullRequestInfo();
       const attachments: MessageAttachment[] = [];
       try {

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -160,6 +160,13 @@ export async function forceSourceDeploy(
   let quickDeploy = false;
   const splitDeployments = await buildDeploymentPackageXmls(packageXmlFile, check, debugMode, options);
   const messages = [];
+  let deployXmlCount = splitDeployments.length;
+  
+  if (deployXmlCount === 0) {
+    uxLog(this, "No deployment to perform");
+    return { messages, quickDeploy, deployXmlCount };
+  }
+
   // Replace quick actions with dummy content in case we have dependencies between Flows & QuickActions
   await replaceQuickActionsWithDummy();
   // Process items of deployment plan
@@ -177,6 +184,7 @@ export async function forceSourceDeploy(
           )}`,
         ),
       );
+      deployXmlCount--;
       elapseEnd(`deploy ${deployment.label}`);
       continue;
     }
@@ -326,7 +334,7 @@ export async function forceSourceDeploy(
     messages.push(message);
   }
   elapseEnd("all deployments");
-  return { messages, quickDeploy };
+  return { messages, quickDeploy, deployXmlCount };
 }
 
 export function truncateProgressLogLines(rawLog: string) {


### PR DESCRIPTION
Skip notification providers if there was nothing to deploy (in delta mode)