### PR TITLE
Fixing small issues with creating scratch org and scratch org pool

### DIFF
--- a/defaults/utils/sfdxHardisKeyValueStore/objects/SfdxHardisKeyValueStore__c.object
+++ b/defaults/utils/sfdxHardisKeyValueStore/objects/SfdxHardisKeyValueStore__c.object
@@ -144,7 +144,7 @@
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
     <description>Technical utility for sfdx-hardis
-https://github.com/hardisgroupcom/sfdx-hardis</description>
+        https://github.com/hardisgroupcom/sfdx-hardis</description>
     <enableActivities>false</enableActivities>
     <enableBulkApi>false</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -164,14 +164,13 @@ https://github.com/hardisgroupcom/sfdx-hardis</description>
         <type>LongTextArea</type>
         <visibleLines>50</visibleLines>
     </fields>
-    <gender>Masculine</gender>
     <label>SfdxHardisKeyValueStore</label>
     <nameField>
         <label>Key</label>
         <type>Text</type>
     </nameField>
     <pluralLabel>SfdxHardisKeyValueStores</pluralLabel>
-    <searchLayouts/>
+    <searchLayouts />
     <sharingModel>ReadWrite</sharingModel>
     <visibility>Public</visibility>
 </CustomObject>

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -193,7 +193,7 @@ export default class ScratchCreate extends SfCommand<any> {
       moment().format('YYYYMMDD_hhmm');
     this.scratchOrgAlias =
       process.env.SCRATCH_ORG_ALIAS ||
-      (!this.forceNew && this.pool === false ? this.configInfo.scratchOrgAlias : null) ||
+      (!this.forceNew && this.pool == false ? this.configInfo.scratchOrgAlias : null) ||
       newScratchName;
     if (isCI && !this.scratchOrgAlias.startsWith('CI-')) {
       this.scratchOrgAlias = 'CI-' + this.scratchOrgAlias;
@@ -260,7 +260,7 @@ export default class ScratchCreate extends SfCommand<any> {
         return org.alias === this.scratchOrgAlias && org.status === 'Active' && org.devHubUsername === hubOrgUsername;
       }) || [];
     // Reuse existing scratch org
-    if (matchingScratchOrgs?.length > 0 && !this.forceNew && this.pool === false) {
+    if (matchingScratchOrgs?.length > 0 && !this.forceNew && this.pool == false) {
       this.scratchOrgInfo = matchingScratchOrgs[0];
       this.scratchOrgUsername = this.scratchOrgInfo.username;
       uxLog(this, c.cyan(`Reusing org ${c.green(this.scratchOrgAlias)} with user ${c.green(this.scratchOrgUsername)}`));
@@ -319,7 +319,7 @@ export default class ScratchCreate extends SfCommand<any> {
       `--definition-file ${projectScratchDefLocal} ` +
       `--alias ${this.scratchOrgAlias} ` +
       `--wait ${waitTime} ` +
-      `--target-org ${this.devHubAlias} ` +
+      `--target-dev-hub ${this.devHubAlias} ` +
       `--duration-days ${this.scratchOrgDuration}`;
     const createResult = await execSfdxJson(createCommand, this, {
       fail: false,

--- a/src/common/keyValueProviders/salesforce.ts
+++ b/src/common/keyValueProviders/salesforce.ts
@@ -97,7 +97,7 @@ export class SalesforceProvider implements KeyValueProviderInterface {
     try {
       await deployMetadatas({
         deployDir: path.join(path.join(PACKAGE_ROOT_DIR, "defaults/utils/sfdxHardisKeyValueStore", ".")),
-        targetUsername: options.devHubConn.options.authInfo.fields.username,
+        targetUsername: options.devHubConn.options.authInfo.username,
       });
     } catch (e) {
       uxLog(


### PR DESCRIPTION
The following changes were made:
File 1: defaults/utils/sfdxHardisKeyValueStore/objects/SfdxHardisKeyValueStore__c.object

    Line 164:
        Removed the <gender> tag for the SfdxHardisKeyValueStore object.
        Deletion: <gender>Masculine</gender>

    Line 167:
        Updated <searchLayouts> tag formatting, removing extra space.
        Change:
            Before: <searchLayouts/>
            After: <searchLayouts />

File 2: src/commands/hardis/scratch/create.ts

    Line 193:
        Fixed comparison operator from === to == in pool alias assignment.
        Change:
            Before: this.pool === false
            After: this.pool == false

    Line 260:
        Same change as line 193, fixing comparison operator from === to == in another pool check.
        Change:
            Before: this.pool === false
            After: this.pool == false

    Line 319:
        Updated the --target-org option to --target-dev-hub to better match the intended behavior of setting the DevHub alias during scratch org creation.
        Change:
            Before: --target-org ${this.devHubAlias}
            After: --target-dev-hub ${this.devHubAlias}

File 3: src/common/keyValueProviders/salesforce.ts

    Line 97:
        Updated the target username reference to use authInfo.username directly instead of accessing the fields.username.
        Change:
            Before: targetUsername: options.devHubConn.options.authInfo.fields.username
            After: targetUsername: options.devHubConn.options.authInfo.username

Summary

    Additions: 7 lines
    Deletions: 8 lines
    Primary Fixes: Operator comparisons for pool checks, username access in Salesforce provider, and removal of unnecessary metadata in object XML.