### PR TITLE
Fix doubling -d option in hardis:scratch:create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [5.2.2] 2024-10-14
+
+- Fix doubling -d option in hardis:scratch:create
+
 ## [5.2.1] 2024-10-14
 
 - 2 hardis commands: rename `-d` into something else when the short option was available twice on the same command

--- a/src/commands/hardis/scratch/create.ts
+++ b/src/commands/hardis/scratch/create.ts
@@ -61,7 +61,6 @@ export default class ScratchCreate extends SfCommand<any> {
       description: messages.getMessage('forceNewScratch'),
     }),
     pool: Flags.boolean({
-      char: 'd',
       default: false,
       description: 'Creates the scratch org for a scratch org pool',
     }),


### PR DESCRIPTION
Related to https://github.com/cristiand391/oclif-carapace-spec-plugin/issues/1
