### PR TITLE
Data Import: allow to run in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [5.9.3] 2024-12-12
+
+- [hardis:org:data:import](https://sfdx-hardis.cloudity.com/hardis/org/data/import/): Allow to run the command in production using, by either:
+  - Define **sfdmuCanModify** in your .sfdx-hardis.yml config file. (Example: `sfdmuCanModify: prod-instance.my.salesforce.com`)
+  - Define an environment variable SFDMU_CAN_MODIFY. (Example: `SFDMU_CAN_MODIFY=prod-instance.my.salesforce.com`)
+
 ## [5.9.2] 2024-12-10
 
 - Fallback message in case sfdx-hardis is not able to parse newest SF CLI errors format.

--- a/src/commands/hardis/org/data/import.ts
+++ b/src/commands/hardis/org/data/import.ts
@@ -15,6 +15,11 @@ export default class DataImport extends SfCommand<any> {
 
   public static description = `Import/Load data in an org using a [SFDX Data Loader](https://help.sfdmu.com/) Project
 
+If you need to run this command in a production org, you need to either:
+
+- Define **sfdmuCanModify** in your .sfdx-hardis.yml config file. (Example: \`sfdmuCanModify: prod-instance.my.salesforce.com\`)
+- Define an environment variable SFDMU_CAN_MODIFY. (Example: \`SFDMU_CAN_MODIFY=prod-instance.my.salesforce.com\`)
+
 See article:
 
 [![How to detect bad words in Salesforce records using SFDX Data Loader and sfdx-hardis](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-badwords.jpg)](https://nicolas.vuillamy.fr/how-to-detect-bad-words-in-salesforce-records-using-sfdx-data-loader-and-sfdx-hardis-171db40a9bac)

--- a/src/common/utils/dataUtils.ts
+++ b/src/common/utils/dataUtils.ts
@@ -27,7 +27,8 @@ export async function importData(sfdmuPath: string, commandThis: any, options: a
     ` --targetusername ${targetUsername}` + // Keep targetusername until sfdmu switches to target-org
     ` -p ${sfdmuPath}` +
     ' --noprompt' +
-    (config.sfdmuCanModify ? ` --canmodify ${config.sfdmuCanModify}` : '');
+    // Needed for production orgs
+    (config.sfdmuCanModify || process.env.SFDMU_CAN_MODIFY ? ` --canmodify ${config.sfdmuCanModify || process.env.SFDMU_CAN_MODIFY}` : '');
   /* jscpd:ignore-end */
   elapseStart(`import ${dtl?.full_label}`);
   await execCommand(dataImportCommand, commandThis, {


### PR DESCRIPTION
- [hardis:org:data:import](https://sfdx-hardis.cloudity.com/hardis/org/data/import/): Allow to run the command in production using, by either:
  - Define **sfdmuCanModify** in your .sfdx-hardis.yml config file. (Example: `sfdmuCanModify: prod-instance.my.salesforce.com`)
  - Define an environment variable SFDMU_CAN_MODIFY. (Example: `SFDMU_CAN_MODIFY=prod-instance.my.salesforce.com`)

Fixes https://github.com/hardisgroupcom/sfdx-hardis/issues/921