### PR TITLE
Generate a file hardis-report/apex-coverage-results.json with Apex code coverage details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
   - [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/) (only if `COVERAGE_FORMATTER_JSON=true` environment variable is defined)
   - [hardis:org:test:apex](https://sfdx-hardis.cloudity.com/hardis/org/test/apex/) (always)
   - [SF Cli deployment wrapper commands](https://sfdx-hardis.cloudity.com/salesforce-deployment-assistant-setup/#using-custom-cicd-pipeline)
+- Do not display command output if execCommand has been called with `output: false`
 
 ## [5.14.0] 2025-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [5.14.1] 2025-01-09
+
+- Generate a file **hardis-report/apex-coverage-results.json** with Apex code coverage details for the following commands:
+  - [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/) (only if `COVERAGE_FORMATTER_JSON=true` environment variable is defined)
+  - [hardis:org:test:apex](https://sfdx-hardis.cloudity.com/hardis/org/test/apex/) (always)
+  - [SF Cli deployment wrapper commands](https://sfdx-hardis.cloudity.com/salesforce-deployment-assistant-setup/#using-custom-cicd-pipeline)
+
 ## [5.14.0] 2025-01-09
 
 - Add ability to replace ApiVersion on specific Metadata Types file using `sf hardis:project:audit:apiversion`

--- a/src/commands/hardis/org/test/apex.ts
+++ b/src/commands/hardis/org/test/apex.ts
@@ -8,6 +8,7 @@ import { execCommand, extractRegexMatchesMultipleGroups, uxLog } from '../../../
 import { getNotificationButtons, getOrgMarkdown } from '../../../../common/utils/notifUtils.js';
 import { CONSTANTS, getConfig, getReportDirectory } from '../../../../config/index.js';
 import { NotifProvider, NotifSeverity } from '../../../../common/notifProvider/index.js';
+import { generateApexCoverageOutputFile } from '../../../../common/utils/deployUtils.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sfdx-hardis', 'org');
@@ -145,6 +146,7 @@ This command is part of [sfdx-hardis Monitoring](${CONSTANTS.DOC_URL_ROOT}/sales
       // Parse outcome value from logs with Regex
       this.testRunOutcome = (/Outcome *(.*) */.exec(execCommandRes.stdout + execCommandRes.stderr) || '')[1].trim();
       this.testRunOutputString = execCommandRes.stdout + execCommandRes.stderr;
+      await generateApexCoverageOutputFile(this.testRunOutputString || '');
     } catch (e) {
       // No Apex in the org
       if (
@@ -156,6 +158,7 @@ This command is part of [sfdx-hardis Monitoring](${CONSTANTS.DOC_URL_ROOT}/sales
         // Failing Apex tests
         this.testRunOutputString = (e as Error).message;
         this.testRunOutcome = 'Failed';
+        await generateApexCoverageOutputFile(e);
       }
     }
   }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -648,7 +648,9 @@ export async function execCommand(
     // Display error in red if not json
     if (!command.includes('--json') || options.fail) {
       const strErr = shortenLogLines(`${(e as any).stdout}\n${(e as any).stderr}`);
-      console.error(c.red(strErr));
+      if (output) {
+        console.error(c.red(strErr));
+      }
       (e as Error).message = (e as Error).message += '\n' + strErr;
       // Manage retry if requested
       if (options.retry != null) {

--- a/src/common/utils/wrapUtils.ts
+++ b/src/common/utils/wrapUtils.ts
@@ -2,6 +2,7 @@ import { SfCommand } from "@salesforce/sf-plugins-core";
 import c from "chalk";
 import { execCommand, uxLog } from "./index.js";
 import { analyzeDeployErrorLogs } from "./deployTips.js";
+import { generateApexCoverageOutputFile } from "./deployUtils.js";
 
 export async function wrapSfdxCoreCommand(commandBase: string, argv: string[], commandThis: SfCommand<any>, debug = false): Promise<any> {
   const endArgs = [...argv].map((arg) => {
@@ -44,7 +45,9 @@ export async function wrapSfdxCoreCommand(commandBase: string, argv: string[], c
       fail: true,
     });
     process.exitCode = 0;
+    await generateApexCoverageOutputFile(deployRes);
   } catch (e) {
+    await generateApexCoverageOutputFile(e);
     // Add deployment tips in error logs
     const { errLog } = await analyzeDeployErrorLogs((e as any).stdout + (e as any).stderr, true, { check: endArgs.includes("--checkonly") });
     uxLog(commandThis, c.red(c.bold("Sadly there has been error(s)")));


### PR DESCRIPTION
Related to https://github.com/orgs/hardisgroupcom/discussions/983

- Generate a file **hardis-report/apex-coverage-results.json** with Apex code coverage details for the following commands:
  - [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/) (only if `COVERAGE_FORMATTER_JSON=true` environment varriable is defined)
  - [hardis:org:test:apex](https://sfdx-hardis.cloudity.com/hardis/org/test/apex/) (always)
  - [SF Cli deployment wrapper commands](https://sfdx-hardis.cloudity.com/salesforce-deployment-assistant-setup/#using-custom-cicd-pipeline)

Sample content from a deployment command:

```json
[
  {
    "id": "01p1n00000PPmcpAAD",
    "locationsNotCovered": [
      {
        "column": 0,
        "line": 35,
        "numExecutions": 0,
        "time": -1
      },
      {
        "column": 0,
        "line": 36,
        "numExecutions": 0,
        "time": -1
      },
      {
        "column": 0,
        "line": 55,
        "numExecutions": 0,
        "time": -1
      },
      {
        "column": 0,
        "line": 72,
        "numExecutions": 0,
        "time": -1
      },
      {
        "column": 0,
        "line": 73,
        "numExecutions": 0,
        "time": -1
      },
      {
        "column": 0,
        "line": 74,
        "numExecutions": 0,
        "time": -1
      },
      {
        "column": 0,
        "line": 75,
        "numExecutions": 0,
        "time": -1
      }
    ],
    "name": "TimeSheetHandler",
    "namespace": null,
    "numLocations": 54,
    "numLocationsNotCovered": 7,
    "type": "Class",
    "dmlInfo": [],
    "methodInfo": [],
    "soqlInfo": [],
    "soslInfo": []
  },
  {
    "id": "01q1n000001de5yAAA",
    "name": "OpportuniteAfterInsert",
    "namespace": null,
    "numLocations": 2,
    "numLocationsNotCovered": 0,
    "type": "Trigger",
...
```

Sample content for apex run test command:

```json
[
  {
    "id": "01p07000000CojOAAS",
    "name": "GestionNewMonthBatch",
    "totalLines": 16,
    "lines": {
      "6": 1,
      "7": 1,
      "10": 1,
      "11": 1,
      "14": 0,
      "15": 0,
      "18": 1,
      "19": 1,
      "27": 1,
      "28": 1,
      "30": 1,
      "31": 1,
      "32": 1,
      "33": 1,
      "37": 1,
      "40": 1
    },
    "totalCovered": 14,
    "coveredPercent": 88
  },
  {
    "id": "01p0Y00000OdBu1QAF",
    "name": "DAL",
    "totalLines": 36,
    "lines": {
      "7": 0,
      "8": 0,
...
```

- Fix: Do not display command output if execCommand has been called with `output: false`