### PR TITLE
GITLAB_API_REJECT_UNAUTHORIZED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [4.44.3] 2024-07-12
+
+- Set **GITLAB_API_REJECT_UNAUTHORIZED=false** to avoid SSH rejections from Gitlab API
+
 ## [4.44.2] 2024-07-09
 
 - New config **skipCodeCoverage**, to use only in branch scoped config to not check for code coverage (Use with caution because won't work when deploying to production !)

--- a/docs/salesforce-deployment-assistant-error-list.md
+++ b/docs/salesforce-deployment-assistant-error-list.md
@@ -341,7 +341,7 @@ You probably also need to add CRM Analytics Admin Permission Set assignment to t
 ---
 ## Error parsing file
 
-- `Error (.*) Error parsing file: (.*) `
+- `Error (.*) Error parsing file: (.*)`
 
 **Resolution tip**
 
@@ -999,7 +999,7 @@ Please check https://developer.salesforce.com/forums/?id=9060G0000005kVLQAY
 ---
 ## Test classes with 0% coverage
 
-- ` 0%`
+- `0%`
 
 **Resolution tip**
 

--- a/src/common/gitProvider/gitlab.ts
+++ b/src/common/gitProvider/gitlab.ts
@@ -13,7 +13,11 @@ export class GitlabProvider extends GitProviderRoot {
     this.serverUrl = process.env.CI_SERVER_URL;
     // It's better to have a project token defined in a CI_SFDX_HARDIS_GITLAB_TOKEN variable, to have the rights to act on Pull Requests
     this.token = process.env.CI_SFDX_HARDIS_GITLAB_TOKEN || process.env.ACCESS_TOKEN;
-    this.gitlabApi = new Gitlab({ host: this.serverUrl, token: this.token });
+    this.gitlabApi = new Gitlab({
+      host: this.serverUrl,
+      token: this.token,
+      rejectUnauthorized: process?.env?.GITLAB_API_REJECT_UNAUTHORIZED === "false" ? false : true,
+    });
   }
 
   public getLabel(): string {


### PR DESCRIPTION
GITLAB_API_REJECT_UNAUTHORIZED: set to `"false"` if you want to allow connection even without certificate (can be useful on on-premise GitLab instance)
