### PR TITLE
commandsPreDeploy & commandsPostDeploy

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -27,6 +27,7 @@
     "Alainbates",
     "Astran",
     "BETAID",
+    "BRANCHNAME",
     "BUILDID",
     "Backuped",
     "Badwords",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 - Deployment tips: add missingDataCategoryGroup (no DataCategoryGroup named...)
 - handle **commandsPreDeploy** and **commandPostDeploy** to run custom command before and after deployments
+  - If the commands are not the same depending on the target org, you can define them into config/branches/.sfdx-hardis-BRANCHNAME.yml instead of root config/.sfdx-hardis.yml
+
+Example:
+
+```yaml
+commandsPreDeploy:
+  - id: knowledgeUnassign
+    label: Remove KnowledgeUser right to the user who has it
+    command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
+  - id: knowledgeAssign
+    label: Assign Knowledge user to the deployment user
+    command: sf data update record --sobject User --where "Username='deploy.github@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
+commandsPostDeploy:
+  - id: knowledgeUnassign
+    label: Remove KnowledgeUser right to the user who has it
+    command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
+  - id: knowledgeAssign
+    label: Assign Knowledge user to the deployment user
+    command: sf data update record --sobject User --where "Username='admin.user@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
+```
 
 ## [4.39.0] 2024-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [4.40.0] 2024-06-13
+
 - Deployment tips: add missingDataCategoryGroup (no DataCategoryGroup named...)
+- handle **commandsPreDeploy** and **commandPostDeploy** to run custom command before and after deployments
 
 ## [4.39.0] 2024-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Deployment tips: add missingDataCategoryGroup (no DataCategoryGroup named...)
+
 ## [4.39.0] 2024-06-13
 
 - hardis:clean:references: new option **v60**

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -276,6 +276,11 @@
         },
         "title": "Command"
       },
+      "required": [
+        "id",
+        "label",
+        "command"
+      ],
       "title": "Commands Pre-Deployment",
       "type": "array"
     },
@@ -306,8 +311,20 @@
             "description": "Command line to run",
             "title": "Command",
             "type": "string"
+          },
+          "skipIfError": {
+            "$id": "#/properties/commandsPostDeploy/items/properties/skipIfError",
+            "description": "Do not run the command if there is a deployment error",
+            "title": "Skip if error",
+            "default": "false",
+            "type": "boolean"
           }
         },
+        "required": [
+          "id",
+          "label",
+          "command"
+        ],
         "title": "Command"
       },
       "title": "Commands Post-Deployment",

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -19,7 +19,15 @@
       "type": "string"
     },
     "enum_monitoring_commands": {
-      "enum": ["AUDIT_TRAIL", "LEGACY_API", "LINT_ACCESS", "UNUSED_METADATAS", "METADATA_STATUS", "MISSING_ATTRIBUTES", "UNUSED_LICENSES"],
+      "enum": [
+        "AUDIT_TRAIL",
+        "LEGACY_API",
+        "LINT_ACCESS",
+        "UNUSED_METADATAS",
+        "METADATA_STATUS",
+        "MISSING_ATTRIBUTES",
+        "UNUSED_LICENSES"
+      ],
       "type": "string"
     }
   },
@@ -28,10 +36,17 @@
     "allowedOrgTypes": {
       "$id": "#/properties/allowedOrgTypes",
       "description": "Types of orgs allowed for config & development. If not set, sandbox and scratch are allowed by default",
-      "examples": [["sandbox"]],
+      "examples": [
+        [
+          "sandbox"
+        ]
+      ],
       "items": {
         "type": "string",
-        "enum": ["sandbox", "scratch"]
+        "enum": [
+          "sandbox",
+          "scratch"
+        ]
       },
       "title": "Allowed org types",
       "type": "array"
@@ -39,7 +54,13 @@
     "autoCleanTypes": {
       "$id": "#/properties/autoCleanTypes",
       "description": "When saving a sfdx-hardis task, the list of cleanings will be automatically applied to sfdx sources",
-      "examples": [["dashboards", "datadotcom", "destructivechanges"]],
+      "examples": [
+        [
+          "dashboards",
+          "datadotcom",
+          "destructivechanges"
+        ]
+      ],
       "items": {
         "type": "string",
         "enum": [
@@ -62,7 +83,13 @@
     "autoRemoveUserPermissions": {
       "$id": "#/properties/autoRemoveUserPermissions",
       "description": "When saving a sfdx-hardis task, these permissions will be removed from profiles",
-      "examples": [["EnableCommunityAppLauncher", "FieldServiceAccess", "OmnichannelInventorySync"]],
+      "examples": [
+        [
+          "EnableCommunityAppLauncher",
+          "FieldServiceAccess",
+          "OmnichannelInventorySync"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -72,7 +99,15 @@
     "autoRetrieveWhenPull": {
       "$id": "#/properties/autoRetrieveWhenPull",
       "description": "When calling hardis:scratch:pull, if you define metadatas (named or not), they will also be retrieved using force:source:retrieve",
-      "examples": [["CustomApplication"], ["CustomApplication:MyApp1", "CustomApplication:MyApp2"]],
+      "examples": [
+        [
+          "CustomApplication"
+        ],
+        [
+          "CustomApplication:MyApp1",
+          "CustomApplication:MyApp2"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -83,14 +118,23 @@
       "$id": "#/properties/apexTestsMinCoverageOrgWide",
       "default": 75.0,
       "description": "Minimum percentage of apex code coverage accepted",
-      "examples": [80.0, 95.0],
+      "examples": [
+        80.0,
+        95.0
+      ],
       "title": "Minimum apex test coverage %",
       "type": "number"
     },
     "availableProjects": {
       "$id": "#/properties/availableProjects",
       "description": "List of business projects that are managed in the same repository. Will be used to build git branch name when using hardis:work:new",
-      "examples": [["sales_cloud", "service_cloud", "community"]],
+      "examples": [
+        [
+          "sales_cloud",
+          "service_cloud",
+          "community"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -100,7 +144,12 @@
     "availableTargetBranches": {
       "$id": "#/properties/availableTargetBranches",
       "description": "List of git branches that can be used as target for merge requests",
-      "examples": [["develop", "develop_next"]],
+      "examples": [
+        [
+          "develop",
+          "develop_next"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -145,11 +194,15 @@
         [
           {
             "globPattern": "/**/*.flexipage-meta.xml",
-            "xpaths": ["//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"]
+            "xpaths": [
+              "//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"
+            ]
           },
           {
             "globPattern": "/**/*.layout-meta.xml",
-            "xpaths": ["//ns:relatedLists//ns:relatedList[contains(text(),'RelatedSolutionList')]"]
+            "xpaths": [
+              "//ns:relatedLists//ns:relatedList[contains(text(),'RelatedSolutionList')]"
+            ]
           }
         ]
       ],
@@ -163,14 +216,20 @@
           "globPattern": {
             "$id": "#/properties/cleanXmlPatterns/items/properties/globPattern",
             "description": "Glob pattern to identify XML files to clean",
-            "examples": ["/**/*.flexipage-meta.xml"],
+            "examples": [
+              "/**/*.flexipage-meta.xml"
+            ],
             "title": "Glob pattern",
             "type": "string"
           },
           "xpaths": {
             "$id": "#/properties/cleanXmlPatterns/items/properties/xpaths",
             "description": "XPaths to identify elements to remove",
-            "examples": [["//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"]],
+            "examples": [
+              [
+                "//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"
+              ]
+            ],
             "title": "XPath list",
             "items": {
               "type": "string"
@@ -178,7 +237,10 @@
             "type": "array"
           }
         },
-        "required": ["globPattern", "xpaths"]
+        "required": [
+          "globPattern",
+          "xpaths"
+        ]
       },
       "title": "Clean XML Patterns",
       "type": "array"
@@ -186,7 +248,20 @@
     "commandsPreDeploy": {
       "$id": "#/properties/commandsPreDeploy",
       "description": "List of commands to run before a deployment",
-      "examples": [],
+      "examples": [
+        [
+          {
+            "id": "knowledgeUnassign",
+            "label": "Remove KnownledgeUser right to the user who has it",
+            "command": "sf data update record --sobject User --where \"UserPermissionsKnowledgeUser='true'\" --values \"UserPermissionsKnowledgeUser='false'\" --json"
+          },
+          {
+            "id": "knowledgeAssign",
+            "label": "Assign Knowledge user to desired username",
+            "command": "sf data update record --sobject User --where \"Username='deployment-user@myclient.com'\" --values \"UserPermissionsKnowledgeUser='true'\" --json"
+          }
+        ]
+      ],
       "items": {
         "$id": "#/properties/commandsPreDeploy/items",
         "type": "object",
@@ -214,14 +289,31 @@
         },
         "title": "Command"
       },
-      "required": ["id", "label", "command"],
+      "required": [
+        "id",
+        "label",
+        "command"
+      ],
       "title": "Commands Pre-Deployment",
       "type": "array"
     },
     "commandsPostDeploy": {
       "$id": "#/properties/commandsPostDeploy",
       "description": "List of commands to run after a deployment",
-      "examples": [],
+      "examples": [
+        [
+          {
+            "id": "knowledgeUnassign",
+            "label": "Remove KnownledgeUser right to the user who has it",
+            "command": "sf data update record --sobject User --where \"UserPermissionsKnowledgeUser='true'\" --values \"UserPermissionsKnowledgeUser='false'\" --json"
+          },
+          {
+            "id": "knowledgeAssign",
+            "label": "Assign Knowledge user to desired username",
+            "command": "sf data update record --sobject User --where \"Username='admin-user@myclient.com'\" --values \"UserPermissionsKnowledgeUser='true'\" --json"
+          }
+        ]
+      ],
       "items": {
         "$id": "#/properties/commandsPostDeploy/items",
         "type": "object",
@@ -254,7 +346,11 @@
             "type": "boolean"
           }
         },
-        "required": ["id", "label", "command"],
+        "required": [
+          "id",
+          "label",
+          "command"
+        ],
         "title": "Command"
       },
       "title": "Commands Post-Deployment",
@@ -364,13 +460,20 @@
                   "type": "string"
                 }
               },
-              "required": ["id", "label", "command"]
+              "required": [
+                "id",
+                "label",
+                "command"
+              ]
             },
             "title": "Label",
             "type": "array"
           }
         },
-        "required": ["id", "label"]
+        "required": [
+          "id",
+          "label"
+        ]
       },
       "title": "Custom commands",
       "type": "array"
@@ -379,8 +482,14 @@
       "$id": "#/properties/customCommandsPosition",
       "description": "Position of custom commands in the menu (first or last)",
       "default": "first",
-      "enum": ["first", "last"],
-      "examples": ["first", "last"],
+      "enum": [
+        "first",
+        "last"
+      ],
+      "examples": [
+        "first",
+        "last"
+      ],
       "title": "Custom commands position",
       "type": "string"
     },
@@ -415,14 +524,20 @@
           "name": {
             "$Id": "#/properties/customPlugins/items/properties/name",
             "description": "Name of the plugin npm package",
-            "examples": ["mo-dx-plugin", "shane-sfdx-plugins"],
+            "examples": [
+              "mo-dx-plugin",
+              "shane-sfdx-plugins"
+            ],
             "title": "Name",
             "type": "string"
           },
           "helpUrl": {
             "$Id": "#/properties/customPlugins/items/properties/helpUrl",
             "description": "Url of plugin documentation",
-            "examples": ["https://github.com/msrivastav13/mo-dx-plugin", "https://github.com/mshanemc/shane-sfdx-plugins"],
+            "examples": [
+              "https://github.com/msrivastav13/mo-dx-plugin",
+              "https://github.com/mshanemc/shane-sfdx-plugins"
+            ],
             "title": "Name",
             "type": "string"
           }
@@ -454,7 +569,10 @@
             "type": "boolean"
           }
         },
-        "required": ["dataPath", "importInScratchOrgs"]
+        "required": [
+          "dataPath",
+          "importInScratchOrgs"
+        ]
       },
       "title": "Data packages",
       "type": "array"
@@ -462,7 +580,11 @@
     "defaultPackageInstallationKey": {
       "$id": "#/properties/defaultPackageInstallationKey",
       "description": "When generating a new package version protected with password, use this value as default package installation key",
-      "examples": ["hardis", "myPassword", "dFGGF43656YfdFDG{{{dhgfh:::;FSEDSFd78"],
+      "examples": [
+        "hardis",
+        "myPassword",
+        "dFGGF43656YfdFDG{{{dhgfh:::;FSEDSFd78"
+      ],
       "title": "Defaut package installation key",
       "type": "string"
     },
@@ -470,7 +592,11 @@
       "$id": "#/properties/developmentBranch",
       "default": "developpement",
       "description": "When creating a new sfdx-hardis task, this git branch is used as base to create the feature/debug sub branch. The merge request will later have this branch as target.",
-      "examples": ["developpement", "dev_lot2", "hotfixes"],
+      "examples": [
+        "developpement",
+        "dev_lot2",
+        "hotfixes"
+      ],
       "title": "Default pull/merge request target org",
       "type": "string"
     },
@@ -524,38 +650,55 @@
             "properties": {
               "dataPath": {
                 "$id": "#/properties/install/properties/packages/items/dataPath",
-                "examples": ["scripts/data/EmailTemplate"],
+                "examples": [
+                  "scripts/data/EmailTemplate"
+                ],
                 "title": "Path to SFDMU data project to deploy",
                 "type": "string"
               },
               "label": {
                 "$id": "#/properties/install/properties/packages/items/label",
-                "examples": ["Deploy EmailTemplate", "Import EmailTemplate records"],
+                "examples": [
+                  "Deploy EmailTemplate",
+                  "Import EmailTemplate records"
+                ],
                 "title": "Source or data package label",
                 "type": "string"
               },
               "order": {
                 "$id": "#/properties/install/properties/packages/items/order",
-                "examples": [-20, 13, 50],
+                "examples": [
+                  -20,
+                  13,
+                  50
+                ],
                 "title": "Execution order in deployment plan",
                 "type": "number"
               },
               "packageXmlFile": {
                 "$id": "#/properties/install/properties/packages/items/packageXmlFile",
-                "examples": ["manifest/splits/packageXmlEmails.xml"],
+                "examples": [
+                  "manifest/splits/packageXmlEmails.xml"
+                ],
                 "title": "Path to package.xml file to use for deployment",
                 "type": "string"
               },
               "waitAfter": {
                 "$id": "#/properties/install/properties/packages/items/waitAfter",
                 "description": "Delay to wait before installing the next package",
-                "examples": [10, 20],
+                "examples": [
+                  10,
+                  20
+                ],
                 "title": "Wait after install (seconds)",
                 "type": "number"
               }
             }
           },
