### PR TITLE
Default deployment waiting time 120mn + warning when uploading connected app

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+import salesforcePrettierConfig from "@salesforce/prettier-config";
+
+export default {
+  ...salesforcePrettierConfig,
+  printWidth: 150,
+};

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,0 @@
-"@salesforce/prettier-config"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [5.1.0] 2024-10-11
+
 - hardis:project:deploy:smart: Fix to adapt stdout checks to output of `sf project deploy start` in case code coverage is ignored
 - hardis:org:monitor:backup: Allow spaces in folders
 - Remove pubsub from default .forceignore
+- Change default deployment waiting time from 60mn to 120mn
+- Display explicit warning message before ConnectedApp deployment so users don't forget to manually create the connected app with the certificate
 
 ## [5.0.10] 2024-10-03
 

--- a/src/commands/hardis/project/deploy/smart.ts
+++ b/src/commands/hardis/project/deploy/smart.ts
@@ -240,7 +240,7 @@ ENV CHROMIUM_PATH="/usr/bin/chromium-browser"
 ENV PUPPETEER_EXECUTABLE_PATH="$\\{CHROMIUM_PATH}" // remove \\ before {
 \`\`\`
 
-If you need to increase the deployment waiting time (sf project deploy start --wait arg), you can define env variable SFDX_DEPLOY_WAIT_MINUTES
+If you need to increase the deployment waiting time (sf project deploy start --wait arg), you can define env variable SFDX_DEPLOY_WAIT_MINUTES (default: 120)
 
 If you need notifications to be sent using the current Pull Request and not the one just merged ([see use case](https://github.com/hardisgroupcom/sfdx-hardis/issues/637#issuecomment-2230798904)), define env variable SFDX_HARDIS_DEPLOY_BEFORE_MERGE=true
 `;

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -237,7 +237,7 @@ export async function smartDeploy(
             `sf project deploy quick` +
             ` --job-id ${deploymentCheckId} ` +
             (options.targetUsername ? ` -o ${options.targetUsername}` : '') +
-            ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '60'}` +
+            ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '120'}` +
             ` --verbose` +
             (process.env.SFDX_DEPLOY_DEV_DEBUG ? ' --dev-debug' : '');
           const quickDeployRes = await execSfdxJson(quickDeployCommand, commandThis, {
@@ -294,7 +294,7 @@ export async function smartDeploy(
         (options.targetUsername ? ` -o ${options.targetUsername}` : '') +
         (testlevel === 'NoTestRun' || branchConfig?.skipCodeCoverage === true ? '' : ' --coverage-formatters json-summary') +
         ' --verbose' +
-        ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '60'}` +
+        ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '120'}` +
         (process.env.SFDX_DEPLOY_DEV_DEBUG ? ' --dev-debug' : '');
       let deployRes;
       try {
@@ -773,7 +773,7 @@ export async function deployDestructiveChanges(
   await fs.copy(packageDeletedXmlFile, path.join(tmpDir, 'destructiveChanges.xml'));
   const deployDelete =
     `sf project deploy ${options.check ? 'validate' : 'start'} --metadata-dir ${tmpDir}` +
-    ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '60'}` +
+    ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '120'}` +
     ` --test-level ${options.testLevel || 'NoTestRun'}` +
     ' --ignore-warnings' + // So it does not fail in case metadata is already deleted
     (options.targetUsername ? ` --target-org ${options.targetUsername}` : '') +
@@ -826,7 +826,7 @@ export async function deployMetadatas(
   const deployCommand =
     `sf project deploy ${options.check ? 'validate' : 'start'}` +
     ` --metadata-dir ${options.deployDir || '.'}` +
-    ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '60'}` +
+    ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '120'}` +
     ` --test-level ${options.testlevel || 'RunLocalTests'}` +
     ` --api-version ${options.apiVersion || CONSTANTS.API_VERSION}` +
     (options.targetUsername ? ` --target-org ${options.targetUsername}` : '') +

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1213,6 +1213,12 @@ export async function generateSSLCertificate(
           } ...`
         )
       );
+      uxLog(
+        commandThis,
+        c.yellow(
+          `If you have an upload error, PLEASE READ THE MESSAGE AFTER, that will explain how to manually create the connected app, and don't forget the CERTIFICATE file :)`
+        )
+      );
       const isProduction = await isProductionOrg(options.targetUsername || null, { conn: conn });
       const deployRes = await deployMetadatas({
         deployDir: tmpDirMd,


### PR DESCRIPTION
- Change default deployment waiting time from 60mn to 120mn
- Display explicit warning message before ConnectedApp deployment so users don't forget to manually create the connected app

Co-authored-by: Matt Farrell <10377148+MattFaz@users.noreply.github.com>

Fixes https://github.com/hardisgroupcom/sfdx-hardis/issues/822