### PR TITLE
hardis:project:deploy:smart: Ignore coverage fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- hardis:project:deploy:smart: Fix to adapt stdout checks to output of `sf project deploy start` in case code coverage is ignored
+
 ## [5.0.10] 2024-10-03
 
 - hardis:project:deploy:smart : Fix parsing of error strings

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -405,9 +405,9 @@ async function handleDeployError(
   if (
     check === true &&
     branchConfig?.testCoverageNotBlocking === true &&
-    output.includes('=== Test Success') &&
+    (output.includes('=== Test Success') || output.includes('Test Success [')) &&
     !output.includes('Test Failures') &&
-    output.includes('=== Apex Code Coverage')
+    (output.includes('=== Apex Code Coverage') || output.includes("Failing: 0"))
   ) {
     uxLog(commandThis, c.yellow(c.bold('Deployment status: Deploy check success & Ignored test coverage error')));
     return { status: 0, stdout: (e as any).stdout, stderr: (e as any).stderr, testCoverageNotBlockingActivated: true };


### PR DESCRIPTION
Adapt stdout checks to output of sf project deploy start
