### PR TITLE
hardis:org:test:apex: Display the number of failed tests in messages and notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- [hardis:org:test:apex](https://sfdx-hardis.cloudity.com/hardis/org/test/apex/): Display the number of failed tests in messages and notifications
+
 ## [5.10.1] 2024-12-12
 
 - Fix sfdx-hardis docker image build by adding coreutils in dependencies

--- a/src/commands/hardis/org/test/apex.ts
+++ b/src/commands/hardis/org/test/apex.ts
@@ -162,8 +162,6 @@ This command is part of [sfdx-hardis Monitoring](${CONSTANTS.DOC_URL_ROOT}/sales
 
   private async processApexTestsFailure() {
     this.notifSeverity = 'error';
-    this.statusMessage = `Org apex tests failure (Outcome: ${this.testRunOutcome})`;
-    this.notifText = `Org apex tests failure in org ${this.orgMarkdown} (Outcome: ${this.testRunOutcome})`;
     const reportDir = await getReportDirectory();
     // Parse log from external file
     const sfReportFile = path.join(reportDir, '/test-result.txt');
@@ -186,6 +184,8 @@ This command is part of [sfdx-hardis Monitoring](${CONSTANTS.DOC_URL_ROOT}/sales
           .join('\n'),
       },
     ];
+    this.statusMessage = `Apex tests failed (${this.failingTestClasses.length}). (Outcome: ${this.testRunOutcome})`;
+    this.notifText = `Apex tests failed (${this.failingTestClasses.length}) in org ${this.orgMarkdown} (Outcome: ${this.testRunOutcome})`;
     console.table(this.failingTestClasses);
   }
 


### PR DESCRIPTION
[hardis:org:test:apex](https://sfdx-hardis.cloudity.com/hardis/org/test/apex/): Display the number of failed tests in messages and notifications
