### PR TITLE
check git history for .cls files instead of .cls-meta.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [5.8.1] 2024-11-26
+
+- Fix [hardis:org:diagnose:unused-apex-classes](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/unused-apex-classes/): Use .cls file, not cls-meta.xml file to get creation date from git
+
 ## [5.8.0] 2024-11-25
 
 - New monitoring command [hardis:org:diagnose:unused-connected-apps](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/unused-connected-apps/) to detect Connected Apps that are not used anymore and might be disabled or deleted.

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -437,7 +437,7 @@ Issue tracking: https://github.com/forcedotcom/cli/issues/2426`)
     const metadataType = metadataTypes[0];
 
     // Look for matching file in sources
-    const globExpression = `**/${metadataType.directoryName}/**/${packageXmlName}.${metadataType.suffix || ""}-meta.xml`;
+    const globExpression = `**/${metadataType.directoryName}/**/${packageXmlName}.${metadataType.suffix || ""}`;
     for (const packageDirectory of packageDirectories) {
       const sourceFiles = await glob(globExpression, {
         cwd: packageDirectory.fullPath,

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -437,14 +437,19 @@ Issue tracking: https://github.com/forcedotcom/cli/issues/2426`)
     const metadataType = metadataTypes[0];
 
     // Look for matching file in sources
-    const globExpression = `**/${metadataType.directoryName}/**/${packageXmlName}.${metadataType.suffix || ""}`;
+    const globExpressions = [
+      `**/${metadataType.directoryName}/**/${packageXmlName}.${metadataType.suffix || ""}`, // Works for not-xml files
+      `**/${metadataType.directoryName}/**/${packageXmlName}.${metadataType.suffix || ""}-meta.xml` // Works for all XML files
+    ]
     for (const packageDirectory of packageDirectories) {
-      const sourceFiles = await glob(globExpression, {
-        cwd: packageDirectory.fullPath,
-      });
-      if (sourceFiles.length > 0) {
-        const metaFile = path.join(packageDirectory.path, sourceFiles[0]);
-        return metaFile;
+      for (const globExpression of globExpressions) {
+        const sourceFiles = await glob(globExpression, {
+          cwd: packageDirectory.fullPath,
+        });
+        if (sourceFiles.length > 0) {
+          const metaFile = path.join(packageDirectory.path, sourceFiles[0]);
+          return metaFile;
+        }
       }
     }
     return null;


### PR DESCRIPTION
In reference to this Issue: https://github.com/hardisgroupcom/sfdx-hardis/issues/902

Compare `.cls` files when tracking git history instead of `.cls-meta.xml`.

I don't see `findMetaFileFromTypeAndName()` used outside of the `unused-apex-classes` command so I think there is limited impact but let me know if I missed something.