### PR TITLE
Monitoring updates + hardis:org:diagnose:licenses

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -775,6 +775,7 @@
     "updatedall",
     "urlonly",
     "usagestop",
+    "usedonly",
     "useremailchangesent",
     "userid",
     "userlicense",

--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -105,6 +105,7 @@
     "Ncss",
     "Ndays",
     "OCIs",
+    "Ohana",
     "ODNs",
     "OOOOOPS",
     "ORGALIAS",

--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - run: echo y|sfdx plugins:install sfdx-hardis
       - run: sfdx hardis:doc:plugin:generate
       # Deploy docs with mkdocs-material
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mdx_truly_sane_lists json-schema-for-humans mkdocs-glightbox==0.3.2 pymdown-extensions==9.1

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Create Pull Request with applied fixes
         id: cpr
         if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.head_commit.message, 'skip fix')
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: "[Mega-Linter] Apply linters automatic fixes"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
-- Monitoring: Exclude some Add / Remove users from a Territory events from Suspect Audit Trail actions
+- hardis:org:diagnose:audittrail: Exclude some Add / Remove users from a Territory events from Suspect Audit Trail actions
+- hardis:org:diagnose:unusedusers: Fix metric name for ActiveUsers
 
 ## [4.37.5] 2024-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Monitoring: Exclude some Add / Remove users from a Territory events from Suspect Audit Trail actions
+
 ## [4.37.5] 2024-05-31
 
 - **hardis:org:purge:flow**: Bulkify Flow deletion to improve performances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
-- hardis:org:diagnose:audittrail: Exclude some Add / Remove users from a Territory events from Suspect Audit Trail actions
-- hardis:org:diagnose:unusedusers: Fix metric name for ActiveUsers
+## [4.38.0] 2024-06-03
+
+- New command **hardis:org:diagnose:licenses** to send used licenses to monitoring logs like Grafana
+- **hardis:org:diagnose:audittrail**: Exclude some Add / Remove users from a Territory events from Suspect Audit Trail actions
+- **hardis:org:diagnose:unusedusers**: Fix metric name for ActiveUsers
 
 ## [4.37.5] 2024-05-31
 

--- a/defaults/ci/.github/workflows/megalinter.yml
+++ b/defaults/ci/.github/workflows/megalinter.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Create Pull Request with applied fixes
         id: cpr
         if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.head_commit.message, 'skip fix')
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: "[Mega-Linter] Apply linters automatic fixes"

--- a/defaults/mkdocs/.github/workflows/build-deploy-docs.yml
+++ b/defaults/mkdocs/.github/workflows/build-deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - run: echo y|sfdx plugins:install sfdx-hardis
       - run: sfdx hardis:doc:plugin:generate
       # Deploy docs with mkdocs-material
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mdx_truly_sane_lists json-schema-for-humans

--- a/docs/deployTips.md
+++ b/docs/deployTips.md
@@ -8,11 +8,11 @@ description: Learn how to fix issues that can happen during sfdx deployments
 
 This page summarizes all errors that can be detected by sfdx-hardis wrapper commands
 
