### PR TITLE
Fix legacy API output message + display deployment message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [4.50.0] 2024-07-29
+
 - Add message in case of deployment check passing thanks to `testCoverageNotBlocking: true`
 - [hardis:org:diagnose:legacyapi](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/legacyapi/) : Fix display error declared in bug [#652](https://github.com/hardisgroupcom/sfdx-hardis/issues/652)
 - Run legacy api detection daily with monitoring, as logs remain only 24h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Add message in case of deployment check passing thanks to `testCoverageNotBlocking: true`
+
 ## [4.49.1] 2024-07-27
 
 - Fix 4.49.0 (deployment error handler bug)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
 - Add message in case of deployment check passing thanks to `testCoverageNotBlocking: true`
+- [hardis:org:diagnose:legacyapi](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/legacyapi/) : Fix display error declared in bug [#652](https://github.com/hardisgroupcom/sfdx-hardis/issues/652)
 
 ## [4.49.1] 2024-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 - Add message in case of deployment check passing thanks to `testCoverageNotBlocking: true`
 - [hardis:org:diagnose:legacyapi](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/legacyapi/) : Fix display error declared in bug [#652](https://github.com/hardisgroupcom/sfdx-hardis/issues/652)
+- Run legacy api detection daily with monitoring, as logs remain only 24h
 
 ## [4.49.1] 2024-07-27
 

--- a/docs/salesforce-deployment-assistant-error-list.md
+++ b/docs/salesforce-deployment-assistant-error-list.md
@@ -341,7 +341,7 @@ You probably also need to add CRM Analytics Admin Permission Set assignment to t
 ---
 ## Error parsing file
 
-- `Error (.*) Error parsing file: (.*) `
+- `Error (.*) Error parsing file: (.*)`
 
 **Resolution tip**
 
@@ -999,7 +999,7 @@ Please check https://developer.salesforce.com/forums/?id=9060G0000005kVLQAY
 ---
 ## Test classes with 0% coverage
 
-- ` 0%`
+- `0%`
 
 **Resolution tip**
 

--- a/src/commands/hardis/org/diagnose/legacyapi.ts
+++ b/src/commands/hardis/org/diagnose/legacyapi.ts
@@ -86,7 +86,7 @@ See article below
       maxApiVersion: 6.0,
       severity: "ERROR",
       deprecationRelease: "Summer 21 - retirement of 1 to 6  ",
-      errors: []
+      errors: [],
     },
     {
       apiFamily: ["SOAP", "REST", "BULK_API"],
@@ -94,7 +94,7 @@ See article below
       maxApiVersion: 20.0,
       severity: "ERROR",
       deprecationRelease: "Summer 22 - retirement of 7 to 20 ",
-      errors: []
+      errors: [],
     },
     {
       apiFamily: ["SOAP", "REST", "BULK_API"],
@@ -102,7 +102,7 @@ See article below
       maxApiVersion: 30.0,
       severity: "WARNING",
       deprecationRelease: "Summer 25 - retirement of 21 to 30",
-      errors: []
+      errors: [],
     },
   ];
 
@@ -151,28 +151,30 @@ See article below
     for (const eventLogFile of eventLogRes.records) {
       await this.collectDeprecatedApiCalls(eventLogFile.LogFile, conn);
     }
-    this.allErrors = [...this.legacyApiDescriptors[0].errors, ...this.legacyApiDescriptors[1].errors, ...this.legacyApiDescriptors[2].errors]
+    this.allErrors = [...this.legacyApiDescriptors[0].errors, ...this.legacyApiDescriptors[1].errors, ...this.legacyApiDescriptors[2].errors];
 
     // Display summary
     uxLog(this, "");
     uxLog(this, c.cyan("Results:"));
     for (const descriptor of this.legacyApiDescriptors) {
-      const colorMethod = descriptor.severity === "ERROR" && descriptor.errors.length > 0 ? c.red :
-        descriptor.severity === "WARNING" && descriptor.errors.length > 0 ? c.yellow :
-          c.green;
+      const colorMethod =
+        descriptor.severity === "ERROR" && descriptor.errors.length > 0
+          ? c.red
+          : descriptor.severity === "WARNING" && descriptor.errors.length > 0
+            ? c.yellow
+            : c.green;
       uxLog(this, colorMethod(`- ${descriptor} : ${c.bold(descriptor.errors.length)}`));
     }
     uxLog(this, "");
 
-
     // Build command result
     let msg = "No deprecated API call has been found in ApiTotalUsage logs";
     let statusCode = 0;
-    if (this.legacyApiDescriptors.filter(descriptor => descriptor.severity === "ERROR" && descriptor.errors.length > 0).length > 0) {
+    if (this.legacyApiDescriptors.filter((descriptor) => descriptor.severity === "ERROR" && descriptor.errors.length > 0).length > 0) {
       msg = "Found legacy API versions calls in logs";
       statusCode = 1;
       uxLog(this, c.red(c.bold(msg)));
-    } else if (this.legacyApiDescriptors.filter(descriptor => descriptor.severity === "WARNING" && descriptor.errors.length > 0).length > 0) {
+    } else if (this.legacyApiDescriptors.filter((descriptor) => descriptor.severity === "WARNING" && descriptor.errors.length > 0).length > 0) {
       msg = "Found deprecated API versions calls in logs that will not be supported anymore in the future";
       statusCode = 0;
       uxLog(this, c.yellow(c.bold(msg)));
@@ -253,7 +255,7 @@ See article to solve issue before it's too late:
       message: msg,
       csvLogFile: this.outputFile,
       outputFileIps: outputFileIps,
-      legacyApiResults: this.legacyApiDescriptors
+      legacyApiResults: this.legacyApiDescriptors,
     };
   }
 

--- a/src/commands/hardis/org/diagnose/legacyapi.ts
+++ b/src/commands/hardis/org/diagnose/legacyapi.ts
@@ -85,7 +85,7 @@ See article below
       minApiVersion: 1.0,
       maxApiVersion: 6.0,
       severity: "ERROR",
-      deprecationRelease: "Summer 21 - retirement of 1 to 6  ",
+      deprecationRelease: "Summer 21 - retirement of 1 to 6",
       errors: [],
     },
     {
@@ -93,7 +93,7 @@ See article below
       minApiVersion: 7.0,
       maxApiVersion: 20.0,
       severity: "ERROR",
-      deprecationRelease: "Summer 22 - retirement of 7 to 20 ",
+      deprecationRelease: "Summer 22 - retirement of 7 to 20",
       errors: [],
     },
     {
@@ -163,7 +163,7 @@ See article below
           : descriptor.severity === "WARNING" && descriptor.errors.length > 0
             ? c.yellow
             : c.green;
-      uxLog(this, colorMethod(`- ${descriptor} : ${c.bold(descriptor.errors.length)}`));
+      uxLog(this, colorMethod(`- ${descriptor.deprecationRelease} : ${c.bold(descriptor.errors.length)}`));
     }
     uxLog(this, "");
 
