### PR TITLE
feat: transform code coverage jsons into cobertura reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,21 @@ FROM python:3.12.8-alpine3.20
 LABEL maintainer="Nicolas VUILLAMY <nicolas.vuillamy@cloudity.com>"
 
 RUN apk add --update --no-cache \
-            coreutils \
-            git \
-            bash \
-            nodejs \
-            npm \
-            # Required for docker
-            docker \
-            openrc \
-            # Required for puppeteer
-            chromium \
-            nss \
-            freetype \
-            harfbuzz \
-            ca-certificates \
-            ttf-freefont
+    coreutils \
+    git \
+    bash \
+    nodejs \
+    npm \
+    # Required for docker
+    docker \
+    openrc \
+    # Required for puppeteer
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont
 
 # Start docker daemon in case mermaid-cli image is used
 RUN rc-update add docker boot && (rc-service docker start || true)
@@ -44,6 +44,7 @@ RUN npm install --no-cache yarn -g && \
     echo 'y' | sf plugins install sfdmu && \
     echo 'y' | sf plugins install sfdx-git-delta && \
     echo 'y' | sf plugins install texei-sfdx-plugin && \
+    echo 'y' | sf plugins install apex-code-coverage-transformer && \
     sf version --verbose --json && \
     rm -rf /root/.npm/_cacache
 

--- a/defaults/ci/.github/workflows/check-deploy.yml
+++ b/defaults/ci/.github/workflows/check-deploy.yml
@@ -47,6 +47,7 @@ jobs:
           sf plugins install @salesforce/plugin-packaging
           echo 'y' | sf plugins install sfdx-hardis
           echo 'y' | sf plugins install sfdx-git-delta
+          echo 'y' | sf plugins install apex-code-coverage-transformer
           sf version --verbose --json
       # Login & check deploy with test classes & code coverage
       - name: Login & Simulate deployment

--- a/defaults/ci/.github/workflows/process-deploy.yml
+++ b/defaults/ci/.github/workflows/process-deploy.yml
@@ -43,6 +43,7 @@ jobs:
           echo 'y' | sf plugins install sfdx-hardis
           # echo 'y' | sf plugins install sfdmu # Disabled while it does not play well with @salesforce/cli
           echo 'y' | sf plugins install sfdx-git-delta
+          echo 'y' | sf plugins install apex-code-coverage-transformer
             sf version --verbose --json
       # Set env branch variable (github.ref_name seems to not work)
       - name: Set env.BRANCH

--- a/defaults/ci/azure-pipelines-checks.yml
+++ b/defaults/ci/azure-pipelines-checks.yml
@@ -57,6 +57,7 @@ jobs:
           sf plugins install @salesforce/plugin-packaging
           echo 'y' | sf plugins install sfdx-hardis
           echo 'y' | sf plugins install sfdx-git-delta
+          echo 'y' | sf plugins install apex-code-coverage-transformer
           sf version --verbose --json
         displayName: "Install SFDX & plugins"
 

--- a/defaults/ci/azure-pipelines-deployment.yml
+++ b/defaults/ci/azure-pipelines-deployment.yml
@@ -53,6 +53,7 @@ jobs:
           echo 'y' | sf plugins install sfdx-hardis
           echo 'y' | sf plugins install sfdmu
           echo 'y' | sf plugins install sfdx-git-delta
+          echo 'y' | sf plugins install apex-code-coverage-transformer
           sf version --verbose --json
         displayName: "Install SFDX & plugins"
 

--- a/defaults/ci/bitbucket-pipelines.yml
+++ b/defaults/ci/bitbucket-pipelines.yml
@@ -26,6 +26,7 @@ pipelines:
                 - sf plugins install @salesforce/plugin-packaging
                 - echo 'y' | sf plugins install sfdx-hardis
                 - echo 'y' | sf plugins install sfdx-git-delta
+                - echo 'y' | sf plugins install apex-code-coverage-transformer
                 - sf version --verbose --json
                 - export BRANCH_NAME=$(echo "$BITBUCKET_PR_DESTINATION_BRANCH" | sed 's/refs\/heads\///')
                 - export CI_COMMIT_REF_NAME=$BRANCH_NAME
@@ -45,6 +46,7 @@ pipelines:
             - sf plugins install @salesforce/plugin-packaging
             - echo 'y' | sf plugins install sfdx-hardis
             - echo 'y' | sf plugins install sfdx-git-delta