-          "required": ["label", "order"],
+          "required": [
+            "label",
+            "order"
+          ],
           "title": "List of packages to deploy",
           "type": "array"
         }
@@ -567,7 +710,11 @@
       "$id": "#/properties/devHubAlias",
       "default": "",
       "description": "Dev Hub alias, usually DevHub_ProjectName",
-      "examples": ["DevHub_MyClientMyProject", "DevHub_GoogleGmail", "DevHub_AppleIWatch"],
+      "examples": [
+        "DevHub_MyClientMyProject",
+        "DevHub_GoogleGmail",
+        "DevHub_AppleIWatch"
+      ],
       "title": "Dev Hub org alias",
       "type": "string"
     },
@@ -575,31 +722,51 @@
       "$id": "#/properties/devHubUsername",
       "default": "",
       "description": "Dev Hub username, used to authenticate to DevHub from CI jobs",
-      "examples": ["cicd-user@myclient.com", "scratch-user@google.fr", "scratch-user@apple.fr"],
+      "examples": [
+        "cicd-user@myclient.com",
+        "scratch-user@google.fr",
+        "scratch-user@apple.fr"
+      ],
       "title": "Dev Hub Username",
       "type": "string"
     },
     "extends": {
       "$id": "#/properties/extends",
       "description": "You can base your local sfdx-hardis configuration on a remote config file. That allows you to have the same config base for all your projects",
-      "examples": ["https://raw.githubusercontent.com/worldcompany/shared-config/main/.sfdx-hardis.yml"],
+      "examples": [
+        "https://raw.githubusercontent.com/worldcompany/shared-config/main/.sfdx-hardis.yml"
+      ],
       "title": "Extends remote configuration URL",
       "type": "string"
     },
     "initPermissionSets": {
       "$id": "#/properties/initPermissionSets",
       "description": "When creating a scratch org, Admin user will be automatically assigned to those permission sets",
-      "examples": [["MyPermissionSet", "MyPermissionSetGroup"]],
+      "examples": [
+        [
+          "MyPermissionSet",
+          "MyPermissionSetGroup"
+        ]
+      ],
       "items": {
         "$id": "#/properties/initPermissionSets/items",
-        "type": ["object", "string"],
+        "type": [
+          "object",
+          "string"
+        ],
         "additionalProperties": false,
         "description": "Permission Set or Permission Set Group",
         "properties": {
           "name": {
             "$Id": "#/properties/initPermissionSets/items/properties/name",
             "description": "Permission Set or Permission Set Group name",
-            "examples": [["MyPermissionSet", "MyPermissionSetGroup", "MyPermissionSetGroup2"]],
+            "examples": [
+              [
+                "MyPermissionSet",
+                "MyPermissionSetGroup",
+                "MyPermissionSetGroup2"
+              ]
+            ],
             "title": "Name",
             "type": "string"
           }
@@ -646,43 +813,60 @@
         "properties": {
           "Id": {
             "$Id": "#/properties/install/properties/packages/items/Id",
-            "examples": ["0A35r000000GveVCAS"],
+            "examples": [
+              "0A35r000000GveVCAS"
+            ],
             "title": "(unused) PackageId",
             "type": "string"
           },
           "SubscriberPackageId": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageId",
-            "examples": ["033b0000000Pf2AAAS"],
+            "examples": [
+              "033b0000000Pf2AAAS"
+            ],
             "title": "Subscriber Package Id",
             "type": "string"
           },
           "SubscriberPackageName": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageName",
-            "examples": ["Files Attachment Notes"],
+            "examples": [
+              "Files Attachment Notes"
+            ],
             "title": "Subscriber Package Name",
             "type": "string"
           },
           "SubscriberPackageNamespace": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageNamespace",
-            "examples": ["fan_astrea"],
+            "examples": [
+              "fan_astrea"
+            ],
             "title": "Subscriber Package NameSpace",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "SubscriberPackageVersionId": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionId",
-            "examples": ["04t0o000003nRWAAA2"],
+            "examples": [
+              "04t0o000003nRWAAA2"
+            ],
             "title": "Subscriber Version Id (IMPORTANT)",
             "type": "string"
           },
           "SubscriberPackageVersionName": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionName",
-            "examples": ["Summer2021"],
+            "examples": [
+              "Summer2021"
+            ],
             "title": "Subscriber Version Name",
             "type": "string"
           },
           "SubscriberPackageVersionNumber": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionNumber",
-            "examples": ["1.22.0.2"],
+            "examples": [
+              "1.22.0.2"
+            ],
             "title": "Subscriber Version Number",
             "type": "string"
           },
@@ -690,7 +874,10 @@
             "$Id": "#/properties/install/properties/packages/items/installDuringDeployments",
             "default": false,
             "description": "If true, during deployments this package will be installed in target org if not installed yet",
-            "examples": [true, false],
+            "examples": [
+              true,
+              false
+            ],
             "title": "Install during deployments",
             "type": "boolean"
           },
@@ -698,19 +885,27 @@
             "$Id": "#/properties/install/properties/packages/items/installOnScratchOrgs",
             "default": false,
             "description": "If true, this package will be installed when creating a new scratch org with sfdx-hardis",
-            "examples": [true, false],
+            "examples": [
+              true,
+              false
+            ],
             "title": "Install on scratch orgs",
             "type": "boolean"
           },
           "installationkey": {
             "$Id": "#/properties/install/properties/packages/items/installationkey",
-            "examples": ["MyInstallationKey", "4FzkMzUSwFfP#@"],
+            "examples": [
+              "MyInstallationKey",
+              "4FzkMzUSwFfP#@"
+            ],
             "description": "Installation key for key-protected package",
             "title": "Package installation key",
             "type": "string"
           }
         },
-        "required": ["SubscriberPackageVersionId"],
+        "required": [
+          "SubscriberPackageVersionId"
+        ],
         "title": "Salesforce package"
       },
       "title": "Installed Packages",
@@ -720,7 +915,9 @@
       "$id": "#/properties/installPackagesDuringCheckDeploy",
       "default": false,
       "description": "When calling deployment check command, installs any package referred within installedPackages property",
-      "examples": [true],
+      "examples": [
+        true
+      ],
       "title": "Install packages during deployment checks",
       "type": "boolean"
     },
@@ -728,7 +925,11 @@
       "$id": "#/properties/instanceUrl",
       "default": "",
       "description": "Salesforce instance URL used by CI for deployment or backups",
-      "examples": ["https://myclient.force.com", "https://google.force.com", "https://apple.force.com"],
+      "examples": [
+        "https://myclient.force.com",
+        "https://google.force.com",
+        "https://apple.force.com"
+      ],
       "title": "Instance URL",
       "type": "string"
     },
@@ -746,7 +947,13 @@
     "sourcesToRetrofit": {
       "$id": "#/properties/sourcesToRetrofit",
       "description": "List of metadata to retrieve for retrofit job",
-      "examples": [["CustomField", "Layout", "PermissionSet"]],
+      "examples": [
+        [
+          "CustomField",
+          "Layout",
+          "PermissionSet"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -803,7 +1010,10 @@
             "type": "string"
           }
         },
-        "required": ["title", "command"]
+        "required": [
+          "title",
+          "command"
+        ]
       },
       "title": "Monitoring commands",
       "type": "array"
@@ -818,7 +1028,12 @@
     "monitoringDisable": {
       "$id": "#/properties/monitoringDisable",
       "description": "List of commands to skip during monitoring jobs",
-      "examples": [["METADATA_STATUS", "UNUSED_METADATAS"]],
+      "examples": [
+        [
+          "METADATA_STATUS",
+          "UNUSED_METADATAS"
+        ]
+      ],
       "items": {
         "$ref": "#/definitions/enum_monitoring_commands"
       },
@@ -828,7 +1043,12 @@
     "monitoringExcludeUsernames": {
       "$id": "#/properties/monitoringExcludeUsernames",
       "description": "List of usernames to exclude while running monitoring commands",
-      "examples": [["deploymentuser@cloudity.com", "mc-cloud-user@cloudity.com"]],
+      "examples": [
+        [
+          "deploymentuser@cloudity.com",
+          "mc-cloud-user@cloudity.com"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -839,7 +1059,9 @@
       "$id": "#/properties/msTeamsWebhookUrl",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send ALL notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (ALL)",
       "type": "string"
     },
@@ -847,7 +1069,9 @@
       "$id": "#/properties/msTeamsWebhookUrlCritical",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send CRITICAL notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (CRITICAL)",
       "type": "string"
     },
@@ -855,7 +1079,9 @@
       "$id": "#/properties/msTeamsWebhookUrlSevere",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send SEVERE notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (SEVERE)",
       "type": "string"
     },
@@ -863,7 +1089,9 @@
       "$id": "#/properties/msTeamsWebhookUrlWarning",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send WARNING notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (WARNING)",
       "type": "string"
     },
@@ -871,14 +1099,21 @@
       "$id": "#/properties/msTeamsWebhookUrlWarning",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send INFO notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (INFO)",
       "type": "string"
     },
     "notificationsDisable": {
       "$id": "#/properties/notificationsDisable",
       "description": "List of notifications types to skip sending",
-      "examples": [["METADATA_STATUS", "UNUSED_METADATAS"]],
+      "examples": [
+        [
+          "METADATA_STATUS",
+          "UNUSED_METADATAS"
+        ]
+      ],
       "items": {
         "$ref": "#/definitions/enum_notification_types"
       },
@@ -928,7 +1163,11 @@
       "$id": "#/properties/productionBranch",
       "default": "",
       "description": "Name of the git branch corresponding to production environment",
-      "examples": ["master", "main", "production"],
+      "examples": [
+        "master",
+        "main",
+        "production"
+      ],
       "title": "Production branch name",
       "type": "string"
     },
@@ -936,7 +1175,11 @@
       "$id": "#/properties/projectName",
       "default": "",
       "description": "Identifier for the project (can be the client and project)",
-      "examples": ["MyClientMyProject", "GoogleGmail", "AppleIWatch"],
+      "examples": [
+        "MyClientMyProject",
+        "GoogleGmail",
+        "AppleIWatch"
+      ],
       "title": "Project Name",
       "type": "string"
     },
@@ -944,7 +1187,11 @@
       "$id": "#/properties/retrofitBranch",
       "default": "",
       "description": "Name of the git branch where retrofit merge requests targets to",
-      "examples": ["preprod", "dev", "maintenance"],
+      "examples": [
+        "preprod",
+        "dev",
+        "maintenance"
+      ],
       "title": "Retrofit branch name",
       "type": "string"
     },
@@ -966,7 +1213,12 @@
     "scratchOrgInitApexScripts": {
       "$id": "#/properties/scratchOrgInitApexScripts",
       "description": "Apex scripts to call after scratch org initialization",
-      "examples": [["scripts/apex/init-scratch.apex", "scripts/apex/init-custom-settings.apex"]],
+      "examples": [
+        [
+          "scripts/apex/init-scratch.apex",
+          "scripts/apex/init-custom-settings.apex"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -986,7 +1238,9 @@
       "$id": "#/properties/sfdmuCanModify",
       "default": "",
       "description": "Instance host name to allow SFDMU to deploy data in a production org",
-      "examples": ["myproject.force.com"],
+      "examples": [
+        "myproject.force.com"
+      ],
       "title": "SFDMU can modify",
       "type": "string"
     },
@@ -1008,7 +1262,11 @@
       "$id": "#/properties/targetUsername",
       "default": "",
       "description": "Salesforce username used by CI for deployment or backups",
-      "examples": ["deployments@myclient.com", "deployments@google.fr", "deployments@apple.com"],
+      "examples": [
+        "deployments@myclient.com",
+        "deployments@google.fr",
+        "deployments@apple.com"
+      ],
       "title": "Target Username",
       "type": "string"
     },
@@ -1023,7 +1281,12 @@
       "$id": "#/properties/linterIgnoreRightMetadataFile",
       "default": "",
       "description": "Ignore profiles or permission sets",
-      "examples": ["Profile", "Profile:ProfileA", "PermissionSet", "PermissionSet:PermissionSetA, Profile:ProfileA"],
+      "examples": [
+        "Profile",
+        "Profile:ProfileA",
+        "PermissionSet",
+        "PermissionSet:PermissionSetA, Profile:ProfileA"
+      ],
       "title": "Linter ignore permission set or/and profile",
       "type": "string"
     }

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -19,7 +19,15 @@
       "type": "string"
     },
     "enum_monitoring_commands": {
-      "enum": ["AUDIT_TRAIL", "LEGACY_API", "LINT_ACCESS", "UNUSED_METADATAS", "METADATA_STATUS", "MISSING_ATTRIBUTES", "UNUSED_LICENSES"],
+      "enum": [
+        "AUDIT_TRAIL",
+        "LEGACY_API",
+        "LINT_ACCESS",
+        "UNUSED_METADATAS",
+        "METADATA_STATUS",
+        "MISSING_ATTRIBUTES",
+        "UNUSED_LICENSES"
+      ],
       "type": "string"
     }
   },
