### PR TITLE
Remove typo from package-no-overwrite.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [4.30.0] 2024-03-25
+
+- Fix default **package-no-overwrite.xml** (typos on NamesCredential & RemoteSiteSetting)
 - Add links to FAQ in documentation
 - Add two new PMD rules for quality **pmd-ruleset-high.xml** and **pmd-ruleset-medium.xml**
+
 
 ## [4.29.0] 2024-03-25
 

--- a/defaults/ci/manifest/package-no-overwrite.xml
+++ b/defaults/ci/manifest/package-no-overwrite.xml
@@ -18,12 +18,12 @@
   <types>
     <!-- Name Credentials can contain auth info that are different between dev, uat, preprod and prod: let's not overwrite them ! -->
     <members>*</members>
-    <name>NamedCredentials</name>
+    <name>NamedCredential</name>
   </types>
   <types>
     <!-- Remote site settings can be different between dev, uat, preprod and prod: let's not overwrite them ! -->
     <members>*</members>
-    <name>RemoteSiteSettings</name>
+    <name>RemoteSiteSetting</name>
   </types>
   <types>
     <!-- Reports are maintained directly in production -->

--- a/docs/salesforce-ci-cd-config-overwrite.md
+++ b/docs/salesforce-ci-cd-config-overwrite.md
@@ -77,7 +77,7 @@ This means that **an item matching package-no-overwrite.xml** will be **deployed
   <types>
     <!-- Name Credentials can contain auth info that are different between dev, uat, preprod and prod: let's not overwrite them ! -->
     <members>*</members>
-    <name>NamedCredentials</name>
+    <name>NamedCredential</name>
   </types>  
   <types>
     <!-- Use permission sets -->
@@ -87,7 +87,7 @@ This means that **an item matching package-no-overwrite.xml** will be **deployed
   <types>
     <!-- Remote site settings can be different between dev, uat, preprod and prod: let's not overwrite them ! -->
     <members>*</members>
-    <name>RemoteSiteSettings</name>
+    <name>RemoteSiteSetting</name>
   </types>  
   <types>
     <!-- Reports are maintained directly in production -->


### PR DESCRIPTION
Remove extra 's' from package-no-overwrite.xml

This incorrectly caused named credentials and remote site settings to be overwritten even though it looked like they were not