-| sfdx command             | sfdx-hardis wrapper command |
-| :-----------             | :-------------------------- |
-| [sfdx force:source:deploy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_source.htm#cli_reference_force_source_deploy) | [sfdx hardis:source:deploy](https://sfdx-hardis.cloudity.com/hardis/source/deploy/)   |
-| [sfdx force:source:push](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_source.htm#cli_reference_force_source_push)   | [sfdx hardis:source:push](https://sfdx-hardis.cloudity.com/hardis/source/push/)     |
-| [sfdx force:mdapi:deploy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_mdapi.htm#cli_reference_force_mdapi_beta_deploy)  | [sfdx hardis:mdapi:deploy](https://sfdx-hardis.cloudity.com/hardis/mdapi/deploy/)    |
+| sfdx command                                                                                                                                                                                | sfdx-hardis wrapper command                                                         |
+|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| [sfdx force:source:deploy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_source.htm#cli_reference_force_source_deploy)   | [sfdx hardis:source:deploy](https://sfdx-hardis.cloudity.com/hardis/source/deploy/) |
+| [sfdx force:source:push](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_source.htm#cli_reference_force_source_push)       | [sfdx hardis:source:push](https://sfdx-hardis.cloudity.com/hardis/source/push/)     |
+| [sfdx force:mdapi:deploy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_mdapi.htm#cli_reference_force_mdapi_beta_deploy) | [sfdx hardis:mdapi:deploy](https://sfdx-hardis.cloudity.com/hardis/mdapi/deploy/)   |
 
 You can also use this function on a [sfdx-hardis Salesforce CI/CD project](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-home/)
 
@@ -302,7 +302,7 @@ You probably also need to add CRM Analytics Admin Permission Set assignment to t
 
 ## Error parsing file
 
-- `Error (.*) Error parsing file: (.*) `
+- `Error (.*) Error parsing file: (.*)`
 
 **Resolution tip**
 
@@ -913,7 +913,7 @@ Please check https://developer.salesforce.com/forums/?id=9060G0000005kVLQAY
 
 ## Test classes with 0% coverage
 
-- ` 0%`
+- `0%`
 
 **Resolution tip**
 

--- a/docs/grafana/dashboards/DTL - Limits Details.json
+++ b/docs/grafana/dashboards/DTL - Limits Details.json
@@ -204,9 +204,7 @@
           "countRows": false,
           "enablePagination": false,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true,
@@ -257,9 +255,7 @@
           "id": "reduce",
           "options": {
             "labelsToFields": false,
-            "reducers": [
-              "allValues"
-            ]
+            "reducers": ["allValues"]
           }
         },
         {

--- a/docs/salesforce-monitoring-home.md
+++ b/docs/salesforce-monitoring-home.md
@@ -34,6 +34,10 @@ _Example of visualization in Grafana_
 
 ![](assets/images/grafana-screenshot-2.png)
 
+_See presentation at Wir Sind Ohana conference in Berlin, may 2024_
+
+<div style="text-align:center"><iframe width="560" height="315" src="https://www.youtube.com/embed/xGbT6at7RZ0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
+
 Extra features are also available, like:
 
 - Run **apex tests** (and soon flow tests)

--- a/src/commands/hardis/org/diagnose/audittrail.ts
+++ b/src/commands/hardis/org/diagnose/audittrail.ts
@@ -204,10 +204,7 @@ monitoringAllowedSectionsActions:
       Holidays: ["holiday_insert"],
       "Inbox mobile and legacy desktop apps": ["enableSIQUserNonEAC"],
       Groups: ["groupMembership"],
-      "Manage Territories": [
-        "tm2_userAddedToTerritory",
-        "tm2_userRemovedFromTerritory"
-      ],
+      "Manage Territories": ["tm2_userAddedToTerritory", "tm2_userRemovedFromTerritory"],
       "Manage Users": [
         "activateduser",
         "createduser",

--- a/src/commands/hardis/org/diagnose/audittrail.ts
+++ b/src/commands/hardis/org/diagnose/audittrail.ts
@@ -204,6 +204,10 @@ monitoringAllowedSectionsActions:
       Holidays: ["holiday_insert"],
       "Inbox mobile and legacy desktop apps": ["enableSIQUserNonEAC"],
       Groups: ["groupMembership"],
+      "Manage Territories": [
+        "tm2_userAddedToTerritory",
+        "tm2_userRemovedFromTerritory"
+      ],
       "Manage Users": [
         "activateduser",
         "createduser",

--- a/src/commands/hardis/org/diagnose/licenses.ts
+++ b/src/commands/hardis/org/diagnose/licenses.ts
@@ -20,9 +20,7 @@ export default class DiagnoseUnusedUsers extends SfdxCommand {
 
   public static description = `Mostly used for monitoring (Grafana) but you can also use it manually :)`;
 
-  public static examples = [
-    "$ sfdx hardis:org:diagnose:licenses"
-  ];
+  public static examples = ["$ sfdx hardis:org:diagnose:licenses"];
 
   //Comment default values to test the prompts
   protected static flagsConfig = {
@@ -71,7 +69,7 @@ export default class DiagnoseUnusedUsers extends SfdxCommand {
 
     // Retrieve the list of users who haven't logged in for a while
     const conn = this.org.getConnection();
-    uxLog(this, c.cyan(`Extracting Licenses from ${conn.instanceUrl} ...` + this.usedOnly ? "(used only)" : ''));
+    uxLog(this, c.cyan(`Extracting Licenses from ${conn.instanceUrl} ...` + this.usedOnly ? "(used only)" : ""));
 
     const licensesByKey = {};
     const usedLicenses = [];
@@ -139,7 +137,7 @@ export default class DiagnoseUnusedUsers extends SfdxCommand {
       data: {
         activeLicenses: Object.keys(licensesByKey).sort(),
         usedLicenses: usedLicenses,
-        licenses: licensesByKey
+        licenses: licensesByKey,
       },
       metrics: {},
     });

--- a/src/commands/hardis/org/diagnose/licenses.ts
+++ b/src/commands/hardis/org/diagnose/licenses.ts
@@ -1,0 +1,155 @@
+/* jscpd:ignore-start */
+import { flags, SfdxCommand } from "@salesforce/command";
+import { Messages } from "@salesforce/core";
+import { AnyJson } from "@salesforce/ts-types";
+import * as c from "chalk";
+import { uxLog } from "../../../../common/utils";
+import { soqlQuery } from "../../../../common/utils/apiUtils";
+import { generateCsvFile, generateReportPath } from "../../../../common/utils/filesUtils";
+import { NotifProvider } from "../../../../common/notifProvider";
+
+// Initialize Messages with the current plugin directory
+Messages.importMessagesDirectory(__dirname);
+
+// Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
+// or any library that is using the messages framework can also be loaded this way.
+const messages = Messages.loadMessages("sfdx-hardis", "org");
+
+export default class DiagnoseUnusedUsers extends SfdxCommand {
+  public static title = "List licenses subscribed and used in a Salesforce org";
+
+  public static description = `Mostly used for monitoring (Grafana) but you can also use it manually :)`;
+
+  public static examples = [
+    "$ sfdx hardis:org:diagnose:licenses"
+  ];
+
+  //Comment default values to test the prompts
+  protected static flagsConfig = {
+    outputfile: flags.string({
+      char: "o",
+      description: "Force the path and name of output report file. Must end with .csv",
+    }),
+    usedonly: flags.boolean({
+      char: "u",
+      default: false,
+      description: "Filter to have only used licenses",
+    }),
+    debug: flags.boolean({
+      char: "d",
+      default: false,
+      description: messages.getMessage("debugMode"),
+    }),
+    websocket: flags.string({
+      description: messages.getMessage("websocket"),
+    }),
+    skipauth: flags.boolean({
+      description: "Skip authentication check when a default username is required",
+    }),
+  };
+
+  // Comment this out if your command does not require an org username
+  protected static requiresUsername = true;
+  // Comment this out if your command does not support a hub org username
+  protected static requiresDevhubUsername = false;
+  // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
+  protected static requiresProject = false;
+
+  protected usedOnly = false;
+  protected debugMode = false;
+  protected outputFile;
+  protected outputFilesRes: any = {};
+  protected licenses: any = [];
+  protected statusCode = 0;
+
+  /* jscpd:ignore-end */
+
+  public async run(): Promise<AnyJson> {
+    this.usedOnly = this.flags.usedonly || false;
+    this.debugMode = this.flags.debug || false;
+    this.outputFile = this.flags.outputfile || null;
+
+    // Retrieve the list of users who haven't logged in for a while
+    const conn = this.org.getConnection();
+    uxLog(this, c.cyan(`Extracting Licenses from ${conn.instanceUrl} ...` + this.usedOnly ? "(used only)" : ''));
+
+    const licensesByKey = {};
+    const usedLicenses = [];
+
+    // Query User Licenses
+    const userLicenseQuery =
+      `Select MasterLabel, Name, TotalLicenses, UsedLicenses ` +
+      `FROM UserLicense ` +
+      `WHERE Status='Active' AND TotalLicenses > 0 ` +
+      `ORDER BY MasterLabel`;
+    const userLicenseQueryRes = await soqlQuery(userLicenseQuery, conn);
+    const userLicenses = userLicenseQueryRes.records.map((userLicense) => {
+      const userLicenseInfo = Object.assign({}, userLicense);
+      delete userLicenseInfo.Id;
+      delete userLicenseInfo.attributes;
+      userLicenseInfo.type = "UserLicense";
+      licensesByKey[userLicenseInfo.MasterLabel] = userLicenseInfo.TotalLicenses;
+      if (userLicenseInfo.UsedLicenses > 0) {
+        usedLicenses.push(userLicenseInfo.MasterLabel);
+      }
+      return userLicenseInfo;
+    });
+    this.licenses.push(...userLicenses);
+
+    // Query Permission Set Licenses
+    let pslQuery =
+      `SELECT MasterLabel, PermissionSetLicenseKey, TotalLicenses, UsedLicenses ` +
+      `FROM PermissionSetLicense ` +
+      `WHERE Status='Active' AND TotalLicenses > 0 `;
+    if (this.usedOnly) {
+      pslQuery += `AND UsedLicenses > 0 `;
+    }
+    pslQuery += `ORDER BY MasterLabel`;
+    const pslQueryRes = await soqlQuery(pslQuery, conn);
+    const pslLicenses = pslQueryRes.records.map((psl) => {
+      const pslInfo = Object.assign({}, psl);
+      pslInfo.Name = pslInfo.PermissionSetLicenseKey;
+      delete pslInfo.Id;
+      delete pslInfo.attributes;
+      delete pslInfo.PermissionSetLicenseKey;
+      pslInfo.type = "PermissionSetLicense";
+      licensesByKey[pslInfo.MasterLabel] = pslInfo.TotalLicenses;
+      if (pslInfo.UsedLicenses > 0) {
+        usedLicenses.push(pslInfo.MasterLabel);
+      }
+      return pslInfo;
+    });
+    this.licenses.push(...pslLicenses);
+
+    usedLicenses.sort();
+    console.table(this.licenses);
+    uxLog(this, c.cyan("Used licenses: " + usedLicenses.join(", ")));
+
+    // Generate output CSV file
+    this.outputFile = await generateReportPath("licenses", this.outputFile);
+    this.outputFilesRes = await generateCsvFile(this.licenses, this.outputFile);
+
+    globalThis.jsForceConn = this?.org?.getConnection(); // Required for some notifications providers like Email
+    NotifProvider.postNotifications({
+      type: "LICENSES",
+      text: "",
+      severity: "log",
+      attachedFiles: this.outputFilesRes.xlsxFile ? [this.outputFilesRes.xlsxFile] : [],
+      logElements: this.licenses,
+      data: {
+        activeLicenses: Object.keys(licensesByKey).sort(),
+        usedLicenses: usedLicenses,
+        licenses: licensesByKey
+      },
+      metrics: {},
+    });
+
+    // Return an object to be displayed with --json
+    return {
+      status: 0,
+      licenses: this.licenses,
+      csvLogFile: this.outputFile,
+      xlsxLogFile: this.outputFilesRes.xlsxFile,
+    };
+  }
+}

--- a/src/commands/hardis/org/diagnose/unusedusers.ts
+++ b/src/commands/hardis/org/diagnose/unusedusers.ts
@@ -229,12 +229,12 @@ Use --returnactiveusers to revert the command and retrieve active users that has
   private async listUsersFromLicenses(conn) {
     let whereConstraint = this.returnActiveUsers
       ? // Active users
-      `WHERE IsActive = true AND (` + `(LastLoginDate >= LAST_N_DAYS:${this.lastNdays} AND LastLoginDate != NULL)` + `)`
+        `WHERE IsActive = true AND (` + `(LastLoginDate >= LAST_N_DAYS:${this.lastNdays} AND LastLoginDate != NULL)` + `)`
       : // Inactive users
-      `WHERE IsActive = true AND (` +
-      `(LastLoginDate < LAST_N_DAYS:${this.lastNdays} AND LastLoginDate != NULL) OR ` +
-      `(CreatedDate < LAST_N_DAYS:${this.lastNdays} AND LastLoginDate = NULL)` + // Check also for users never used
-      `)`;
+        `WHERE IsActive = true AND (` +
+        `(LastLoginDate < LAST_N_DAYS:${this.lastNdays} AND LastLoginDate != NULL) OR ` +
+        `(CreatedDate < LAST_N_DAYS:${this.lastNdays} AND LastLoginDate = NULL)` + // Check also for users never used
+        `)`;
     // Add License constraint only if necessary
     if (this.licenseTypes !== "all") {
       const licenseIdentifierValues = this.licenseIdentifiers.split(",");

--- a/src/commands/hardis/org/diagnose/unusedusers.ts
+++ b/src/commands/hardis/org/diagnose/unusedusers.ts
@@ -229,12 +229,12 @@ Use --returnactiveusers to revert the command and retrieve active users that has
   private async listUsersFromLicenses(conn) {
     let whereConstraint = this.returnActiveUsers
       ? // Active users
-        `WHERE IsActive = true AND (` + `(LastLoginDate >= LAST_N_DAYS:${this.lastNdays} AND LastLoginDate != NULL)` + `)`
+      `WHERE IsActive = true AND (` + `(LastLoginDate >= LAST_N_DAYS:${this.lastNdays} AND LastLoginDate != NULL)` + `)`
       : // Inactive users
-        `WHERE IsActive = true AND (` +
-        `(LastLoginDate < LAST_N_DAYS:${this.lastNdays} AND LastLoginDate != NULL) OR ` +
-        `(CreatedDate < LAST_N_DAYS:${this.lastNdays} AND LastLoginDate = NULL)` + // Check also for users never used
-        `)`;
+      `WHERE IsActive = true AND (` +
+      `(LastLoginDate < LAST_N_DAYS:${this.lastNdays} AND LastLoginDate != NULL) OR ` +
+      `(CreatedDate < LAST_N_DAYS:${this.lastNdays} AND LastLoginDate = NULL)` + // Check also for users never used
+      `)`;
     // Add License constraint only if necessary
     if (this.licenseTypes !== "all") {
       const licenseIdentifierValues = this.licenseIdentifiers.split(",");
@@ -266,6 +266,7 @@ Use --returnactiveusers to revert the command and retrieve active users that has
         : `${this.users.length} active users have not logged in to ${orgMarkdown} within the last ${this.lastNdays} days.`;
       attachments = [{ text: notifDetailText }];
     }
+    const metrics = this.returnActiveUsers ? { ActiveUsers: this.users.length } : { UnusedUsers: this.users.length };
     /* jscpd:ignore-start */
     // Send notifications
     globalThis.jsForceConn = this?.org?.getConnection(); // Required for some notifications providers like Email
@@ -278,9 +279,7 @@ Use --returnactiveusers to revert the command and retrieve active users that has
       attachedFiles: this.outputFilesRes.xlsxFile ? [this.outputFilesRes.xlsxFile] : [],
       logElements: this.users,
       data: { metric: this.users.length },
-      metrics: {
-        UnusedUsers: this.users.length,
-      },
+      metrics: metrics,
     });
     /* jscpd:ignore-end */
     return [];

--- a/src/commands/hardis/org/monitor/all.ts
+++ b/src/commands/hardis/org/monitor/all.ts
@@ -112,6 +112,12 @@ You can force the daily run of all commands by defining env var \`MONITORING_IGN
         frequency: "daily",
       },
       {
+        key: "LICENSES",
+        title: "Extract licenses information",
+        command: "sfdx hardis:org:diagnose:licenses",
+        frequency: "daily", // TODO: Set as weekly later
+      },
+      {
         key: "LINT_ACCESS",
         title: "Detect custom elements with no access rights defined in permission sets",
         command: "sfdx hardis:lint:access",
@@ -127,13 +133,13 @@ You can force the daily run of all commands by defining env var \`MONITORING_IGN
         key: "UNUSED_USERS",
         title: "Detect active users without recent logins",
         command: "sfdx hardis:org:diagnose:unusedusers",
-        frequency: "weekly",
+        frequency: "daily", // TODO: Set as weekly later
       },
       {
         key: "ACTIVE_USERS",
         title: "Detect active users with recent logins",
         command: "sfdx hardis:org:diagnose:unusedusers --returnactiveusers",
-        frequency: "weekly",
+        frequency: "daily", // TODO: Set as weekly later
       },
       {
         key: "UNUSED_METADATAS",

--- a/src/commands/hardis/org/purge/flow.ts
+++ b/src/commands/hardis/org/purge/flow.ts
@@ -183,7 +183,7 @@ export default class OrgPurgeFlow extends SfdxCommand {
       return { deleted: [], outputString };
     }
 
-    // Simplify results format & display them 
+    // Simplify results format & display them
     const records = recordsRaw.map((record: any) => {
       return {
         Id: record.Id,
@@ -215,7 +215,7 @@ export default class OrgPurgeFlow extends SfdxCommand {
     const deleted = [];
     const deleteErrors = [];
     const conn = this.org.getConnection();
-    const deleteResults = await bulkDeleteTooling('Flow', records, conn);
+    const deleteResults = await bulkDeleteTooling("Flow", records, conn);
     for (const deleteRes of deleteResults.results) {
       if (deleteRes.success) {
         deleted.push(deleteRes);

--- a/src/common/notifProvider/index.ts
+++ b/src/common/notifProvider/index.ts
@@ -88,6 +88,7 @@ export interface NotifMessage {
     | "BACKUP"
     | "DEPLOYMENT"
     | "LEGACY_API"
+    | "LICENSES"
     | "LINT_ACCESS"
     | "UNUSED_METADATAS"
     | "METADATA_STATUS"

--- a/src/common/utils/apiUtils.ts
+++ b/src/common/utils/apiUtils.ts
@@ -102,9 +102,9 @@ export async function bulkUpdate(objectName: string, action: string, records: Ar
   });
 }
 
-export async function bulkDeleteTooling(objectName: string, recordsFull: {Id: string}[], conn: Connection): Promise<any> {
+export async function bulkDeleteTooling(objectName: string, recordsFull: { Id: string }[], conn: Connection): Promise<any> {
   return new Promise((resolve, reject) => {
-    const records = recordsFull.map(record => record.Id);
+    const records = recordsFull.map((record) => record.Id);
     const options: RestApiOptions = { allOrNone: false };
     const handleCallback = (err: Error, result: RecordResult | RecordResult[]) => {
       if (err) {
@@ -114,9 +114,9 @@ export async function bulkDeleteTooling(objectName: string, recordsFull: {Id: st
         throw new SfdxError(c.red(`Error deleting ${objectName} records:` + resultObject));
       } else {
         const resultsArray = Array.isArray(result) ? result : [result];
-        const anyFailure = resultsArray.some(result => !result.success);
+        const anyFailure = resultsArray.some((result) => !result.success);
 
-        const resultObject = createResultObject(records, !anyFailure, anyFailure ? `One or more ${objectName} records failed to delete.` : '');
+        const resultObject = createResultObject(records, !anyFailure, anyFailure ? `One or more ${objectName} records failed to delete.` : "");
         resolve(resultObject);
       }
     };
@@ -124,21 +124,21 @@ export async function bulkDeleteTooling(objectName: string, recordsFull: {Id: st
       const recordsArray = Array.isArray(records) ? records : [records];
 
       return {
-        results: recordsArray.map(record => ({
+        results: recordsArray.map((record) => ({
           id: record,
           success: success,
-          errors: success ? [] : [errorMessage]
+          errors: success ? [] : [errorMessage],
         })),
         totalSize: recordsArray.length,
         successRecordsNb: success ? recordsArray.length : 0,
         errorRecordsNb: success ? 0 : recordsArray.length,
-        errorDetails: success ? [] : [{ error: errorMessage }]
+        errorDetails: success ? [] : [{ error: errorMessage }],
       };
     };
     try {
       conn.tooling.del(objectName, records, options, handleCallback);
     } catch (error) {
-      const resultObject = createResultObject(records, false, 'One or more records failed to delete due to a synchronous error.');
+      const resultObject = createResultObject(records, false, "One or more records failed to delete due to a synchronous error.");
       reject(resultObject);
       throw new SfdxError(c.red("Tooling Error:" + resultObject));
     }


### PR DESCRIPTION
- New command **hardis:org:diagnose:licenses** to send used licenses to monitoring logs like Grafana
- **hardis:org:diagnose:audittrail**: Exclude some Add / Remove users from a Territory events from Suspect Audit Trail actions
- **hardis:org:diagnose:unusedusers**: Fix metric name for ActiveUsers