@@ -28,10 +36,17 @@
     "allowedOrgTypes": {
       "$id": "#/properties/allowedOrgTypes",
       "description": "Types of orgs allowed for config & development. If not set, sandbox and scratch are allowed by default",
-      "examples": [["sandbox"]],
+      "examples": [
+        [
+          "sandbox"
+        ]
+      ],
       "items": {
         "type": "string",
-        "enum": ["sandbox", "scratch"]
+        "enum": [
+          "sandbox",
+          "scratch"
+        ]
       },
       "title": "Allowed org types",
       "type": "array"
@@ -39,7 +54,13 @@
     "autoCleanTypes": {
       "$id": "#/properties/autoCleanTypes",
       "description": "When saving a sfdx-hardis task, the list of cleanings will be automatically applied to sfdx sources",
-      "examples": [["dashboards", "datadotcom", "destructivechanges"]],
+      "examples": [
+        [
+          "dashboards",
+          "datadotcom",
+          "destructivechanges"
+        ]
+      ],
       "items": {
         "type": "string",
         "enum": [
@@ -62,7 +83,13 @@
     "autoRemoveUserPermissions": {
       "$id": "#/properties/autoRemoveUserPermissions",
       "description": "When saving a sfdx-hardis task, these permissions will be removed from profiles",
-      "examples": [["EnableCommunityAppLauncher", "FieldServiceAccess", "OmnichannelInventorySync"]],
+      "examples": [
+        [
+          "EnableCommunityAppLauncher",
+          "FieldServiceAccess",
+          "OmnichannelInventorySync"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -72,7 +99,15 @@
     "autoRetrieveWhenPull": {
       "$id": "#/properties/autoRetrieveWhenPull",
       "description": "When calling hardis:scratch:pull, if you define metadatas (named or not), they will also be retrieved using force:source:retrieve",
-      "examples": [["CustomApplication"], ["CustomApplication:MyApp1", "CustomApplication:MyApp2"]],
+      "examples": [
+        [
+          "CustomApplication"
+        ],
+        [
+          "CustomApplication:MyApp1",
+          "CustomApplication:MyApp2"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -83,14 +118,23 @@
       "$id": "#/properties/apexTestsMinCoverageOrgWide",
       "default": 75.0,
       "description": "Minimum percentage of apex code coverage accepted",
-      "examples": [80.0, 95.0],
+      "examples": [
+        80.0,
+        95.0
+      ],
       "title": "Minimum apex test coverage %",
       "type": "number"
     },
     "availableProjects": {
       "$id": "#/properties/availableProjects",
       "description": "List of business projects that are managed in the same repository. Will be used to build git branch name when using hardis:work:new",
-      "examples": [["sales_cloud", "service_cloud", "community"]],
+      "examples": [
+        [
+          "sales_cloud",
+          "service_cloud",
+          "community"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -100,7 +144,12 @@
     "availableTargetBranches": {
       "$id": "#/properties/availableTargetBranches",
       "description": "List of git branches that can be used as target for merge requests",
-      "examples": [["develop", "develop_next"]],
+      "examples": [
+        [
+          "develop",
+          "develop_next"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -145,11 +194,15 @@
         [
           {
             "globPattern": "/**/*.flexipage-meta.xml",
-            "xpaths": ["//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"]
+            "xpaths": [
+              "//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"
+            ]
           },
           {
             "globPattern": "/**/*.layout-meta.xml",
-            "xpaths": ["//ns:relatedLists//ns:relatedList[contains(text(),'RelatedSolutionList')]"]
+            "xpaths": [
+              "//ns:relatedLists//ns:relatedList[contains(text(),'RelatedSolutionList')]"
+            ]
           }
         ]
       ],
@@ -163,14 +216,20 @@
           "globPattern": {
             "$id": "#/properties/cleanXmlPatterns/items/properties/globPattern",
             "description": "Glob pattern to identify XML files to clean",
-            "examples": ["/**/*.flexipage-meta.xml"],
+            "examples": [
+              "/**/*.flexipage-meta.xml"
+            ],
             "title": "Glob pattern",
             "type": "string"
           },
           "xpaths": {
             "$id": "#/properties/cleanXmlPatterns/items/properties/xpaths",
             "description": "XPaths to identify elements to remove",
-            "examples": [["//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"]],
+            "examples": [
+              [
+                "//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"
+              ]
+            ],
             "title": "XPath list",
             "items": {
               "type": "string"
@@ -178,9 +237,80 @@
             "type": "array"
           }
         },
-        "required": ["globPattern", "xpaths"]
+        "required": [
+          "globPattern",
+          "xpaths"
+        ]
       },
       "title": "Clean XML Patterns",
+      "type": "array"
+    },
+    "commandsPreDeploy": {
+      "$id": "#/properties/commandsPreDeploy",
+      "description": "List of commands to run before a deployment",
+      "examples": [],
+      "items": {
+        "$id": "#/properties/commandsPreDeploy/items",
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Command definition",
+        "properties": {
+          "id": {
+            "$id": "#/properties/commandsPreDeploy/items/properties/id",
+            "description": "Identifier of the command (can be any string)",
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "$id": "#/properties/commandsPreDeploy/items/properties/label",
+            "description": "Label of the command (what does it do ?)",
+            "title": "Label",
+            "type": "string"
+          },
+          "command": {
+            "$id": "#/properties/commandsPreDeploy/items/properties/command",
+            "description": "Command line to run",
+            "title": "Command",
+            "type": "string"
+          }
+        },
+        "title": "Command"
+      },
+      "title": "Commands Pre-Deployment",
+      "type": "array"
+    },
+    "commandsPostDeploy": {
+      "$id": "#/properties/commandsPostDeploy",
+      "description": "List of commands to run after a deployment",
+      "examples": [],
+      "items": {
+        "$id": "#/properties/commandsPostDeploy/items",
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Command definition",
+        "properties": {
+          "id": {
+            "$id": "#/properties/commandsPostDeploy/items/properties/id",
+            "description": "Identifier of the command (can be any string)",
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "$id": "#/properties/commandsPostDeploy/items/properties/label",
+            "description": "Label of the command (what does it do ?)",
+            "title": "Label",
+            "type": "string"
+          },
+          "command": {
+            "$id": "#/properties/commandsPostDeploy/items/properties/command",
+            "description": "Command line to run",
+            "title": "Command",
+            "type": "string"
+          }
+        },
+        "title": "Command"
+      },
+      "title": "Commands Post-Deployment",
       "type": "array"
     },
     "customCommands": {
@@ -287,13 +417,20 @@
                   "type": "string"
                 }
               },
-              "required": ["id", "label", "command"]
+              "required": [
+                "id",
+                "label",
+                "command"
+              ]
             },
             "title": "Label",
             "type": "array"
           }
         },
-        "required": ["id", "label"]
+        "required": [
+          "id",
+          "label"
+        ]
       },
       "title": "Custom commands",
       "type": "array"
@@ -302,8 +439,14 @@
       "$id": "#/properties/customCommandsPosition",
       "description": "Position of custom commands in the menu (first or last)",
       "default": "first",
-      "enum": ["first", "last"],
-      "examples": ["first", "last"],
+      "enum": [
+        "first",
+        "last"
+      ],
+      "examples": [
+        "first",
+        "last"
+      ],
       "title": "Custom commands position",
       "type": "string"
     },
@@ -338,14 +481,20 @@
           "name": {
             "$Id": "#/properties/customPlugins/items/properties/name",
             "description": "Name of the plugin npm package",
-            "examples": ["mo-dx-plugin", "shane-sfdx-plugins"],
+            "examples": [
+              "mo-dx-plugin",
+              "shane-sfdx-plugins"
+            ],
             "title": "Name",
             "type": "string"
           },
           "helpUrl": {
             "$Id": "#/properties/customPlugins/items/properties/helpUrl",
             "description": "Url of plugin documentation",
-            "examples": ["https://github.com/msrivastav13/mo-dx-plugin", "https://github.com/mshanemc/shane-sfdx-plugins"],
+            "examples": [
+              "https://github.com/msrivastav13/mo-dx-plugin",
+              "https://github.com/mshanemc/shane-sfdx-plugins"
+            ],
             "title": "Name",
             "type": "string"
           }
@@ -377,7 +526,10 @@
             "type": "boolean"
           }
         },
-        "required": ["dataPath", "importInScratchOrgs"]
+        "required": [
+          "dataPath",
+          "importInScratchOrgs"
+        ]
       },
       "title": "Data packages",
       "type": "array"
@@ -385,7 +537,11 @@
     "defaultPackageInstallationKey": {
       "$id": "#/properties/defaultPackageInstallationKey",
       "description": "When generating a new package version protected with password, use this value as default package installation key",
-      "examples": ["hardis", "myPassword", "dFGGF43656YfdFDG{{{dhgfh:::;FSEDSFd78"],
+      "examples": [
+        "hardis",
+        "myPassword",
+        "dFGGF43656YfdFDG{{{dhgfh:::;FSEDSFd78"
+      ],
       "title": "Defaut package installation key",
       "type": "string"
     },
@@ -393,7 +549,11 @@
       "$id": "#/properties/developmentBranch",
       "default": "developpement",
       "description": "When creating a new sfdx-hardis task, this git branch is used as base to create the feature/debug sub branch. The merge request will later have this branch as target.",
-      "examples": ["developpement", "dev_lot2", "hotfixes"],
+      "examples": [
+        "developpement",
+        "dev_lot2",
+        "hotfixes"
+      ],
       "title": "Default pull/merge request target org",
       "type": "string"
     },
@@ -447,38 +607,55 @@
             "properties": {
               "dataPath": {
                 "$id": "#/properties/install/properties/packages/items/dataPath",
-                "examples": ["scripts/data/EmailTemplate"],
+                "examples": [
+                  "scripts/data/EmailTemplate"
+                ],
                 "title": "Path to SFDMU data project to deploy",
                 "type": "string"
               },
               "label": {
                 "$id": "#/properties/install/properties/packages/items/label",
-                "examples": ["Deploy EmailTemplate", "Import EmailTemplate records"],
+                "examples": [
+                  "Deploy EmailTemplate",
+                  "Import EmailTemplate records"
+                ],
                 "title": "Source or data package label",
                 "type": "string"
               },
               "order": {
                 "$id": "#/properties/install/properties/packages/items/order",
-                "examples": [-20, 13, 50],
+                "examples": [
+                  -20,
+                  13,
+                  50
+                ],
                 "title": "Execution order in deployment plan",
                 "type": "number"
               },
               "packageXmlFile": {
                 "$id": "#/properties/install/properties/packages/items/packageXmlFile",
-                "examples": ["manifest/splits/packageXmlEmails.xml"],
+                "examples": [
+                  "manifest/splits/packageXmlEmails.xml"
+                ],
                 "title": "Path to package.xml file to use for deployment",
                 "type": "string"
               },
               "waitAfter": {
                 "$id": "#/properties/install/properties/packages/items/waitAfter",
                 "description": "Delay to wait before installing the next package",
-                "examples": [10, 20],
+                "examples": [
+                  10,
+                  20
+                ],
                 "title": "Wait after install (seconds)",
                 "type": "number"
               }
             }
           },
-          "required": ["label", "order"],
+          "required": [
+            "label",
+            "order"
+          ],
           "title": "List of packages to deploy",
           "type": "array"
         }
@@ -490,7 +667,11 @@
       "$id": "#/properties/devHubAlias",
       "default": "",
       "description": "Dev Hub alias, usually DevHub_ProjectName",
-      "examples": ["DevHub_MyClientMyProject", "DevHub_GoogleGmail", "DevHub_AppleIWatch"],
+      "examples": [
+        "DevHub_MyClientMyProject",
+        "DevHub_GoogleGmail",
+        "DevHub_AppleIWatch"
+      ],
       "title": "Dev Hub org alias",
       "type": "string"
     },
@@ -498,31 +679,51 @@
       "$id": "#/properties/devHubUsername",
       "default": "",
       "description": "Dev Hub username, used to authenticate to DevHub from CI jobs",
-      "examples": ["cicd-user@myclient.com", "scratch-user@google.fr", "scratch-user@apple.fr"],
+      "examples": [
+        "cicd-user@myclient.com",
+        "scratch-user@google.fr",
+        "scratch-user@apple.fr"
+      ],
       "title": "Dev Hub Username",
       "type": "string"
     },
     "extends": {
       "$id": "#/properties/extends",
       "description": "You can base your local sfdx-hardis configuration on a remote config file. That allows you to have the same config base for all your projects",
-      "examples": ["https://raw.githubusercontent.com/worldcompany/shared-config/main/.sfdx-hardis.yml"],
+      "examples": [
+        "https://raw.githubusercontent.com/worldcompany/shared-config/main/.sfdx-hardis.yml"
+      ],
       "title": "Extends remote configuration URL",
       "type": "string"
     },
     "initPermissionSets": {
       "$id": "#/properties/initPermissionSets",
       "description": "When creating a scratch org, Admin user will be automatically assigned to those permission sets",
-      "examples": [["MyPermissionSet", "MyPermissionSetGroup"]],
+      "examples": [
+        [
+          "MyPermissionSet",
+          "MyPermissionSetGroup"
+        ]
+      ],
       "items": {
         "$id": "#/properties/initPermissionSets/items",
-        "type": ["object", "string"],
+        "type": [
+          "object",
+          "string"
+        ],
         "additionalProperties": false,
         "description": "Permission Set or Permission Set Group",
         "properties": {
           "name": {
             "$Id": "#/properties/initPermissionSets/items/properties/name",
             "description": "Permission Set or Permission Set Group name",
-            "examples": [["MyPermissionSet", "MyPermissionSetGroup", "MyPermissionSetGroup2"]],
+            "examples": [
+              [
+                "MyPermissionSet",
+                "MyPermissionSetGroup",
+                "MyPermissionSetGroup2"
+              ]
+            ],
             "title": "Name",
             "type": "string"
           }
@@ -569,43 +770,60 @@
         "properties": {
           "Id": {
             "$Id": "#/properties/install/properties/packages/items/Id",
-            "examples": ["0A35r000000GveVCAS"],
+            "examples": [
+              "0A35r000000GveVCAS"
+            ],
             "title": "(unused) PackageId",
             "type": "string"
           },
           "SubscriberPackageId": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageId",
-            "examples": ["033b0000000Pf2AAAS"],
+            "examples": [
+              "033b0000000Pf2AAAS"
+            ],
             "title": "Subscriber Package Id",
             "type": "string"
           },
           "SubscriberPackageName": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageName",
-            "examples": ["Files Attachment Notes"],
+            "examples": [
+              "Files Attachment Notes"
+            ],
             "title": "Subscriber Package Name",
             "type": "string"
           },
           "SubscriberPackageNamespace": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageNamespace",
-            "examples": ["fan_astrea"],
+            "examples": [
+              "fan_astrea"
+            ],
             "title": "Subscriber Package NameSpace",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "SubscriberPackageVersionId": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionId",
-            "examples": ["04t0o000003nRWAAA2"],
+            "examples": [
+              "04t0o000003nRWAAA2"
+            ],
             "title": "Subscriber Version Id (IMPORTANT)",
             "type": "string"
           },
           "SubscriberPackageVersionName": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionName",
-            "examples": ["Summer2021"],
+            "examples": [
+              "Summer2021"
+            ],
             "title": "Subscriber Version Name",
             "type": "string"
           },
           "SubscriberPackageVersionNumber": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionNumber",
