### PR TITLE
Remove push on org-monitoring

### DIFF
--- a/defaults/monitoring/.github/workflows/org-monitoring.yml
+++ b/defaults/monitoring/.github/workflows/org-monitoring.yml
@@ -18,7 +18,6 @@
 # Doc & support: https://sfdx-hardis.cloudity.com/salesforce-monitoring-home/
 
 on:
-  push:
   # Automatically run every day at midnight
   schedule:
     - cron: "0 0 * * *" # Cron format -> https://crontab.cronhub.io/


### PR DESCRIPTION
The org monitoring github action does not need to run on every push to the repo. I removed this in the example.