+            - echo 'y' | sf plugins install apex-code-coverage-transformer
             - sf version --verbose --json
             - export BRANCH_NAME=$(echo "$BITBUCKET_BRANCH" | sed 's/refs\/heads\///')
             - export CI_COMMIT_REF_NAME=$BRANCH_NAME

--- a/defaults/monitoring/.github/workflows/org-monitoring.yml
+++ b/defaults/monitoring/.github/workflows/org-monitoring.yml
@@ -70,6 +70,7 @@ jobs:
           sf plugins install --force @salesforce/plugin-packaging
           echo 'y' | sf plugins install --force sfdx-hardis
           echo 'y' | sf plugins install --force sfdx-git-delta
+          echo 'y' | sf plugins install apex-code-coverage-transformer
           sf version --verbose --json
       # Login & check deploy with test classes & code coverage
       - name: Login & Retrieve Metadata
@@ -158,6 +159,7 @@ jobs:
           sf plugins install --force @salesforce/plugin-packaging
           echo 'y' | sf plugins install --force sfdx-hardis
           echo 'y' | sf plugins install --force sfdx-git-delta
+          echo 'y' | sf plugins install apex-code-coverage-transformer
           sf version --verbose --json
       # Login & check deploy with test classes & code coverage
       - name: Login & Run apex tests
@@ -298,6 +300,7 @@ jobs:
           sf plugins install --force @salesforce/plugin-packaging
           echo 'y' | sf plugins install --force sfdx-hardis
           echo 'y' | sf plugins install --force sfdx-git-delta
+          echo 'y' | sf plugins install apex-code-coverage-transformer
           sf version --verbose --json
       # Login & check deploy with test classes & code coverage
       - name: Login & Run monitoring checks

--- a/defaults/monitoring/bitbucket-pipelines.yml
+++ b/defaults/monitoring/bitbucket-pipelines.yml
@@ -24,6 +24,7 @@ pipelines:
           - sf plugins install @salesforce/plugin-packaging
           - echo 'y' | sf plugins install sfdx-hardis
           - echo 'y' | sf plugins install sfdx-git-delta
+          - echo 'y' | sf plugins install apex-code-coverage-transformer
           - sf version --verbose --json
           - export BRANCH_NAME=$(echo "$BITBUCKET_BRANCH" | sed 's/refs\/heads\///')
           - export CI_COMMIT_REF_NAME=$BRANCH_NAME
@@ -54,6 +55,7 @@ pipelines:
               - sf plugins install @salesforce/plugin-packaging
               - echo 'y' | sf plugins install sfdx-hardis
               - echo 'y' | sf plugins install sfdx-git-delta
+              - echo 'y' | sf plugins install apex-code-coverage-transformer
               - sf version --verbose --json
               - export BRANCH_NAME=$(echo "$BITBUCKET_BRANCH" | sed 's/refs\/heads\///')
               - export CI_COMMIT_REF_NAME=$BRANCH_NAME
@@ -93,6 +95,7 @@ pipelines:
               - sf plugins install @salesforce/plugin-packaging
               - echo 'y' | sf plugins install sfdx-hardis
               - echo 'y' | sf plugins install sfdx-git-delta
+              - echo 'y' | sf plugins install apex-code-coverage-transformer
               - sf version --verbose --json
               - export BRANCH_NAME=$(echo "$BITBUCKET_BRANCH" | sed 's/refs\/heads\///')
               - export CI_COMMIT_REF_NAME=$BRANCH_NAME


### PR DESCRIPTION
Per https://github.com/orgs/hardisgroupcom/discussions/983, adding my apex-code-coverage-transformer plugin to your newer `generateApexCoverageOutputFile` function.

My plugin needs to be ran in the git folder, preferably root folder, to parse the `sfdx-project.json` file for package directories, thus why I'm importing the get repo root function.

My apex-code-coverage-transformer plugin can create 4 possible output formats at the moment: sonar (for sonarqube), cobertura, clover, lcovonly (`.info` file)

Cobertura is suported by most major platforms like GitHub, GitLab, Jenkins, etc. so I'm putting that one in here, but I'm open to suggestion if you want to add more formats to my plugin, use a different format, etc. I'm currently looking into updating my plugin to allow multiple output formats when running a single command, but that's not in the latest build yet.

Let me know what you think @nvuillam and if this is what you meant for the updates to hardis. 

I kinda went on how you integrated sfdx-git-delta into hardis, but let me know if I did anything wrong. First time!