-            "examples": ["1.22.0.2"],
+            "examples": [
+              "1.22.0.2"
+            ],
             "title": "Subscriber Version Number",
             "type": "string"
           },
@@ -613,7 +831,10 @@
             "$Id": "#/properties/install/properties/packages/items/installDuringDeployments",
             "default": false,
             "description": "If true, during deployments this package will be installed in target org if not installed yet",
-            "examples": [true, false],
+            "examples": [
+              true,
+              false
+            ],
             "title": "Install during deployments",
             "type": "boolean"
           },
@@ -621,19 +842,27 @@
             "$Id": "#/properties/install/properties/packages/items/installOnScratchOrgs",
             "default": false,
             "description": "If true, this package will be installed when creating a new scratch org with sfdx-hardis",
-            "examples": [true, false],
+            "examples": [
+              true,
+              false
+            ],
             "title": "Install on scratch orgs",
             "type": "boolean"
           },
           "installationkey": {
             "$Id": "#/properties/install/properties/packages/items/installationkey",
-            "examples": ["MyInstallationKey", "4FzkMzUSwFfP#@"],
+            "examples": [
+              "MyInstallationKey",
+              "4FzkMzUSwFfP#@"
+            ],
             "description": "Installation key for key-protected package",
             "title": "Package installation key",
             "type": "string"
           }
         },
-        "required": ["SubscriberPackageVersionId"],
+        "required": [
+          "SubscriberPackageVersionId"
+        ],
         "title": "Salesforce package"
       },
       "title": "Installed Packages",
@@ -643,7 +872,9 @@
       "$id": "#/properties/installPackagesDuringCheckDeploy",
       "default": false,
       "description": "When calling deployment check command, installs any package referred within installedPackages property",
-      "examples": [true],
+      "examples": [
+        true
+      ],
       "title": "Install packages during deployment checks",
       "type": "boolean"
     },
@@ -651,7 +882,11 @@
       "$id": "#/properties/instanceUrl",
       "default": "",
       "description": "Salesforce instance URL used by CI for deployment or backups",
-      "examples": ["https://myclient.force.com", "https://google.force.com", "https://apple.force.com"],
+      "examples": [
+        "https://myclient.force.com",
+        "https://google.force.com",
+        "https://apple.force.com"
+      ],
       "title": "Instance URL",
       "type": "string"
     },
@@ -669,7 +904,13 @@
     "sourcesToRetrofit": {
       "$id": "#/properties/sourcesToRetrofit",
       "description": "List of metadata to retrieve for retrofit job",
-      "examples": [["CustomField", "Layout", "PermissionSet"]],
+      "examples": [
+        [
+          "CustomField",
+          "Layout",
+          "PermissionSet"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -726,7 +967,10 @@
             "type": "string"
           }
         },
-        "required": ["title", "command"]
+        "required": [
+          "title",
+          "command"
+        ]
       },
       "title": "Monitoring commands",
       "type": "array"
@@ -741,7 +985,12 @@
     "monitoringDisable": {
       "$id": "#/properties/monitoringDisable",
       "description": "List of commands to skip during monitoring jobs",
-      "examples": [["METADATA_STATUS", "UNUSED_METADATAS"]],
+      "examples": [
+        [
+          "METADATA_STATUS",
+          "UNUSED_METADATAS"
+        ]
+      ],
       "items": {
         "$ref": "#/definitions/enum_monitoring_commands"
       },
@@ -751,7 +1000,12 @@
     "monitoringExcludeUsernames": {
       "$id": "#/properties/monitoringExcludeUsernames",
       "description": "List of usernames to exclude while running monitoring commands",
-      "examples": [["deploymentuser@cloudity.com", "mc-cloud-user@cloudity.com"]],
+      "examples": [
+        [
+          "deploymentuser@cloudity.com",
+          "mc-cloud-user@cloudity.com"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -762,7 +1016,9 @@
       "$id": "#/properties/msTeamsWebhookUrl",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send ALL notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (ALL)",
       "type": "string"
     },
@@ -770,7 +1026,9 @@
       "$id": "#/properties/msTeamsWebhookUrlCritical",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send CRITICAL notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (CRITICAL)",
       "type": "string"
     },
@@ -778,7 +1036,9 @@
       "$id": "#/properties/msTeamsWebhookUrlSevere",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send SEVERE notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (SEVERE)",
       "type": "string"
     },
@@ -786,7 +1046,9 @@
       "$id": "#/properties/msTeamsWebhookUrlWarning",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send WARNING notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (WARNING)",
       "type": "string"
     },
@@ -794,14 +1056,21 @@
       "$id": "#/properties/msTeamsWebhookUrlWarning",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send INFO notifications",
-      "examples": ["https://my.msteams.webhook.url"],
+      "examples": [
+        "https://my.msteams.webhook.url"
+      ],
       "title": "MsTeams WebHook Url (INFO)",
       "type": "string"
     },
     "notificationsDisable": {
       "$id": "#/properties/notificationsDisable",
       "description": "List of notifications types to skip sending",
-      "examples": [["METADATA_STATUS", "UNUSED_METADATAS"]],
+      "examples": [
+        [
+          "METADATA_STATUS",
+          "UNUSED_METADATAS"
+        ]
+      ],
       "items": {
         "$ref": "#/definitions/enum_notification_types"
       },
@@ -851,7 +1120,11 @@
       "$id": "#/properties/productionBranch",
       "default": "",
       "description": "Name of the git branch corresponding to production environment",
-      "examples": ["master", "main", "production"],
+      "examples": [
+        "master",
+        "main",
+        "production"
+      ],
       "title": "Production branch name",
       "type": "string"
     },
@@ -859,7 +1132,11 @@
       "$id": "#/properties/projectName",
       "default": "",
       "description": "Identifier for the project (can be the client and project)",
-      "examples": ["MyClientMyProject", "GoogleGmail", "AppleIWatch"],
+      "examples": [
+        "MyClientMyProject",
+        "GoogleGmail",
+        "AppleIWatch"
+      ],
       "title": "Project Name",
       "type": "string"
     },
@@ -867,7 +1144,11 @@
       "$id": "#/properties/retrofitBranch",
       "default": "",
       "description": "Name of the git branch where retrofit merge requests targets to",
-      "examples": ["preprod", "dev", "maintenance"],
+      "examples": [
+        "preprod",
+        "dev",
+        "maintenance"
+      ],
       "title": "Retrofit branch name",
       "type": "string"
     },
@@ -889,7 +1170,12 @@
     "scratchOrgInitApexScripts": {
       "$id": "#/properties/scratchOrgInitApexScripts",
       "description": "Apex scripts to call after scratch org initialization",
-      "examples": [["scripts/apex/init-scratch.apex", "scripts/apex/init-custom-settings.apex"]],
+      "examples": [
+        [
+          "scripts/apex/init-scratch.apex",
+          "scripts/apex/init-custom-settings.apex"
+        ]
+      ],
       "items": {
         "type": "string"
       },
@@ -909,7 +1195,9 @@
       "$id": "#/properties/sfdmuCanModify",
       "default": "",
       "description": "Instance host name to allow SFDMU to deploy data in a production org",
-      "examples": ["myproject.force.com"],
+      "examples": [
+        "myproject.force.com"
+      ],
       "title": "SFDMU can modify",
       "type": "string"
     },
@@ -931,7 +1219,11 @@
       "$id": "#/properties/targetUsername",
       "default": "",
       "description": "Salesforce username used by CI for deployment or backups",
-      "examples": ["deployments@myclient.com", "deployments@google.fr", "deployments@apple.com"],
+      "examples": [
+        "deployments@myclient.com",
+        "deployments@google.fr",
+        "deployments@apple.com"
+      ],
       "title": "Target Username",
       "type": "string"
     },
@@ -946,7 +1238,12 @@
       "$id": "#/properties/linterIgnoreRightMetadataFile",
       "default": "",
       "description": "Ignore profiles or permission sets",
-      "examples": ["Profile", "Profile:ProfileA", "PermissionSet", "PermissionSet:PermissionSetA, Profile:ProfileA"],
+      "examples": [
+        "Profile",
+        "Profile:ProfileA",
+        "PermissionSet",
+        "PermissionSet:PermissionSetA, Profile:ProfileA"
+      ],
       "title": "Linter ignore permission set or/and profile",
       "type": "string"
     }

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -19,15 +19,7 @@
       "type": "string"
     },
     "enum_monitoring_commands": {
-      "enum": [
-        "AUDIT_TRAIL",
-        "LEGACY_API",
-        "LINT_ACCESS",
-        "UNUSED_METADATAS",
-        "METADATA_STATUS",
-        "MISSING_ATTRIBUTES",
-        "UNUSED_LICENSES"
-      ],
+      "enum": ["AUDIT_TRAIL", "LEGACY_API", "LINT_ACCESS", "UNUSED_METADATAS", "METADATA_STATUS", "MISSING_ATTRIBUTES", "UNUSED_LICENSES"],
       "type": "string"
     }
   },
@@ -36,17 +28,10 @@
     "allowedOrgTypes": {
       "$id": "#/properties/allowedOrgTypes",
       "description": "Types of orgs allowed for config & development. If not set, sandbox and scratch are allowed by default",
-      "examples": [
-        [
-          "sandbox"
-        ]
-      ],
+      "examples": [["sandbox"]],
       "items": {
         "type": "string",
-        "enum": [
-          "sandbox",
-          "scratch"
-        ]
+        "enum": ["sandbox", "scratch"]
       },
       "title": "Allowed org types",
       "type": "array"
@@ -54,13 +39,7 @@
     "autoCleanTypes": {
       "$id": "#/properties/autoCleanTypes",
       "description": "When saving a sfdx-hardis task, the list of cleanings will be automatically applied to sfdx sources",
-      "examples": [
-        [
-          "dashboards",
-          "datadotcom",
-          "destructivechanges"
-        ]
-      ],
+      "examples": [["dashboards", "datadotcom", "destructivechanges"]],
       "items": {
         "type": "string",
         "enum": [
@@ -83,13 +62,7 @@
     "autoRemoveUserPermissions": {
       "$id": "#/properties/autoRemoveUserPermissions",
       "description": "When saving a sfdx-hardis task, these permissions will be removed from profiles",
-      "examples": [
-        [
-          "EnableCommunityAppLauncher",
-          "FieldServiceAccess",
-          "OmnichannelInventorySync"
-        ]
-      ],
+      "examples": [["EnableCommunityAppLauncher", "FieldServiceAccess", "OmnichannelInventorySync"]],
       "items": {
         "type": "string"
       },
@@ -99,15 +72,7 @@
     "autoRetrieveWhenPull": {
       "$id": "#/properties/autoRetrieveWhenPull",
       "description": "When calling hardis:scratch:pull, if you define metadatas (named or not), they will also be retrieved using force:source:retrieve",
-      "examples": [
-        [
-          "CustomApplication"
-        ],
-        [
-          "CustomApplication:MyApp1",
-          "CustomApplication:MyApp2"
-        ]
-      ],
+      "examples": [["CustomApplication"], ["CustomApplication:MyApp1", "CustomApplication:MyApp2"]],
       "items": {
         "type": "string"
       },
@@ -118,23 +83,14 @@
       "$id": "#/properties/apexTestsMinCoverageOrgWide",
       "default": 75.0,
       "description": "Minimum percentage of apex code coverage accepted",
-      "examples": [
-        80.0,
-        95.0
-      ],
+      "examples": [80.0, 95.0],
       "title": "Minimum apex test coverage %",
       "type": "number"
     },
     "availableProjects": {
       "$id": "#/properties/availableProjects",
       "description": "List of business projects that are managed in the same repository. Will be used to build git branch name when using hardis:work:new",
-      "examples": [
-        [
-          "sales_cloud",
-          "service_cloud",
-          "community"
-        ]
-      ],
+      "examples": [["sales_cloud", "service_cloud", "community"]],
       "items": {
         "type": "string"
       },
@@ -144,12 +100,7 @@
     "availableTargetBranches": {
       "$id": "#/properties/availableTargetBranches",
       "description": "List of git branches that can be used as target for merge requests",
-      "examples": [
-        [
-          "develop",
-          "develop_next"
-        ]
-      ],
+      "examples": [["develop", "develop_next"]],
       "items": {
         "type": "string"
       },
@@ -194,15 +145,11 @@
         [
           {
             "globPattern": "/**/*.flexipage-meta.xml",
-            "xpaths": [
-              "//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"
-            ]
+            "xpaths": ["//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"]
           },
           {
             "globPattern": "/**/*.layout-meta.xml",
-            "xpaths": [
-              "//ns:relatedLists//ns:relatedList[contains(text(),'RelatedSolutionList')]"
-            ]
+            "xpaths": ["//ns:relatedLists//ns:relatedList[contains(text(),'RelatedSolutionList')]"]
           }
         ]
       ],
@@ -216,20 +163,14 @@
           "globPattern": {
             "$id": "#/properties/cleanXmlPatterns/items/properties/globPattern",
             "description": "Glob pattern to identify XML files to clean",
-            "examples": [
-              "/**/*.flexipage-meta.xml"
-            ],
+            "examples": ["/**/*.flexipage-meta.xml"],
             "title": "Glob pattern",
             "type": "string"
           },
           "xpaths": {
             "$id": "#/properties/cleanXmlPatterns/items/properties/xpaths",
             "description": "XPaths to identify elements to remove",
-            "examples": [
-              [
-                "//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"
-              ]
-            ],
+            "examples": [["//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"]],
             "title": "XPath list",
             "items": {
               "type": "string"
@@ -237,10 +178,7 @@
             "type": "array"
           }
         },
-        "required": [
-          "globPattern",
-          "xpaths"
-        ]
+        "required": ["globPattern", "xpaths"]
       },
       "title": "Clean XML Patterns",
       "type": "array"
@@ -289,11 +227,7 @@
         },
         "title": "Command"
       },
-      "required": [
-        "id",
-        "label",
-        "command"
-      ],
+      "required": ["id", "label", "command"],
       "title": "Commands Pre-Deployment",
       "type": "array"
     },
@@ -346,11 +280,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "id",
-          "label",
-          "command"
-        ],
+        "required": ["id", "label", "command"],
         "title": "Command"
       },
       "title": "Commands Post-Deployment",