@@ -201,7 +201,7 @@ See article below
     // Debug or manage CSV file generation error
     if (this.debugMode || this.outputFile == null) {
       for (const descriptor of this.legacyApiDescriptors) {
-        uxLog(this, c.grey(`- ${descriptor} : ${JSON.stringify(descriptor.errors.length)}`));
+        uxLog(this, c.grey(`- ${descriptor.deprecationRelease} : ${JSON.stringify(descriptor.errors.length)}`));
       }
     }
 

--- a/src/commands/hardis/org/monitor/all.ts
+++ b/src/commands/hardis/org/monitor/all.ts
@@ -103,7 +103,7 @@ You can force the daily run of all commands by defining env var \`MONITORING_IGN
         key: "LEGACY_API",
         title: "Detect calls to deprecated API versions",
         command: "sfdx hardis:org:diagnose:legacyapi",
-        frequency: "weekly",
+        frequency: "daily",
       },
       {
         key: "ORG_LIMITS",

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -305,6 +305,9 @@ export async function forceSourceDeploy(
           `[sfdx-hardis] Successfully ${check ? "checked deployment of" : "deployed"} ${c.bold(deployment.label)} to target Salesforce org - ` +
           extraInfo;
         uxLog(commandThis, c.green(message));
+        if (deployRes?.testCoverageNotBlockingActivated === true) {
+          uxLog(commandThis,c.yellow("There is a code coverage issue, but the check is passing by design because you configured testCoverageNotBlocking: true in your branch .sfdx-hardis.yml") )
+        }
       } else {
         message = `[sfdx-hardis] Unable to deploy ${c.bold(deployment.label)} to target Salesforce org - ` + extraInfo;
         uxLog(commandThis, c.red(c.bold(deployRes.errorMessage)));
@@ -345,7 +348,7 @@ async function handleDeployError(e: any, check: boolean, branchConfig: any, comm
     output.includes("=== Apex Code Coverage")
   ) {
     uxLog(commandThis, c.yellow(c.bold("Deployment status: Deploy check success & Ignored test coverage error")));
-    return { status: 0, stdout: e.stdout, stderr: e.stderr };
+    return { status: 0, stdout: e.stdout, stderr: e.stderr, testCoverageNotBlockingActivated: true };
   }
   // Handle Effective error
   const { tips, errLog } = await analyzeDeployErrorLogs(output, true, { check: check });

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -306,7 +306,12 @@ export async function forceSourceDeploy(
           extraInfo;
         uxLog(commandThis, c.green(message));
         if (deployRes?.testCoverageNotBlockingActivated === true) {
-          uxLog(commandThis,c.yellow("There is a code coverage issue, but the check is passing by design because you configured testCoverageNotBlocking: true in your branch .sfdx-hardis.yml") )
+          uxLog(
+            commandThis,
+            c.yellow(
+              "There is a code coverage issue, but the check is passing by design because you configured testCoverageNotBlocking: true in your branch .sfdx-hardis.yml",
+            ),
+          );
         }
       } else {
         message = `[sfdx-hardis] Unable to deploy ${c.bold(deployment.label)} to target Salesforce org - ` + extraInfo;


### PR DESCRIPTION
- Add message in case of deployment check passing thanks to `testCoverageNotBlocking: true`
- hardis:org:diagnose:legacyapi: fix display error
- Run legacy api detection daily with monitoring, as logs remain only 24h

Fixes https://github.com/hardisgroupcom/sfdx-hardis/issues/652