### PR TITLE
Deployment notifications enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [4.46.0] 2024-07-18
+
 - Allow **hardis:project:deploy:source:dx** notifications to work if the deployment is performed before the Pull Request is merged
   - Activate such mode with variable **SFDX_HARDIS_DEPLOY_BEFORE_MERGE**
 - Add link to [Conga Article](https://medium.com/@nicolasvuillamy/how-to-deploy-conga-composer-configuration-using-salesforce-cli-plugins-c2899641f36b)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 ## [4.46.0] 2024-07-18
 
-- Allow **hardis:project:deploy:source:dx** notifications to work if the deployment is performed before the Pull Request is merged
+- Allow **hardis:project:deploy:source:dx** notifications to work if the deployment is performed before the Pull Request is merged (see [Exotic Use Case](https://github.com/hardisgroupcom/sfdx-hardis/issues/637#issuecomment-2230798904))
   - Activate such mode with variable **SFDX_HARDIS_DEPLOY_BEFORE_MERGE**
 - Add link to [Conga Article](https://medium.com/@nicolasvuillamy/how-to-deploy-conga-composer-configuration-using-salesforce-cli-plugins-c2899641f36b)
 - Add Conga article in README list of articles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Allow **hardis:project:deploy:source:dx** notifications to work if the deployment is performed before the Pull Request is merged
+  - Activate such mode with variable **SFDX_HARDIS_DEPLOY_BEFORE_MERGE**
 - Add link to [Conga Article](https://medium.com/@nicolasvuillamy/how-to-deploy-conga-composer-configuration-using-salesforce-cli-plugins-c2899641f36b)
 - Add Conga article in README list of articles
 

--- a/docs/salesforce-ci-cd-release-home.md
+++ b/docs/salesforce-ci-cd-release-home.md
@@ -13,3 +13,8 @@ The release manager(s) responsibilities are:
 - [Validate users merge requests](salesforce-ci-cd-validate-merge-request.md)
 - [Proceed deployments to major branches/org (UAT,Preprod,Production...)](salesforce-ci-cd-deploy-major-branches.md)
 - [Configure CI/CD project](salesforce-ci-cd-config-home.md)
+
+You can also see specific use cases documentation
+
+- [sfdx-hardis for ISV](salesforce-ci-cd-packaging.md)
+- [sfdx-hardis for Conga](salesforce-ci-cd-conga.md)

--- a/src/commands/hardis/project/deploy/sources/dx.ts
+++ b/src/commands/hardis/project/deploy/sources/dx.ts
@@ -181,8 +181,10 @@ ENV CHROMIUM_PATH="/usr/bin/chromium-browser"
 ENV PUPPETEER_EXECUTABLE_PATH="$\\{CHROMIUM_PATH}" // remove \\ before {
 \`\`\`
 
-If you need to increase the deployment waiting time (force:source:deploy --wait arg), you can define env var SFDX_DEPLOY_WAIT_MINUTES
-  `;
+If you need to increase the deployment waiting time (force:source:deploy --wait arg), you can define env variable SFDX_DEPLOY_WAIT_MINUTES
+
+If you need notifications to be sent using the current Pull Request and not the one just merged ([see use case](https://github.com/hardisgroupcom/sfdx-hardis/issues/637#issuecomment-2230798904)), define env variable SFDX_HARDIS_DEPLOY_BEFORE_MERGE=true
+`;
 
   public static examples = [
     "$ sfdx hardis:project:deploy:sources:dx",

--- a/src/common/gitProvider/azureDevops.ts
+++ b/src/common/gitProvider/azureDevops.ts
@@ -133,7 +133,13 @@ ${this.getPipelineVariablesConfig()}
     if (latestMergedPullRequestOnBranch.length > 0) {
       const latestPullRequest = latestMergedPullRequestOnBranch[0];
       const latestPullRequestId = latestPullRequest.pullRequestId;
-      deploymentCheckId = await this.getDeploymentIdFromPullRequest(azureGitApi, repositoryId, latestPullRequestId, deploymentCheckId, latestPullRequest);
+      deploymentCheckId = await this.getDeploymentIdFromPullRequest(
+        azureGitApi,
+        repositoryId,
+        latestPullRequestId,
+        deploymentCheckId,
+        latestPullRequest,
+      );
     }
     return deploymentCheckId;
   }
@@ -147,11 +153,17 @@ ${this.getPipelineVariablesConfig()}
         uxLog(this, c.yellow("BUILD_REPOSITORY_ID must be defined"));
         return null;
       }
-      return await this.getDeploymentIdFromPullRequest(azureGitApi, repositoryId,pullRequestInfo.pullRequestId, null,pullRequestInfo);
+      return await this.getDeploymentIdFromPullRequest(azureGitApi, repositoryId, pullRequestInfo.pullRequestId, null, pullRequestInfo);
     }
   }
 
-  private async getDeploymentIdFromPullRequest(azureGitApi, repositoryId: string, latestPullRequestId: number, deploymentCheckId: any, latestPullRequest) {
+  private async getDeploymentIdFromPullRequest(
+    azureGitApi,
+    repositoryId: string,
+    latestPullRequestId: number,
+    deploymentCheckId: any,
+    latestPullRequest,
+  ) {
     const existingThreads = await azureGitApi.getThreads(repositoryId, latestPullRequestId);
     for (const existingThread of existingThreads) {
       if (existingThread.isDeleted) {

--- a/src/common/gitProvider/azureDevops.ts
+++ b/src/common/gitProvider/azureDevops.ts
@@ -176,8 +176,8 @@ ${this.getPipelineVariablesConfig()}
           if (matches) {
             deploymentCheckId = matches[1];
             uxLog(this, c.gray(`Found deployment id ${deploymentCheckId} on PR #${latestPullRequestId} ${latestPullRequest.title}`));
+            break;
           }
-          break;
         }
       }
       if (deploymentCheckId) {

--- a/src/common/gitProvider/azureDevops.ts
+++ b/src/common/gitProvider/azureDevops.ts
@@ -155,6 +155,7 @@ ${this.getPipelineVariablesConfig()}
       }
       return await this.getDeploymentIdFromPullRequest(azureGitApi, repositoryId, pullRequestInfo.pullRequestId, null, pullRequestInfo);
     }
+    return null;
   }
 
   private async getDeploymentIdFromPullRequest(

--- a/src/common/gitProvider/bitbucket.ts
+++ b/src/common/gitProvider/bitbucket.ts
@@ -147,8 +147,8 @@ export class BitbucketProvider extends GitProviderRoot {
             this,
             c.gray(`[Bitbucket Integration] Found deployment id ${deploymentCheckId} on PR #${latestPullRequestId} ${latestPullRequest.title}`),
           );
+          break;
         }
-        break;
       }
     }
     return deploymentCheckId;