@@ -460,20 +390,13 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "id",
-                "label",
-                "command"
-              ]
+              "required": ["id", "label", "command"]
             },
             "title": "Label",
             "type": "array"
           }
         },
-        "required": [
-          "id",
-          "label"
-        ]
+        "required": ["id", "label"]
       },
       "title": "Custom commands",
       "type": "array"
@@ -482,14 +405,8 @@
       "$id": "#/properties/customCommandsPosition",
       "description": "Position of custom commands in the menu (first or last)",
       "default": "first",
-      "enum": [
-        "first",
-        "last"
-      ],
-      "examples": [
-        "first",
-        "last"
-      ],
+      "enum": ["first", "last"],
+      "examples": ["first", "last"],
       "title": "Custom commands position",
       "type": "string"
     },
@@ -524,20 +441,14 @@
           "name": {
             "$Id": "#/properties/customPlugins/items/properties/name",
             "description": "Name of the plugin npm package",
-            "examples": [
-              "mo-dx-plugin",
-              "shane-sfdx-plugins"
-            ],
+            "examples": ["mo-dx-plugin", "shane-sfdx-plugins"],
             "title": "Name",
             "type": "string"
           },
           "helpUrl": {
             "$Id": "#/properties/customPlugins/items/properties/helpUrl",
             "description": "Url of plugin documentation",
-            "examples": [
-              "https://github.com/msrivastav13/mo-dx-plugin",
-              "https://github.com/mshanemc/shane-sfdx-plugins"
-            ],
+            "examples": ["https://github.com/msrivastav13/mo-dx-plugin", "https://github.com/mshanemc/shane-sfdx-plugins"],
             "title": "Name",
             "type": "string"
           }
@@ -569,10 +480,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "dataPath",
-          "importInScratchOrgs"
-        ]
+        "required": ["dataPath", "importInScratchOrgs"]
       },
       "title": "Data packages",
       "type": "array"
@@ -580,11 +488,7 @@
     "defaultPackageInstallationKey": {
       "$id": "#/properties/defaultPackageInstallationKey",
       "description": "When generating a new package version protected with password, use this value as default package installation key",
-      "examples": [
-        "hardis",
-        "myPassword",
-        "dFGGF43656YfdFDG{{{dhgfh:::;FSEDSFd78"
-      ],
+      "examples": ["hardis", "myPassword", "dFGGF43656YfdFDG{{{dhgfh:::;FSEDSFd78"],
       "title": "Defaut package installation key",
       "type": "string"
     },
@@ -592,11 +496,7 @@
       "$id": "#/properties/developmentBranch",
       "default": "developpement",
       "description": "When creating a new sfdx-hardis task, this git branch is used as base to create the feature/debug sub branch. The merge request will later have this branch as target.",
-      "examples": [
-        "developpement",
-        "dev_lot2",
-        "hotfixes"
-      ],
+      "examples": ["developpement", "dev_lot2", "hotfixes"],
       "title": "Default pull/merge request target org",
       "type": "string"
     },
@@ -650,55 +550,38 @@
             "properties": {
               "dataPath": {
                 "$id": "#/properties/install/properties/packages/items/dataPath",
-                "examples": [
-                  "scripts/data/EmailTemplate"
-                ],
+                "examples": ["scripts/data/EmailTemplate"],
                 "title": "Path to SFDMU data project to deploy",
                 "type": "string"
               },
               "label": {
                 "$id": "#/properties/install/properties/packages/items/label",
-                "examples": [
-                  "Deploy EmailTemplate",
-                  "Import EmailTemplate records"
-                ],
+                "examples": ["Deploy EmailTemplate", "Import EmailTemplate records"],
                 "title": "Source or data package label",
                 "type": "string"
               },
               "order": {
                 "$id": "#/properties/install/properties/packages/items/order",
-                "examples": [
-                  -20,
-                  13,
-                  50
-                ],
+                "examples": [-20, 13, 50],
                 "title": "Execution order in deployment plan",
                 "type": "number"
               },
               "packageXmlFile": {
                 "$id": "#/properties/install/properties/packages/items/packageXmlFile",
-                "examples": [
-                  "manifest/splits/packageXmlEmails.xml"
-                ],
+                "examples": ["manifest/splits/packageXmlEmails.xml"],
                 "title": "Path to package.xml file to use for deployment",
                 "type": "string"
               },
               "waitAfter": {
                 "$id": "#/properties/install/properties/packages/items/waitAfter",
                 "description": "Delay to wait before installing the next package",
-                "examples": [
-                  10,
-                  20
-                ],
+                "examples": [10, 20],
                 "title": "Wait after install (seconds)",
                 "type": "number"
               }
             }
           },
-          "required": [
-            "label",
-            "order"
-          ],
+          "required": ["label", "order"],
           "title": "List of packages to deploy",
           "type": "array"
         }
@@ -710,11 +593,7 @@
       "$id": "#/properties/devHubAlias",
       "default": "",
       "description": "Dev Hub alias, usually DevHub_ProjectName",
-      "examples": [
-        "DevHub_MyClientMyProject",
-        "DevHub_GoogleGmail",
-        "DevHub_AppleIWatch"
-      ],
+      "examples": ["DevHub_MyClientMyProject", "DevHub_GoogleGmail", "DevHub_AppleIWatch"],
       "title": "Dev Hub org alias",
       "type": "string"
     },
@@ -722,51 +601,31 @@
       "$id": "#/properties/devHubUsername",
       "default": "",
       "description": "Dev Hub username, used to authenticate to DevHub from CI jobs",
-      "examples": [
-        "cicd-user@myclient.com",
-        "scratch-user@google.fr",
-        "scratch-user@apple.fr"
-      ],
+      "examples": ["cicd-user@myclient.com", "scratch-user@google.fr", "scratch-user@apple.fr"],
       "title": "Dev Hub Username",
       "type": "string"
     },
     "extends": {
       "$id": "#/properties/extends",
       "description": "You can base your local sfdx-hardis configuration on a remote config file. That allows you to have the same config base for all your projects",
-      "examples": [
-        "https://raw.githubusercontent.com/worldcompany/shared-config/main/.sfdx-hardis.yml"
-      ],
+      "examples": ["https://raw.githubusercontent.com/worldcompany/shared-config/main/.sfdx-hardis.yml"],
       "title": "Extends remote configuration URL",
       "type": "string"
     },
     "initPermissionSets": {
       "$id": "#/properties/initPermissionSets",
       "description": "When creating a scratch org, Admin user will be automatically assigned to those permission sets",
-      "examples": [
-        [
-          "MyPermissionSet",
-          "MyPermissionSetGroup"
-        ]
-      ],
+      "examples": [["MyPermissionSet", "MyPermissionSetGroup"]],
       "items": {
         "$id": "#/properties/initPermissionSets/items",
-        "type": [
-          "object",
-          "string"
-        ],
+        "type": ["object", "string"],
         "additionalProperties": false,
         "description": "Permission Set or Permission Set Group",
         "properties": {
           "name": {
             "$Id": "#/properties/initPermissionSets/items/properties/name",
             "description": "Permission Set or Permission Set Group name",
-            "examples": [
-              [
-                "MyPermissionSet",
-                "MyPermissionSetGroup",
-                "MyPermissionSetGroup2"
-              ]
-            ],
+            "examples": [["MyPermissionSet", "MyPermissionSetGroup", "MyPermissionSetGroup2"]],
             "title": "Name",
             "type": "string"
           }
@@ -813,60 +672,43 @@
         "properties": {
           "Id": {
             "$Id": "#/properties/install/properties/packages/items/Id",
-            "examples": [
-              "0A35r000000GveVCAS"
-            ],
+            "examples": ["0A35r000000GveVCAS"],
             "title": "(unused) PackageId",
             "type": "string"
           },
           "SubscriberPackageId": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageId",
-            "examples": [
-              "033b0000000Pf2AAAS"
-            ],
+            "examples": ["033b0000000Pf2AAAS"],
             "title": "Subscriber Package Id",
             "type": "string"
           },
           "SubscriberPackageName": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageName",
-            "examples": [
-              "Files Attachment Notes"
-            ],
+            "examples": ["Files Attachment Notes"],
             "title": "Subscriber Package Name",
             "type": "string"
           },
           "SubscriberPackageNamespace": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageNamespace",
-            "examples": [
-              "fan_astrea"
-            ],
+            "examples": ["fan_astrea"],
             "title": "Subscriber Package NameSpace",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "SubscriberPackageVersionId": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionId",
-            "examples": [
-              "04t0o000003nRWAAA2"
-            ],
+            "examples": ["04t0o000003nRWAAA2"],
             "title": "Subscriber Version Id (IMPORTANT)",
             "type": "string"
           },
           "SubscriberPackageVersionName": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionName",
-            "examples": [
-              "Summer2021"
-            ],
+            "examples": ["Summer2021"],
             "title": "Subscriber Version Name",
             "type": "string"
           },
           "SubscriberPackageVersionNumber": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionNumber",
-            "examples": [
-              "1.22.0.2"
-            ],
+            "examples": ["1.22.0.2"],
             "title": "Subscriber Version Number",
             "type": "string"
           },
@@ -874,10 +716,7 @@
             "$Id": "#/properties/install/properties/packages/items/installDuringDeployments",
             "default": false,
             "description": "If true, during deployments this package will be installed in target org if not installed yet",
-            "examples": [
-              true,
-              false
-            ],
+            "examples": [true, false],
             "title": "Install during deployments",
             "type": "boolean"
           },
@@ -885,27 +724,19 @@
             "$Id": "#/properties/install/properties/packages/items/installOnScratchOrgs",
             "default": false,
             "description": "If true, this package will be installed when creating a new scratch org with sfdx-hardis",
-            "examples": [
-              true,
-              false
-            ],
+            "examples": [true, false],
             "title": "Install on scratch orgs",
             "type": "boolean"
           },
           "installationkey": {
             "$Id": "#/properties/install/properties/packages/items/installationkey",
-            "examples": [
-              "MyInstallationKey",
-              "4FzkMzUSwFfP#@"
-            ],
+            "examples": ["MyInstallationKey", "4FzkMzUSwFfP#@"],
             "description": "Installation key for key-protected package",
             "title": "Package installation key",
             "type": "string"
           }
         },
-        "required": [
-          "SubscriberPackageVersionId"
-        ],
+        "required": ["SubscriberPackageVersionId"],
         "title": "Salesforce package"
       },
       "title": "Installed Packages",
@@ -915,9 +746,7 @@
       "$id": "#/properties/installPackagesDuringCheckDeploy",
       "default": false,
       "description": "When calling deployment check command, installs any package referred within installedPackages property",
-      "examples": [
-        true
-      ],
+      "examples": [true],
       "title": "Install packages during deployment checks",
       "type": "boolean"
     },
@@ -925,11 +754,7 @@
       "$id": "#/properties/instanceUrl",
       "default": "",
       "description": "Salesforce instance URL used by CI for deployment or backups",
-      "examples": [
-        "https://myclient.force.com",
-        "https://google.force.com",
-        "https://apple.force.com"
-      ],
+      "examples": ["https://myclient.force.com", "https://google.force.com", "https://apple.force.com"],
       "title": "Instance URL",
       "type": "string"
     },
@@ -947,13 +772,7 @@
     "sourcesToRetrofit": {
       "$id": "#/properties/sourcesToRetrofit",
       "description": "List of metadata to retrieve for retrofit job",
-      "examples": [
-        [
-          "CustomField",
-          "Layout",
-          "PermissionSet"
-        ]
-      ],
+      "examples": [["CustomField", "Layout", "PermissionSet"]],
       "items": {
         "type": "string"
       },
@@ -1010,10 +829,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "title",
-          "command"
-        ]
+        "required": ["title", "command"]
       },
       "title": "Monitoring commands",
       "type": "array"
@@ -1028,12 +844,7 @@
     "monitoringDisable": {
       "$id": "#/properties/monitoringDisable",
       "description": "List of commands to skip during monitoring jobs",
-      "examples": [
-        [
-          "METADATA_STATUS",
-          "UNUSED_METADATAS"
-        ]
-      ],
+      "examples": [["METADATA_STATUS", "UNUSED_METADATAS"]],
       "items": {
         "$ref": "#/definitions/enum_monitoring_commands"
       },
@@ -1043,12 +854,7 @@
     "monitoringExcludeUsernames": {
       "$id": "#/properties/monitoringExcludeUsernames",
       "description": "List of usernames to exclude while running monitoring commands",
-      "examples": [
-        [
-          "deploymentuser@cloudity.com",
-          "mc-cloud-user@cloudity.com"
-        ]
-      ],
+      "examples": [["deploymentuser@cloudity.com", "mc-cloud-user@cloudity.com"]],
       "items": {
         "type": "string"
       },
@@ -1059,9 +865,7 @@
       "$id": "#/properties/msTeamsWebhookUrl",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send ALL notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (ALL)",
       "type": "string"
     },
@@ -1069,9 +873,7 @@
       "$id": "#/properties/msTeamsWebhookUrlCritical",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send CRITICAL notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (CRITICAL)",
       "type": "string"
     },
@@ -1079,9 +881,7 @@
       "$id": "#/properties/msTeamsWebhookUrlSevere",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send SEVERE notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (SEVERE)",
       "type": "string"
     },
@@ -1089,9 +889,7 @@
       "$id": "#/properties/msTeamsWebhookUrlWarning",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send WARNING notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (WARNING)",
       "type": "string"
     },
@@ -1099,21 +897,14 @@
       "$id": "#/properties/msTeamsWebhookUrlWarning",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send INFO notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (INFO)",
       "type": "string"
     },
     "notificationsDisable": {
       "$id": "#/properties/notificationsDisable",
       "description": "List of notifications types to skip sending",
-      "examples": [
-        [
-          "METADATA_STATUS",
-          "UNUSED_METADATAS"
-        ]
-      ],
+      "examples": [["METADATA_STATUS", "UNUSED_METADATAS"]],
       "items": {
         "$ref": "#/definitions/enum_notification_types"
       },
@@ -1163,11 +954,7 @@
       "$id": "#/properties/productionBranch",
       "default": "",
       "description": "Name of the git branch corresponding to production environment",
-      "examples": [
-        "master",
-        "main",
-        "production"
-      ],
+      "examples": ["master", "main", "production"],
       "title": "Production branch name",
       "type": "string"
     },
@@ -1175,11 +962,7 @@
       "$id": "#/properties/projectName",
       "default": "",
       "description": "Identifier for the project (can be the client and project)",
-      "examples": [
-        "MyClientMyProject",
-        "GoogleGmail",
-        "AppleIWatch"
-      ],
+      "examples": ["MyClientMyProject", "GoogleGmail", "AppleIWatch"],
       "title": "Project Name",
       "type": "string"
     },
@@ -1187,11 +970,7 @@
       "$id": "#/properties/retrofitBranch",
       "default": "",
       "description": "Name of the git branch where retrofit merge requests targets to",
-      "examples": [
-        "preprod",
-        "dev",
-        "maintenance"
-      ],
+      "examples": ["preprod", "dev", "maintenance"],
       "title": "Retrofit branch name",
       "type": "string"
     },
@@ -1213,12 +992,7 @@
     "scratchOrgInitApexScripts": {
       "$id": "#/properties/scratchOrgInitApexScripts",
       "description": "Apex scripts to call after scratch org initialization",
-      "examples": [
-        [
-          "scripts/apex/init-scratch.apex",
-          "scripts/apex/init-custom-settings.apex"
-        ]
-      ],
+      "examples": [["scripts/apex/init-scratch.apex", "scripts/apex/init-custom-settings.apex"]],
       "items": {
         "type": "string"
       },
@@ -1238,9 +1012,7 @@
       "$id": "#/properties/sfdmuCanModify",
       "default": "",
       "description": "Instance host name to allow SFDMU to deploy data in a production org",
-      "examples": [
-        "myproject.force.com"
-      ],
+      "examples": ["myproject.force.com"],
       "title": "SFDMU can modify",
       "type": "string"
     },
@@ -1262,11 +1034,7 @@
       "$id": "#/properties/targetUsername",
       "default": "",
       "description": "Salesforce username used by CI for deployment or backups",
-      "examples": [
-        "deployments@myclient.com",
-        "deployments@google.fr",
-        "deployments@apple.com"
-      ],
+      "examples": ["deployments@myclient.com", "deployments@google.fr", "deployments@apple.com"],
       "title": "Target Username",
       "type": "string"
     },
@@ -1281,12 +1049,7 @@
       "$id": "#/properties/linterIgnoreRightMetadataFile",
       "default": "",
       "description": "Ignore profiles or permission sets",
-      "examples": [
-        "Profile",
-        "Profile:ProfileA",
-        "PermissionSet",
-        "PermissionSet:PermissionSetA, Profile:ProfileA"
-      ],
+      "examples": ["Profile", "Profile:ProfileA", "PermissionSet", "PermissionSet:PermissionSetA, Profile:ProfileA"],
       "title": "Linter ignore permission set or/and profile",
       "type": "string"
     }

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -252,7 +252,7 @@
         [
           {
             "id": "knowledgeUnassign",
-            "label": "Remove KnownledgeUser right to the user who has it",
+            "label": "Remove KnowledgeUser right to the user who has it",
             "command": "sf data update record --sobject User --where \"UserPermissionsKnowledgeUser='true'\" --values \"UserPermissionsKnowledgeUser='false'\" --json"
           },
           {
@@ -304,7 +304,7 @@
         [
           {
             "id": "knowledgeUnassign",
-            "label": "Remove KnownledgeUser right to the user who has it",
+            "label": "Remove KnowledgeUser right to the user who has it",
             "command": "sf data update record --sobject User --where \"UserPermissionsKnowledgeUser='true'\" --values \"UserPermissionsKnowledgeUser='false'\" --json"
           },
           {

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -19,15 +19,7 @@
       "type": "string"
     },
     "enum_monitoring_commands": {
-      "enum": [
-        "AUDIT_TRAIL",
-        "LEGACY_API",
-        "LINT_ACCESS",
-        "UNUSED_METADATAS",
-        "METADATA_STATUS",
-        "MISSING_ATTRIBUTES",
-        "UNUSED_LICENSES"
-      ],
+      "enum": ["AUDIT_TRAIL", "LEGACY_API", "LINT_ACCESS", "UNUSED_METADATAS", "METADATA_STATUS", "MISSING_ATTRIBUTES", "UNUSED_LICENSES"],
       "type": "string"
     }
   },
@@ -36,17 +28,10 @@
     "allowedOrgTypes": {
       "$id": "#/properties/allowedOrgTypes",
       "description": "Types of orgs allowed for config & development. If not set, sandbox and scratch are allowed by default",
-      "examples": [
-        [
-          "sandbox"
-        ]
-      ],
+      "examples": [["sandbox"]],
       "items": {
         "type": "string",
-        "enum": [
-          "sandbox",
-          "scratch"
-        ]
+        "enum": ["sandbox", "scratch"]
       },
       "title": "Allowed org types",
       "type": "array"
@@ -54,13 +39,7 @@
     "autoCleanTypes": {
       "$id": "#/properties/autoCleanTypes",
       "description": "When saving a sfdx-hardis task, the list of cleanings will be automatically applied to sfdx sources",
-      "examples": [
-        [
-          "dashboards",
-          "datadotcom",
-          "destructivechanges"
-        ]
-      ],
+      "examples": [["dashboards", "datadotcom", "destructivechanges"]],
       "items": {
         "type": "string",
         "enum": [
@@ -83,13 +62,7 @@
     "autoRemoveUserPermissions": {
       "$id": "#/properties/autoRemoveUserPermissions",
       "description": "When saving a sfdx-hardis task, these permissions will be removed from profiles",
-      "examples": [
-        [
-          "EnableCommunityAppLauncher",
-          "FieldServiceAccess",
-          "OmnichannelInventorySync"
-        ]
-      ],
+      "examples": [["EnableCommunityAppLauncher", "FieldServiceAccess", "OmnichannelInventorySync"]],
       "items": {
         "type": "string"
       },
@@ -99,15 +72,7 @@
     "autoRetrieveWhenPull": {
       "$id": "#/properties/autoRetrieveWhenPull",
       "description": "When calling hardis:scratch:pull, if you define metadatas (named or not), they will also be retrieved using force:source:retrieve",
-      "examples": [
-        [
-          "CustomApplication"
-        ],
-        [
-          "CustomApplication:MyApp1",
-          "CustomApplication:MyApp2"
-        ]
-      ],
+      "examples": [["CustomApplication"], ["CustomApplication:MyApp1", "CustomApplication:MyApp2"]],
       "items": {
         "type": "string"
       },
@@ -118,23 +83,14 @@
       "$id": "#/properties/apexTestsMinCoverageOrgWide",
       "default": 75.0,
       "description": "Minimum percentage of apex code coverage accepted",
-      "examples": [
-        80.0,
-        95.0
-      ],
+      "examples": [80.0, 95.0],
       "title": "Minimum apex test coverage %",
       "type": "number"
     },
     "availableProjects": {
       "$id": "#/properties/availableProjects",
       "description": "List of business projects that are managed in the same repository. Will be used to build git branch name when using hardis:work:new",
-      "examples": [
-        [
-          "sales_cloud",
-          "service_cloud",
-          "community"
-        ]
-      ],
+      "examples": [["sales_cloud", "service_cloud", "community"]],
       "items": {
         "type": "string"
       },
@@ -144,12 +100,7 @@
     "availableTargetBranches": {
       "$id": "#/properties/availableTargetBranches",
       "description": "List of git branches that can be used as target for merge requests",
-      "examples": [
-        [
-          "develop",
-          "develop_next"
-        ]
-      ],
+      "examples": [["develop", "develop_next"]],
       "items": {
         "type": "string"
       },
@@ -194,15 +145,11 @@
         [
           {
             "globPattern": "/**/*.flexipage-meta.xml",
-            "xpaths": [
-              "//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"
-            ]
+            "xpaths": ["//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"]
           },
           {
             "globPattern": "/**/*.layout-meta.xml",
-            "xpaths": [
-              "//ns:relatedLists//ns:relatedList[contains(text(),'RelatedSolutionList')]"
-            ]
+            "xpaths": ["//ns:relatedLists//ns:relatedList[contains(text(),'RelatedSolutionList')]"]
           }
         ]
       ],
@@ -216,20 +163,14 @@
           "globPattern": {
             "$id": "#/properties/cleanXmlPatterns/items/properties/globPattern",
             "description": "Glob pattern to identify XML files to clean",
-            "examples": [
-              "/**/*.flexipage-meta.xml"
-            ],
+            "examples": ["/**/*.flexipage-meta.xml"],
             "title": "Glob pattern",
             "type": "string"
           },
           "xpaths": {
             "$id": "#/properties/cleanXmlPatterns/items/properties/xpaths",
             "description": "XPaths to identify elements to remove",
-            "examples": [
-              [
-                "//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"
-              ]
-            ],
+            "examples": [["//ns:flexiPageRegions//ns:name[contains(text(),'dashboardName')]"]],
             "title": "XPath list",
             "items": {
               "type": "string"
@@ -237,10 +178,7 @@
             "type": "array"
           }
         },
-        "required": [
-          "globPattern",
-          "xpaths"
-        ]
+        "required": ["globPattern", "xpaths"]
       },
       "title": "Clean XML Patterns",
       "type": "array"
@@ -276,11 +214,7 @@
         },
         "title": "Command"
       },
-      "required": [
-        "id",
-        "label",
-        "command"
-      ],
+      "required": ["id", "label", "command"],
       "title": "Commands Pre-Deployment",
       "type": "array"
     },
@@ -320,11 +254,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "id",
-          "label",
-          "command"
-        ],
+        "required": ["id", "label", "command"],
         "title": "Command"
       },
       "title": "Commands Post-Deployment",
@@ -434,20 +364,13 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "id",
-                "label",
-                "command"
-              ]
+              "required": ["id", "label", "command"]
             },
             "title": "Label",
             "type": "array"
           }
         },
-        "required": [
-          "id",
-          "label"
-        ]
+        "required": ["id", "label"]
       },
       "title": "Custom commands",
       "type": "array"
@@ -456,14 +379,8 @@
       "$id": "#/properties/customCommandsPosition",
       "description": "Position of custom commands in the menu (first or last)",
       "default": "first",
-      "enum": [
-        "first",
-        "last"
-      ],
-      "examples": [
-        "first",
-        "last"
-      ],
+      "enum": ["first", "last"],
+      "examples": ["first", "last"],
       "title": "Custom commands position",
       "type": "string"
     },
@@ -498,20 +415,14 @@
           "name": {
             "$Id": "#/properties/customPlugins/items/properties/name",
             "description": "Name of the plugin npm package",
-            "examples": [
-              "mo-dx-plugin",
-              "shane-sfdx-plugins"
-            ],
+            "examples": ["mo-dx-plugin", "shane-sfdx-plugins"],
             "title": "Name",
             "type": "string"
           },
           "helpUrl": {
             "$Id": "#/properties/customPlugins/items/properties/helpUrl",
             "description": "Url of plugin documentation",
-            "examples": [
-              "https://github.com/msrivastav13/mo-dx-plugin",
-              "https://github.com/mshanemc/shane-sfdx-plugins"
-            ],
+            "examples": ["https://github.com/msrivastav13/mo-dx-plugin", "https://github.com/mshanemc/shane-sfdx-plugins"],
             "title": "Name",
             "type": "string"
           }
@@ -543,10 +454,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "dataPath",
-          "importInScratchOrgs"
-        ]
+        "required": ["dataPath", "importInScratchOrgs"]
       },
       "title": "Data packages",
       "type": "array"
@@ -554,11 +462,7 @@
     "defaultPackageInstallationKey": {
       "$id": "#/properties/defaultPackageInstallationKey",
       "description": "When generating a new package version protected with password, use this value as default package installation key",
-      "examples": [
-        "hardis",
-        "myPassword",
-        "dFGGF43656YfdFDG{{{dhgfh:::;FSEDSFd78"
-      ],
+      "examples": ["hardis", "myPassword", "dFGGF43656YfdFDG{{{dhgfh:::;FSEDSFd78"],
       "title": "Defaut package installation key",
       "type": "string"
     },
@@ -566,11 +470,7 @@
       "$id": "#/properties/developmentBranch",
       "default": "developpement",
       "description": "When creating a new sfdx-hardis task, this git branch is used as base to create the feature/debug sub branch. The merge request will later have this branch as target.",