--- a/src/common/gitProvider/bitbucket.ts
+++ b/src/common/gitProvider/bitbucket.ts
@@ -122,6 +122,7 @@ export class BitbucketProvider extends GitProviderRoot {
       const workspace = process.env.BITBUCKET_WORKSPACE || null;
       return await this.getDeploymentIdFromPullRequest(pullRequestInfo.id, repoSlug, workspace, null, pullRequestInfo);
     }
+    return null;
   }
 
   private async getDeploymentIdFromPullRequest(

--- a/src/common/gitProvider/bitbucket.ts
+++ b/src/common/gitProvider/bitbucket.ts
@@ -124,7 +124,13 @@ export class BitbucketProvider extends GitProviderRoot {
     }
   }
 
-  private async getDeploymentIdFromPullRequest(latestPullRequestId: number, repoSlug: string, workspace: string, deploymentCheckId: any, latestPullRequest: Schema.Pullrequest) {
+  private async getDeploymentIdFromPullRequest(
+    latestPullRequestId: number,
+    repoSlug: string,
+    workspace: string,
+    deploymentCheckId: any,
+    latestPullRequest: Schema.Pullrequest,
+  ) {
     const comments = await this.bitbucket.repositories.listPullRequestComments({
       pull_request_id: latestPullRequestId,
       repo_slug: repoSlug,
@@ -138,7 +144,7 @@ export class BitbucketProvider extends GitProviderRoot {
           deploymentCheckId = matches[1];
           uxLog(
             this,
-            c.gray(`[Bitbucket Integration] Found deployment id ${deploymentCheckId} on PR #${latestPullRequestId} ${latestPullRequest.title}`)
+            c.gray(`[Bitbucket Integration] Found deployment id ${deploymentCheckId} on PR #${latestPullRequestId} ${latestPullRequest.title}`),
           );
         }
         break;

--- a/src/common/gitProvider/gitProviderRoot.ts
+++ b/src/common/gitProvider/gitProviderRoot.ts
@@ -16,6 +16,11 @@ export abstract class GitProviderRoot {
     return null;
   }
 
+  public async getPullRequestDeploymentCheckId(): Promise<string> {
+    uxLog(this, `Method getPullRequestDeploymentCheckId() is not implemented yet on ${this.getLabel()}`);
+    return null;
+  }
+
   public async getCurrentJobUrl(): Promise<string> {
     uxLog(this, `Method getCurrentJobUrl is not implemented yet on ${this.getLabel()}`);
     return null;

--- a/src/common/gitProvider/github.ts
+++ b/src/common/gitProvider/github.ts
@@ -55,7 +55,13 @@ export class GithubProvider extends GitProviderRoot {
     return null;
   }
 
-  private async getDeploymentIdFromPullRequest(latestPullRequestId: number, repoOwner: string, repoName: string, deploymentCheckId: any, latestPullRequest: any) {
+  private async getDeploymentIdFromPullRequest(
+    latestPullRequestId: number,
+    repoOwner: string,
+    repoName: string,
+    deploymentCheckId: any,
+    latestPullRequest: any,
+  ) {
     uxLog(this, c.grey(`[GitHub integration] Listing comments for PR ${latestPullRequestId}`));
     const existingComments = await this.octokit.rest.issues.listComments({
       owner: repoOwner,

--- a/src/common/gitProvider/github.ts
+++ b/src/common/gitProvider/github.ts
@@ -40,21 +40,36 @@ export class GithubProvider extends GitProviderRoot {
     if (latestPullRequestsOnBranch.data.length > 0) {
       const latestPullRequest = latestPullRequestsOnBranch.data[0];
       const latestPullRequestId = latestPullRequest.number;
-      uxLog(this, c.grey(`[GitHub integration] Listing comments for PR ${latestPullRequestId}`));
-      const existingComments = await this.octokit.rest.issues.listComments({
-        owner: repoOwner,
-        repo: repoName,
-        issue_number: latestPullRequestId,
-      });
-      for (const existingComment of existingComments.data) {
-        if (existingComment.body.includes("<!-- sfdx-hardis deployment-id ")) {
-          const matches = /<!-- sfdx-hardis deployment-id (.*) -->/gm.exec(existingComment.body);
-          if (matches) {
-            deploymentCheckId = matches[1];
-            uxLog(this, c.gray(`Found deployment id ${deploymentCheckId} on PR #${latestPullRequestId} ${latestPullRequest.title}`));
-          }
-          break;
+      deploymentCheckId = await this.getDeploymentIdFromPullRequest(latestPullRequestId, repoOwner, repoName, deploymentCheckId, latestPullRequest);
+    }
+    return deploymentCheckId;
+  }
+
+  public async getPullRequestDeploymentCheckId(): Promise<string> {
+    const pullRequestInfo = await this.getPullRequestInfo();
+    if (pullRequestInfo) {
+      const repoOwner = github?.context?.repo?.owner || null;
+      const repoName = github?.context?.repo?.repo || null;
+      return await this.getDeploymentIdFromPullRequest(pullRequestInfo.number, repoOwner, repoName, null, pullRequestInfo);
+    }
+    return null;
+  }
+
+  private async getDeploymentIdFromPullRequest(latestPullRequestId: number, repoOwner: string, repoName: string, deploymentCheckId: any, latestPullRequest: any) {
+    uxLog(this, c.grey(`[GitHub integration] Listing comments for PR ${latestPullRequestId}`));
+    const existingComments = await this.octokit.rest.issues.listComments({
+      owner: repoOwner,
+      repo: repoName,
+      issue_number: latestPullRequestId,
+    });
+    for (const existingComment of existingComments.data) {
+      if (existingComment.body.includes("<!-- sfdx-hardis deployment-id ")) {
+        const matches = /<!-- sfdx-hardis deployment-id (.*) -->/gm.exec(existingComment.body);
+        if (matches) {
+          deploymentCheckId = matches[1];
+          uxLog(this, c.gray(`Found deployment id ${deploymentCheckId} on PR #${latestPullRequestId} ${latestPullRequest.title}`));
         }
+        break;
       }
     }
     return deploymentCheckId;

--- a/src/common/gitProvider/github.ts
+++ b/src/common/gitProvider/github.ts
@@ -74,8 +74,8 @@ export class GithubProvider extends GitProviderRoot {
         if (matches) {
           deploymentCheckId = matches[1];
           uxLog(this, c.gray(`Found deployment id ${deploymentCheckId} on PR #${latestPullRequestId} ${latestPullRequest.title}`));
+          break;
         }
-        break;
       }
     }
     return deploymentCheckId;

--- a/src/common/gitProvider/gitlab.ts
+++ b/src/common/gitProvider/gitlab.ts
@@ -105,8 +105,8 @@ export class GitlabProvider extends GitProviderRoot {
         if (matches) {
           deploymentCheckId = matches[1];
           uxLog(this, c.gray(`Found deployment id ${deploymentCheckId} on MR #${latestMergeRequestId} ${latestMergeRequest.title}`));
+          break;
         }
-        break;
       }
     }
     return deploymentCheckId;

--- a/src/common/gitProvider/gitlab.ts
+++ b/src/common/gitProvider/gitlab.ts
@@ -83,16 +83,30 @@ export class GitlabProvider extends GitProviderRoot {
     if (latestMergeRequestsOnBranch.length > 0) {
       const latestMergeRequest = latestMergeRequestsOnBranch[0];
       const latestMergeRequestId = latestMergeRequest.iid;
-      const existingNotes = await this.gitlabApi.MergeRequestNotes.all(projectId, latestMergeRequestId);
-      for (const existingNote of existingNotes) {
-        if (existingNote.body.includes("<!-- sfdx-hardis deployment-id ")) {
-          const matches = /<!-- sfdx-hardis deployment-id (.*) -->/gm.exec(existingNote.body);
-          if (matches) {
-            deploymentCheckId = matches[1];
-            uxLog(this, c.gray(`Found deployment id ${deploymentCheckId} on MR #${latestMergeRequestId} ${latestMergeRequest.title}`));
-          }
-          break;
+      deploymentCheckId = await this.getDeploymentIdFromPullRequest(projectId, latestMergeRequestId, deploymentCheckId, latestMergeRequest);
+    }
+    return deploymentCheckId;
+  }
+
+  public async getPullRequestDeploymentCheckId(): Promise<string> {
+    const pullRequestInfo = await this.getPullRequestInfo();
+    if (pullRequestInfo) {
+      const projectId = process.env.CI_PROJECT_ID || null;
+      return await this.getDeploymentIdFromPullRequest(projectId, pullRequestInfo.iid, null, pullRequestInfo);
+    }
+    return null;
+  }
+
+  private async getDeploymentIdFromPullRequest(projectId: string, latestMergeRequestId: number, deploymentCheckId: any, latestMergeRequest) {
+    const existingNotes = await this.gitlabApi.MergeRequestNotes.all(projectId, latestMergeRequestId);
+    for (const existingNote of existingNotes) {
+      if (existingNote.body.includes("<!-- sfdx-hardis deployment-id ")) {
+        const matches = /<!-- sfdx-hardis deployment-id (.*) -->/gm.exec(existingNote.body);
+        if (matches) {
+          deploymentCheckId = matches[1];
+          uxLog(this, c.gray(`Found deployment id ${deploymentCheckId} on MR #${latestMergeRequestId} ${latestMergeRequest.title}`));
         }
+        break;
       }
     }
     return deploymentCheckId;

--- a/src/common/gitProvider/index.ts
+++ b/src/common/gitProvider/index.ts
@@ -156,8 +156,8 @@ export abstract class GitProvider {
   }
 
   static isDeployBeforeMerge(): boolean {
-    const deployBeforeMerge = getEnvVar("SFDX_HARDIS_DEPLOY_BEFORE_MERGE") || false ;
-    return [true,"true"].includes(deployBeforeMerge);
+    const deployBeforeMerge = getEnvVar("SFDX_HARDIS_DEPLOY_BEFORE_MERGE") || false;
+    return [true, "true"].includes(deployBeforeMerge);
   }
 }
 

--- a/src/common/utils/gitUtils.ts
+++ b/src/common/utils/gitUtils.ts
@@ -37,8 +37,8 @@ export async function selectTargetBranch(options: { message?: string } = {}) {
       message: c.cyanBright(message),
       choices: availableTargetBranches
         ? availableTargetBranches.map((branch) => {
-          return { title: branch, value: branch };
-        })
+            return { title: branch, value: branch };
+          })
         : [],
       initial: config.developmentBranch || "developpement",
     },

--- a/src/common/utils/gitUtils.ts
+++ b/src/common/utils/gitUtils.ts
@@ -37,8 +37,8 @@ export async function selectTargetBranch(options: { message?: string } = {}) {
       message: c.cyanBright(message),
       choices: availableTargetBranches
         ? availableTargetBranches.map((branch) => {
-            return { title: branch, value: branch };
-          })
+          return { title: branch, value: branch };
+        })
         : [],
       initial: config.developmentBranch || "developpement",
     },
@@ -87,7 +87,7 @@ export async function computeCommitsSummary(checkOnly, pullRequestInfo: any) {
   uxLog(this, c.cyan("Computing commits summary..."));
   const currentGitBranch = await getCurrentGitBranch();
   let logResults: (DefaultLogFields & ListLogLine)[] = [];
-  if (checkOnly) {
+  if (checkOnly || GitProvider.isDeployBeforeMerge()) {
     const prInfo = await GitProvider.getPullRequestInfo();
     const deltaScope = await getGitDeltaScope(prInfo?.sourceBranch || currentGitBranch, prInfo?.targetBranch || process.env.FORCE_TARGET_BRANCH);
     logResults = [...deltaScope.logResult.all];


### PR DESCRIPTION
- Allow **hardis:project:deploy:source:dx** notifications to work if the deployment is performed before the Pull Request is merged
  - Activate such mode with variable **SFDX_HARDIS_DEPLOY_BEFORE_MERGE**

Fixes https://github.com/hardisgroupcom/sfdx-hardis/issues/637