-      "examples": [
-        "developpement",
-        "dev_lot2",
-        "hotfixes"
-      ],
+      "examples": ["developpement", "dev_lot2", "hotfixes"],
       "title": "Default pull/merge request target org",
       "type": "string"
     },
@@ -624,55 +524,38 @@
             "properties": {
               "dataPath": {
                 "$id": "#/properties/install/properties/packages/items/dataPath",
-                "examples": [
-                  "scripts/data/EmailTemplate"
-                ],
+                "examples": ["scripts/data/EmailTemplate"],
                 "title": "Path to SFDMU data project to deploy",
                 "type": "string"
               },
               "label": {
                 "$id": "#/properties/install/properties/packages/items/label",
-                "examples": [
-                  "Deploy EmailTemplate",
-                  "Import EmailTemplate records"
-                ],
+                "examples": ["Deploy EmailTemplate", "Import EmailTemplate records"],
                 "title": "Source or data package label",
                 "type": "string"
               },
               "order": {
                 "$id": "#/properties/install/properties/packages/items/order",
-                "examples": [
-                  -20,
-                  13,
-                  50
-                ],
+                "examples": [-20, 13, 50],
                 "title": "Execution order in deployment plan",
                 "type": "number"
               },
               "packageXmlFile": {
                 "$id": "#/properties/install/properties/packages/items/packageXmlFile",
-                "examples": [
-                  "manifest/splits/packageXmlEmails.xml"
-                ],
+                "examples": ["manifest/splits/packageXmlEmails.xml"],
                 "title": "Path to package.xml file to use for deployment",
                 "type": "string"
               },
               "waitAfter": {
                 "$id": "#/properties/install/properties/packages/items/waitAfter",
                 "description": "Delay to wait before installing the next package",
-                "examples": [
-                  10,
-                  20
-                ],
+                "examples": [10, 20],
                 "title": "Wait after install (seconds)",
                 "type": "number"
               }
             }
           },
-          "required": [
-            "label",
-            "order"
-          ],
+          "required": ["label", "order"],
           "title": "List of packages to deploy",
           "type": "array"
         }
@@ -684,11 +567,7 @@
       "$id": "#/properties/devHubAlias",
       "default": "",
       "description": "Dev Hub alias, usually DevHub_ProjectName",
-      "examples": [
-        "DevHub_MyClientMyProject",
-        "DevHub_GoogleGmail",
-        "DevHub_AppleIWatch"
-      ],
+      "examples": ["DevHub_MyClientMyProject", "DevHub_GoogleGmail", "DevHub_AppleIWatch"],
       "title": "Dev Hub org alias",
       "type": "string"
     },
@@ -696,51 +575,31 @@
       "$id": "#/properties/devHubUsername",
       "default": "",
       "description": "Dev Hub username, used to authenticate to DevHub from CI jobs",
-      "examples": [
-        "cicd-user@myclient.com",
-        "scratch-user@google.fr",
-        "scratch-user@apple.fr"
-      ],
+      "examples": ["cicd-user@myclient.com", "scratch-user@google.fr", "scratch-user@apple.fr"],
       "title": "Dev Hub Username",
       "type": "string"
     },
     "extends": {
       "$id": "#/properties/extends",
       "description": "You can base your local sfdx-hardis configuration on a remote config file. That allows you to have the same config base for all your projects",
-      "examples": [
-        "https://raw.githubusercontent.com/worldcompany/shared-config/main/.sfdx-hardis.yml"
-      ],
+      "examples": ["https://raw.githubusercontent.com/worldcompany/shared-config/main/.sfdx-hardis.yml"],
       "title": "Extends remote configuration URL",
       "type": "string"
     },
     "initPermissionSets": {
       "$id": "#/properties/initPermissionSets",
       "description": "When creating a scratch org, Admin user will be automatically assigned to those permission sets",
-      "examples": [
-        [
-          "MyPermissionSet",
-          "MyPermissionSetGroup"
-        ]
-      ],
+      "examples": [["MyPermissionSet", "MyPermissionSetGroup"]],
       "items": {
         "$id": "#/properties/initPermissionSets/items",
-        "type": [
-          "object",
-          "string"
-        ],
+        "type": ["object", "string"],
         "additionalProperties": false,
         "description": "Permission Set or Permission Set Group",
         "properties": {
           "name": {
             "$Id": "#/properties/initPermissionSets/items/properties/name",
             "description": "Permission Set or Permission Set Group name",
-            "examples": [
-              [
-                "MyPermissionSet",
-                "MyPermissionSetGroup",
-                "MyPermissionSetGroup2"
-              ]
-            ],
+            "examples": [["MyPermissionSet", "MyPermissionSetGroup", "MyPermissionSetGroup2"]],
             "title": "Name",
             "type": "string"
           }
@@ -787,60 +646,43 @@
         "properties": {
           "Id": {
             "$Id": "#/properties/install/properties/packages/items/Id",
-            "examples": [
-              "0A35r000000GveVCAS"
-            ],
+            "examples": ["0A35r000000GveVCAS"],
             "title": "(unused) PackageId",
             "type": "string"
           },
           "SubscriberPackageId": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageId",
-            "examples": [
-              "033b0000000Pf2AAAS"
-            ],
+            "examples": ["033b0000000Pf2AAAS"],
             "title": "Subscriber Package Id",
             "type": "string"
           },
           "SubscriberPackageName": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageName",
-            "examples": [
-              "Files Attachment Notes"
-            ],
+            "examples": ["Files Attachment Notes"],
             "title": "Subscriber Package Name",
             "type": "string"
           },
           "SubscriberPackageNamespace": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageNamespace",
-            "examples": [
-              "fan_astrea"
-            ],
+            "examples": ["fan_astrea"],
             "title": "Subscriber Package NameSpace",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "SubscriberPackageVersionId": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionId",
-            "examples": [
-              "04t0o000003nRWAAA2"
-            ],
+            "examples": ["04t0o000003nRWAAA2"],
             "title": "Subscriber Version Id (IMPORTANT)",
             "type": "string"
           },
           "SubscriberPackageVersionName": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionName",
-            "examples": [
-              "Summer2021"
-            ],
+            "examples": ["Summer2021"],
             "title": "Subscriber Version Name",
             "type": "string"
           },
           "SubscriberPackageVersionNumber": {
             "$Id": "#/properties/install/properties/packages/items/SubscriberPackageVersionNumber",
-            "examples": [
-              "1.22.0.2"
-            ],
+            "examples": ["1.22.0.2"],
             "title": "Subscriber Version Number",
             "type": "string"
           },
@@ -848,10 +690,7 @@
             "$Id": "#/properties/install/properties/packages/items/installDuringDeployments",
             "default": false,
             "description": "If true, during deployments this package will be installed in target org if not installed yet",
-            "examples": [
-              true,
-              false
-            ],
+            "examples": [true, false],
             "title": "Install during deployments",
             "type": "boolean"
           },
@@ -859,27 +698,19 @@
             "$Id": "#/properties/install/properties/packages/items/installOnScratchOrgs",
             "default": false,
             "description": "If true, this package will be installed when creating a new scratch org with sfdx-hardis",
-            "examples": [
-              true,
-              false
-            ],
+            "examples": [true, false],
             "title": "Install on scratch orgs",
             "type": "boolean"
           },
           "installationkey": {
             "$Id": "#/properties/install/properties/packages/items/installationkey",
-            "examples": [
-              "MyInstallationKey",
-              "4FzkMzUSwFfP#@"
-            ],
+            "examples": ["MyInstallationKey", "4FzkMzUSwFfP#@"],
             "description": "Installation key for key-protected package",
             "title": "Package installation key",
             "type": "string"
           }
         },
-        "required": [
-          "SubscriberPackageVersionId"
-        ],
+        "required": ["SubscriberPackageVersionId"],
         "title": "Salesforce package"
       },
       "title": "Installed Packages",
@@ -889,9 +720,7 @@
       "$id": "#/properties/installPackagesDuringCheckDeploy",
       "default": false,
       "description": "When calling deployment check command, installs any package referred within installedPackages property",
-      "examples": [
-        true
-      ],
+      "examples": [true],
       "title": "Install packages during deployment checks",
       "type": "boolean"
     },
@@ -899,11 +728,7 @@
       "$id": "#/properties/instanceUrl",
       "default": "",
       "description": "Salesforce instance URL used by CI for deployment or backups",
-      "examples": [
-        "https://myclient.force.com",
-        "https://google.force.com",
-        "https://apple.force.com"
-      ],
+      "examples": ["https://myclient.force.com", "https://google.force.com", "https://apple.force.com"],
       "title": "Instance URL",
       "type": "string"
     },
@@ -921,13 +746,7 @@
     "sourcesToRetrofit": {
       "$id": "#/properties/sourcesToRetrofit",
       "description": "List of metadata to retrieve for retrofit job",
-      "examples": [
-        [
-          "CustomField",
-          "Layout",
-          "PermissionSet"
-        ]
-      ],
+      "examples": [["CustomField", "Layout", "PermissionSet"]],
       "items": {
         "type": "string"
       },
@@ -984,10 +803,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "title",
-          "command"
-        ]
+        "required": ["title", "command"]
       },
       "title": "Monitoring commands",
       "type": "array"
@@ -1002,12 +818,7 @@
     "monitoringDisable": {
       "$id": "#/properties/monitoringDisable",
       "description": "List of commands to skip during monitoring jobs",
-      "examples": [
-        [
-          "METADATA_STATUS",
-          "UNUSED_METADATAS"
-        ]
-      ],
+      "examples": [["METADATA_STATUS", "UNUSED_METADATAS"]],
       "items": {
         "$ref": "#/definitions/enum_monitoring_commands"
       },
@@ -1017,12 +828,7 @@
     "monitoringExcludeUsernames": {
       "$id": "#/properties/monitoringExcludeUsernames",
       "description": "List of usernames to exclude while running monitoring commands",
-      "examples": [
-        [
-          "deploymentuser@cloudity.com",
-          "mc-cloud-user@cloudity.com"
-        ]
-      ],
+      "examples": [["deploymentuser@cloudity.com", "mc-cloud-user@cloudity.com"]],
       "items": {
         "type": "string"
       },
@@ -1033,9 +839,7 @@
       "$id": "#/properties/msTeamsWebhookUrl",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send ALL notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (ALL)",
       "type": "string"
     },
@@ -1043,9 +847,7 @@
       "$id": "#/properties/msTeamsWebhookUrlCritical",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send CRITICAL notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (CRITICAL)",
       "type": "string"
     },
@@ -1053,9 +855,7 @@
       "$id": "#/properties/msTeamsWebhookUrlSevere",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send SEVERE notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (SEVERE)",
       "type": "string"
     },
@@ -1063,9 +863,7 @@
       "$id": "#/properties/msTeamsWebhookUrlWarning",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send WARNING notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (WARNING)",
       "type": "string"
     },
@@ -1073,21 +871,14 @@
       "$id": "#/properties/msTeamsWebhookUrlWarning",
       "default": "",
       "description": "Url of the Ms Teams channel Web Hook that can be used to send INFO notifications",
-      "examples": [
-        "https://my.msteams.webhook.url"
-      ],
+      "examples": ["https://my.msteams.webhook.url"],
       "title": "MsTeams WebHook Url (INFO)",
       "type": "string"
     },
     "notificationsDisable": {
       "$id": "#/properties/notificationsDisable",
       "description": "List of notifications types to skip sending",
-      "examples": [
-        [
-          "METADATA_STATUS",
-          "UNUSED_METADATAS"
-        ]
-      ],
+      "examples": [["METADATA_STATUS", "UNUSED_METADATAS"]],
       "items": {
         "$ref": "#/definitions/enum_notification_types"
       },
@@ -1137,11 +928,7 @@
       "$id": "#/properties/productionBranch",
       "default": "",
       "description": "Name of the git branch corresponding to production environment",
-      "examples": [
-        "master",
-        "main",
-        "production"
-      ],
+      "examples": ["master", "main", "production"],
       "title": "Production branch name",
       "type": "string"
     },
@@ -1149,11 +936,7 @@
       "$id": "#/properties/projectName",
       "default": "",
       "description": "Identifier for the project (can be the client and project)",
-      "examples": [
-        "MyClientMyProject",
-        "GoogleGmail",
-        "AppleIWatch"
-      ],
+      "examples": ["MyClientMyProject", "GoogleGmail", "AppleIWatch"],
       "title": "Project Name",
       "type": "string"
     },
@@ -1161,11 +944,7 @@
       "$id": "#/properties/retrofitBranch",
       "default": "",
       "description": "Name of the git branch where retrofit merge requests targets to",
-      "examples": [
-        "preprod",
-        "dev",
-        "maintenance"
-      ],
+      "examples": ["preprod", "dev", "maintenance"],
       "title": "Retrofit branch name",
       "type": "string"
     },
@@ -1187,12 +966,7 @@
     "scratchOrgInitApexScripts": {
       "$id": "#/properties/scratchOrgInitApexScripts",
       "description": "Apex scripts to call after scratch org initialization",
-      "examples": [
-        [
-          "scripts/apex/init-scratch.apex",
-          "scripts/apex/init-custom-settings.apex"
-        ]
-      ],
+      "examples": [["scripts/apex/init-scratch.apex", "scripts/apex/init-custom-settings.apex"]],
       "items": {
         "type": "string"
       },
@@ -1212,9 +986,7 @@
       "$id": "#/properties/sfdmuCanModify",
       "default": "",
       "description": "Instance host name to allow SFDMU to deploy data in a production org",
-      "examples": [
-        "myproject.force.com"
-      ],
+      "examples": ["myproject.force.com"],
       "title": "SFDMU can modify",
       "type": "string"
     },
@@ -1236,11 +1008,7 @@
       "$id": "#/properties/targetUsername",
       "default": "",
       "description": "Salesforce username used by CI for deployment or backups",
-      "examples": [
-        "deployments@myclient.com",
-        "deployments@google.fr",
-        "deployments@apple.com"
-      ],
+      "examples": ["deployments@myclient.com", "deployments@google.fr", "deployments@apple.com"],
       "title": "Target Username",
       "type": "string"
     },
@@ -1255,12 +1023,7 @@
       "$id": "#/properties/linterIgnoreRightMetadataFile",
       "default": "",
       "description": "Ignore profiles or permission sets",
-      "examples": [
-        "Profile",
-        "Profile:ProfileA",
-        "PermissionSet",
-        "PermissionSet:PermissionSetA, Profile:ProfileA"
-      ],
+      "examples": ["Profile", "Profile:ProfileA", "PermissionSet", "PermissionSet:PermissionSetA, Profile:ProfileA"],
       "title": "Linter ignore permission set or/and profile",
       "type": "string"
     }

--- a/docs/deployTips.md
+++ b/docs/deployTips.md
@@ -8,11 +8,11 @@ description: Learn how to fix issues that can happen during sfdx deployments
 
 This page summarizes all errors that can be detected by sfdx-hardis wrapper commands
 
-| sfdx command             | sfdx-hardis wrapper command |
-| :-----------             | :-------------------------- |
-| [sfdx force:source:deploy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_source.htm#cli_reference_force_source_deploy) | [sfdx hardis:source:deploy](https://sfdx-hardis.cloudity.com/hardis/source/deploy/)   |
-| [sfdx force:source:push](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_source.htm#cli_reference_force_source_push)   | [sfdx hardis:source:push](https://sfdx-hardis.cloudity.com/hardis/source/push/)     |
-| [sfdx force:mdapi:deploy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_mdapi.htm#cli_reference_force_mdapi_beta_deploy)  | [sfdx hardis:mdapi:deploy](https://sfdx-hardis.cloudity.com/hardis/mdapi/deploy/)    |
+| sfdx command                                                                                                                                                                                | sfdx-hardis wrapper command                                                         |
+|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| [sfdx force:source:deploy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_source.htm#cli_reference_force_source_deploy)   | [sfdx hardis:source:deploy](https://sfdx-hardis.cloudity.com/hardis/source/deploy/) |
+| [sfdx force:source:push](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_source.htm#cli_reference_force_source_push)       | [sfdx hardis:source:push](https://sfdx-hardis.cloudity.com/hardis/source/push/)     |
+| [sfdx force:mdapi:deploy](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_mdapi.htm#cli_reference_force_mdapi_beta_deploy) | [sfdx hardis:mdapi:deploy](https://sfdx-hardis.cloudity.com/hardis/mdapi/deploy/)   |
 
 You can also use this function on a [sfdx-hardis Salesforce CI/CD project](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-home/)
 
@@ -302,7 +302,7 @@ You probably also need to add CRM Analytics Admin Permission Set assignment to t
 
 ## Error parsing file
 
-- `Error (.*) Error parsing file: (.*) `
+- `Error (.*) Error parsing file: (.*)`
 
 **Resolution tip**
 
@@ -913,7 +913,7 @@ Please check https://developer.salesforce.com/forums/?id=9060G0000005kVLQAY
 
 ## Test classes with 0% coverage
 
-- ` 0%`
+- `0%`
 
 **Resolution tip**
 

--- a/src/commands/hardis/project/deploy/sources/dx.ts
+++ b/src/commands/hardis/project/deploy/sources/dx.ts
@@ -151,7 +151,7 @@ commandsPostDeploy:
   - id: knowledgeAssign
     label: Assign Knowledge user to desired username
     command: sf data update record --sobject User --where "Username='admin-yser@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
-\`\`\`yaml
+\`\`\`
 
 ### Automated fixes post deployments
 

--- a/src/commands/hardis/project/deploy/sources/dx.ts
+++ b/src/commands/hardis/project/deploy/sources/dx.ts
@@ -128,6 +128,31 @@ installedPackages:
     installDuringDeployments: true
 \`\`\`
 
+### Deployment pre or post commands
+
+You can define command lines to run before or after a deployment
+
+If the commands are not the same depending on the target org, you can define them into **config/branches/.sfdx-hardis-BRANCHNAME.yml** instead of root **config/.sfdx-hardis.yml**
+
+Example:
+
+\`\`\`yaml
+commandsPreDeploy:
+  - id: knowledgeUnassign
+    label: Remove KnownledgeUser right to the user who has it
+    command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
+  - id: knowledgeAssign
+    label: Assign Knowledge user to the deployment user
+    command: sf data update record --sobject User --where "Username='deploy.github@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
+commandsPostDeploy:
+  - id: knowledgeUnassign
+    label: Remove KnownledgeUser right to the user who has it
+    command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
+  - id: knowledgeAssign
+    label: Assign Knowledge user to desired username
+    command: sf data update record --sobject User --where "Username='admin-yser@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
+\`\`\`yaml
+
 ### Automated fixes post deployments
 
 #### List view with scope Mine

--- a/src/commands/hardis/project/deploy/sources/dx.ts
+++ b/src/commands/hardis/project/deploy/sources/dx.ts
@@ -139,14 +139,14 @@ Example:
 \`\`\`yaml
 commandsPreDeploy:
   - id: knowledgeUnassign
-    label: Remove KnownledgeUser right to the user who has it
+    label: Remove KnowledgeUser right to the user who has it
     command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
   - id: knowledgeAssign
     label: Assign Knowledge user to the deployment user
     command: sf data update record --sobject User --where "Username='deploy.github@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
 commandsPostDeploy:
   - id: knowledgeUnassign
-    label: Remove KnownledgeUser right to the user who has it
+    label: Remove KnowledgeUser right to the user who has it
     command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
   - id: knowledgeAssign
     label: Assign Knowledge user to desired username

--- a/src/commands/hardis/source/deploy.ts
+++ b/src/commands/hardis/source/deploy.ts
@@ -45,7 +45,7 @@ commandsPostDeploy:
   - id: knowledgeAssign
     label: Assign Knowledge user to desired username
     command: sf data update record --sobject User --where "Username='admin-yser@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
-\`\`\`yaml
+\`\`\`
 
 Notes:
 

--- a/src/commands/hardis/source/deploy.ts
+++ b/src/commands/hardis/source/deploy.ts
@@ -126,7 +126,7 @@ Notes:
 
   public async run(): Promise<AnyJson> {
     // Run pre deployment commands if defined
-    await executePrePostCommands('commandsPreDeploy', true);
+    await executePrePostCommands("commandsPreDeploy", true);
     const result = await wrapSfdxCoreCommand("sfdx force:source:deploy", this.argv, this, this.flags.debug);
     // Check org coverage if requested
     if (this.flags.checkcoverage && result.stdout) {
@@ -142,7 +142,7 @@ Notes:
       }
     }
     // Run post deployment commands if defined
-    await executePrePostCommands('commandsPostDeploy', process.exitCode === 0);
+    await executePrePostCommands("commandsPostDeploy", process.exitCode === 0);
     await GitProvider.managePostPullRequestComment();
     return result;
   }

--- a/src/commands/hardis/source/deploy.ts
+++ b/src/commands/hardis/source/deploy.ts
@@ -33,14 +33,14 @@ Example:
 \`\`\`yaml
 commandsPreDeploy:
   - id: knowledgeUnassign
-    label: Remove KnownledgeUser right to the user who has it
+    label: Remove KnowledgeUser right to the user who has it
     command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
   - id: knowledgeAssign
     label: Assign Knowledge user to the deployment user
     command: sf data update record --sobject User --where "Username='deploy.github@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
 commandsPostDeploy:
   - id: knowledgeUnassign
-    label: Remove KnownledgeUser right to the user who has it
+    label: Remove KnowledgeUser right to the user who has it
     command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
   - id: knowledgeAssign
     label: Assign Knowledge user to desired username

--- a/src/commands/hardis/source/deploy.ts
+++ b/src/commands/hardis/source/deploy.ts
@@ -11,6 +11,8 @@ export class Deploy extends SfdxCommand {
 
 Additional to the base command wrapper: If using **--checkonly**, add options **--checkcoverage** and **--coverageformatters json-summary** to check that org coverage is > 75% (or value defined in .sfdx-hardis.yml property **apexTestsMinCoverageOrgWide**)
 
+### Deployment results
+
 You can also have deployment results as pull request comments, on:
 
 - GitHub (see [GitHub Pull Requests comments config](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-integration-github/))
@@ -19,6 +21,31 @@ You can also have deployment results as pull request comments, on:
 
 
 [![Assisted solving of Salesforce deployments errors](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-deployment-errors.jpg)](https://nicolas.vuillamy.fr/assisted-solving-of-salesforce-deployments-errors-47f3666a9ed0)
+
+### Deployment pre or post commands
+
+You can define command lines to run before or after a deployment
+
+If the commands are not the same depending on the target org, you can define them into **config/branches/.sfdx-hardis-BRANCHNAME.yml** instead of root **config/.sfdx-hardis.yml**
+
+Example:
+
+\`\`\`yaml
+commandsPreDeploy:
+  - id: knowledgeUnassign
+    label: Remove KnownledgeUser right to the user who has it
+    command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
+  - id: knowledgeAssign
+    label: Assign Knowledge user to the deployment user
+    command: sf data update record --sobject User --where "Username='deploy.github@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
+commandsPostDeploy:
+  - id: knowledgeUnassign
+    label: Remove KnownledgeUser right to the user who has it
+    command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
+  - id: knowledgeAssign
+    label: Assign Knowledge user to desired username
+    command: sf data update record --sobject User --where "Username='admin-yser@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
+\`\`\`yaml
 
 Notes:
 

--- a/src/common/utils/deployTipsList.ts
+++ b/src/common/utils/deployTipsList.ts
@@ -154,6 +154,15 @@ Example of element to delete:
 `,
     },
     {
+      name: "missingDataCategoryGroup",
+      label: "Missing Data Category Group",
+      expressionRegex: [/Error (.*) In field: DeveloperName - no DataCategoryGroup named (.*) found/gm],
+      tip: `If Data Category Group {2} is not existing yet in target org, you might need to:
+- create it manually in target org before deployment
+- comment DataCategoryGroup in {1} XML
+`,
+    },
+    {
       name: "dependent-class-invalid",
       label: "Dependent class is invalid and needs recompilation",
       expressionRegex: [/Error (.*) Dependent class is invalid and needs recompilation/gm],

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -169,7 +169,7 @@ export async function forceSourceDeploy(
   // Replace quick actions with dummy content in case we have dependencies between Flows & QuickActions
   await replaceQuickActionsWithDummy();
   // Run deployment pre-commands
-  await executePrePostCommands('commandsPreDeploy',true);
+  await executePrePostCommands("commandsPreDeploy", true);
   // Process items of deployment plan
   uxLog(this, c.cyan("Processing split deployments build from deployment plan..."));
   uxLog(this, c.whiteBright(JSON.stringify(splitDeployments, null, 2)));
@@ -267,7 +267,7 @@ export async function forceSourceDeploy(
         if (check) {
           await GitProvider.managePostPullRequestComment();
         }
-        await executePrePostCommands('commandsPostDeploy',false);
+        await executePrePostCommands("commandsPostDeploy", false);
         throw new SfdxError("Deployment failure. Check messages above");
       }
 
@@ -336,7 +336,7 @@ export async function forceSourceDeploy(
     messages.push(message);
   }
   // Run deployment post commands
-  await executePrePostCommands('commandsPostDeploy',true);
+  await executePrePostCommands("commandsPostDeploy", true);
   elapseEnd("all deployments");
   return { messages, quickDeploy, deployXmlCount };
 }
@@ -855,19 +855,19 @@ export async function buildOrgManifest(targetOrgUsernameAlias, packageXmlOutputF
   return packageXmlFull;
 }
 
-export async function executePrePostCommands(property: 'commandsPreDeploy'|'commandsPostDeploy', success = true) {
+export async function executePrePostCommands(property: "commandsPreDeploy" | "commandsPostDeploy", success = true) {
   const branchConfig = await getConfig("branch");
   const commands = branchConfig[property] || [];
   if (commands.length === 0) {
-    uxLog(this,c.grey(`No ${property} found to run`));
+    uxLog(this, c.grey(`No ${property} found to run`));
     return;
   }
-  uxLog(this,c.cyan(`Running ${property} found in .sfdx-hardis.yml configuration...`));
+  uxLog(this, c.cyan(`Running ${property} found in .sfdx-hardis.yml configuration...`));
   for (const cmd of commands) {
     if (success === false && cmd.skipIfError === true) {
-      uxLog(this,c.yellow(`Skipping skipIfError=true command [${cmd.id}]: ${cmd.label}`));
+      uxLog(this, c.yellow(`Skipping skipIfError=true command [${cmd.id}]: ${cmd.label}`));
     }
-    uxLog(this,c.cyan(`Running [${cmd.id}]: ${cmd.label}`));
+    uxLog(this, c.cyan(`Running [${cmd.id}]: ${cmd.label}`));
     await execCommand(cmd.command, this, { fail: false, output: true });
   }
 }


### PR DESCRIPTION
### Deployment pre or post commands

You can define command lines to run before or after a deployment

If the commands are not the same depending on the target org, you can define them into **config/branches/.sfdx-hardis-BRANCHNAME.yml** instead of root **config/.sfdx-hardis.yml**

Example:

```yaml
commandsPreDeploy:
  - id: knowledgeUnassign
    label: Remove KnowledgeUser right to the user who has it
    command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
  - id: knowledgeAssign
    label: Assign Knowledge user to the deployment user
    command: sf data update record --sobject User --where "Username='deploy.github@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
commandsPostDeploy:
  - id: knowledgeUnassign
    label: Remove KnowledgeUser right to the user who has it
    command: sf data update record --sobject User --where "UserPermissionsKnowledgeUser='true'" --values "UserPermissionsKnowledgeUser='false'" --json
  - id: knowledgeAssign
    label: Assign Knowledge user to desired username
    command: sf data update record --sobject User --where "Username='admin-yser@myclient.com'" --values "UserPermissionsKnowledgeUser='true'" --json
```
