### PR TITLE
Fixes about doc gen & flow diff PR comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [5.16.3] 2025-01-21
+
+- Truncate the number of flows git diff displayed in Pull Request comments to 30 (override the number using MAX_FLOW_DIFF_TO_SHOW )
+
 ## [5.16.2] 2025-01-21
 
 - Strip XML to save prompts tokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 ## [5.16.3] 2025-01-21
 
 - Truncate the number of flows git diff displayed in Pull Request comments to 30 (override the number using MAX_FLOW_DIFF_TO_SHOW )
+- Keep history link in main flow doc if available and history not recalculated
 
 ## [5.16.2] 2025-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 - Truncate the number of flows git diff displayed in Pull Request comments to 30 (override the number using MAX_FLOW_DIFF_TO_SHOW )
 - Keep history link in main flow doc if available and history not recalculated
+- Remove Flows History mkdocs menu if present from an old sfdx-hardis doc generation
 
 ## [5.16.2] 2025-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 ## [5.16.3] 2025-01-21
 
+- Do not post comments with Flows if there is no real differences
 - Truncate the number of flows git diff displayed in Pull Request comments to 30 (override the number using MAX_FLOW_DIFF_TO_SHOW )
 - Keep history link in main flow doc if available and history not recalculated
 - Remove Flows History mkdocs menu if present from an old sfdx-hardis doc generation

--- a/src/commands/hardis/doc/project2markdown.ts
+++ b/src/commands/hardis/doc/project2markdown.ts
@@ -264,6 +264,9 @@ ${Project2Markdown.htmlInstructions}
         mkdocsYml.nav.push(navMenu);
       }
     }
+    // Remove deprecated Flows History if found
+    mkdocsYml.nav = mkdocsYml.nav.filter(navItem => !navItem["Flows History"]);
+    // Update mkdocs file
     await writeMkDocsFile(mkdocsYmlFile, mkdocsYml);
     uxLog(this, c.cyan(`To generate a HTML WebSite with this documentation with a single command, see instructions at ${CONSTANTS.DOC_URL_ROOT}/hardis/doc/project2markdown/`));
   }

--- a/src/commands/hardis/doc/project2markdown.ts
+++ b/src/commands/hardis/doc/project2markdown.ts
@@ -280,7 +280,7 @@ ${Project2Markdown.htmlInstructions}
         uxLog(this, c.grey(`Skip Data Cloud Object ${objectName}... (use INCLUDE_DATA_CLOUD_DOC=true to enforce it)`));
         continue;
       }
-      uxLog(this, c.grey(`Generating markdown for Object ${objectName}...`));
+      uxLog(this, c.cyan(`Generating markdown for Object ${objectName}...`));
       const objectXml = (await fs.readFile(path.join(this.tempDir, objectFile), "utf8")).toString();
       const objectMdFile = path.join(this.outputMarkdownRoot, "objects", objectName + ".md");
       // Build filtered XML

--- a/src/common/gitProvider/utilsMarkdown.ts
+++ b/src/common/gitProvider/utilsMarkdown.ts
@@ -84,7 +84,7 @@ export function mdTableCell(str: string) {
   return str.replace(/\n/gm, "<br/>".replace(/\|/gm, ""))
 }
 
-export async function flowDiffToMarkdownForPullRequest(flowNames: string[], fromCommit: string, toCommit: string): Promise<any> {
+export async function flowDiffToMarkdownForPullRequest(flowNames: string[], fromCommit: string, toCommit: string, truncatedNb: number = 0): Promise<any> {
   if (flowNames.length === 0) {
     return "";
   }
@@ -110,12 +110,10 @@ export async function flowDiffToMarkdownForPullRequest(flowNames: string[], from
       }
     } catch (e: any) {
       uxLog(this, c.yellow(`[FlowGitDiff] Unable to generate Flow diff for ${flowName}: ${e.message}`));
-      const flowGenErrorMd = `# ${flowName}
-
-Error while generating Flows visual git diff
-`;
-      flowDiffMarkdownList.push({ name: flowName, markdown: flowGenErrorMd });
     }
+  }
+  if (truncatedNb > 0) {
+    flowDiffFilesSummary += `\n\n:warning: _${truncatedNb} Flows have been truncated_\n\n`;
   }
   return {
     markdownSummary: flowDiffFilesSummary,
@@ -124,23 +122,27 @@ Error while generating Flows visual git diff
 }
 
 async function generateDiffMarkdownWithMermaid(fileMetadata: string | null, fromCommit: string, toCommit: string, flowDiffMarkdownList: any, flowName: string) {
-  const { outputDiffMdFile } = await generateFlowVisualGitDiff(fileMetadata, fromCommit, toCommit, { mermaidMd: true, svgMd: false, pngMd: false, debug: false });
-  if (outputDiffMdFile) {
+  const { outputDiffMdFile, hasFlowDiffs } = await generateFlowVisualGitDiff(fileMetadata, fromCommit, toCommit, { mermaidMd: true, svgMd: false, pngMd: false, debug: false });
+  if (outputDiffMdFile && hasFlowDiffs) {
     const flowDiffMarkdownMermaid = await fs.readFile(outputDiffMdFile.replace(".md", ".mermaid.md"), "utf8");
     flowDiffMarkdownList.push({ name: flowName, markdown: flowDiffMarkdownMermaid, markdownFile: outputDiffMdFile });
   }
 }
 
 async function generateDiffMarkdownWithSvg(fileMetadata: string | null, fromCommit: string, toCommit: string, flowDiffMarkdownList: any, flowName: string) {
-  const { outputDiffMdFile } = await generateFlowVisualGitDiff(fileMetadata, fromCommit, toCommit, { mermaidMd: true, svgMd: true, pngMd: false, debug: false });
-  const flowDiffMarkdownWithSvg = await fs.readFile(outputDiffMdFile, "utf8");
-  flowDiffMarkdownList.push({ name: flowName, markdown: flowDiffMarkdownWithSvg, markdownFile: outputDiffMdFile });
+  const { outputDiffMdFile, hasFlowDiffs } = await generateFlowVisualGitDiff(fileMetadata, fromCommit, toCommit, { mermaidMd: true, svgMd: true, pngMd: false, debug: false });
+  if (outputDiffMdFile && hasFlowDiffs && fs.existsSync(outputDiffMdFile)) {
+    const flowDiffMarkdownWithSvg = await fs.readFile(outputDiffMdFile, "utf8");
+    flowDiffMarkdownList.push({ name: flowName, markdown: flowDiffMarkdownWithSvg, markdownFile: outputDiffMdFile });
+  }
 }
 
 async function generateDiffMarkdownWithPng(fileMetadata: string | null, fromCommit: string, toCommit: string, flowDiffMarkdownList: any, flowName: string) {
-  const { outputDiffMdFile } = await generateFlowVisualGitDiff(fileMetadata, fromCommit, toCommit, { mermaidMd: true, svgMd: false, pngMd: true, debug: false });
-  const flowDiffMarkdownWithPng = await fs.readFile(outputDiffMdFile, "utf8");
-  flowDiffMarkdownList.push({ name: flowName, markdown: flowDiffMarkdownWithPng, markdownFile: outputDiffMdFile });
+  const { outputDiffMdFile, hasFlowDiffs } = await generateFlowVisualGitDiff(fileMetadata, fromCommit, toCommit, { mermaidMd: true, svgMd: false, pngMd: true, debug: false });
+  if (outputDiffMdFile && hasFlowDiffs && fs.existsSync(outputDiffMdFile)) {
+    const flowDiffMarkdownWithPng = await fs.readFile(outputDiffMdFile, "utf8");
+    flowDiffMarkdownList.push({ name: flowName, markdown: flowDiffMarkdownWithPng, markdownFile: outputDiffMdFile });
+  }
 }
 
 function getAiPromptResponseMarkdown(title, message) {

--- a/src/common/utils/gitUtils.ts
+++ b/src/common/utils/gitUtils.ts
@@ -199,13 +199,15 @@ export async function computeCommitsSummary(checkOnly, pullRequestInfo: any) {
     }
     const flowListUnique = [...new Set(flowList)].sort();
     // Truncate flows to the only 30 ones, to avoid floodind the pull request comments
+    let truncatedNb = 0;
     const maxFlowsToShow = parseInt(process.env?.MAX_FLOW_DIFF_TO_SHOW || "30");
     if (flowListUnique.length > maxFlowsToShow) {
+      truncatedNb = flowListUnique.length - maxFlowsToShow;
       flowListUnique.splice(maxFlowsToShow, flowListUnique.length - maxFlowsToShow);
       uxLog(this, c.yellow(`[FlowGitDiff] Truncated flow list to 30 flows to avoid flooding Pull Request comments`));
       uxLog(this, c.yellow(`[FlowGitDiff] If you want to see the diff of truncated flows, use VsCode SFDX Hardis extension :)`));
     }
-    flowDiffMarkdown = await flowDiffToMarkdownForPullRequest(flowListUnique, previousTargetBranchCommit, (logResults.at(-1) || logResults[0]).hash);
+    flowDiffMarkdown = await flowDiffToMarkdownForPullRequest(flowListUnique, previousTargetBranchCommit, (logResults.at(-1) || logResults[0]).hash, truncatedNb);
   }
 
   return {

--- a/src/common/utils/gitUtils.ts
+++ b/src/common/utils/gitUtils.ts
@@ -198,7 +198,7 @@ export async function computeCommitsSummary(checkOnly, pullRequestInfo: any) {
       }
     }
     const flowListUnique = [...new Set(flowList)].sort();
-    // Truncate flows to the only 30 ones, to avoid floodind the pull request comments
+    // Truncate flows to the only 30 ones, to avoid flooding the pull request comments
     let truncatedNb = 0;
     const maxFlowsToShow = parseInt(process.env?.MAX_FLOW_DIFF_TO_SHOW || "30");
     if (flowListUnique.length > maxFlowsToShow) {

--- a/src/common/utils/gitUtils.ts
+++ b/src/common/utils/gitUtils.ts
@@ -198,6 +198,13 @@ export async function computeCommitsSummary(checkOnly, pullRequestInfo: any) {
       }
     }
     const flowListUnique = [...new Set(flowList)].sort();
+    // Truncate flows to the only 30 ones, to avoid floodind the pull request comments
+    const maxFlowsToShow = parseInt(process.env?.MAX_FLOW_DIFF_TO_SHOW || "30");
+    if (flowListUnique.length > maxFlowsToShow) {
+      flowListUnique.splice(maxFlowsToShow, flowListUnique.length - maxFlowsToShow);
+      uxLog(this, c.yellow(`[FlowGitDiff] Truncated flow list to 30 flows to avoid flooding Pull Request comments`));
+      uxLog(this, c.yellow(`[FlowGitDiff] If you want to see the diff of truncated flows, use VsCode SFDX Hardis extension :)`));
+    }
     flowDiffMarkdown = await flowDiffToMarkdownForPullRequest(flowListUnique, previousTargetBranchCommit, (logResults.at(-1) || logResults[0]).hash);
   }
 

--- a/src/common/utils/mermaidUtils.ts
+++ b/src/common/utils/mermaidUtils.ts
@@ -214,7 +214,7 @@ export async function generateFlowVisualGitDiff(flowFile, commitBefore: string, 
   }
 
   const flowDiffs = Diff.diffLines(mermaidMdBefore, mermaidMdAfter);
-  result.hasFlowDiffs = flowDiffs.some(line => line.added || line.removed);
+  result.hasFlowDiffs = flowDiffs.some((line) => (line.added || line.removed) && line.value.trim() !== "");
   result.diffLines = flowDiffs.filter(line => line.added || line.removed);
 
   const mixedLines: any[] = [];

--- a/src/common/utils/mermaidUtils.ts
+++ b/src/common/utils/mermaidUtils.ts
@@ -44,6 +44,16 @@ export async function generateFlowMarkdownFile(flowName: string, flowXml: string
     if (options.describeWithAi) {
       flowMarkdownDoc = await completeWithAiDescription(flowMarkdownDoc, flowXml, flowName);
     }
+
+    // Add link to history flow doc 
+    const historyFlowDoc = path.join("docs", "flows", flowName + "-history.md");
+    if (fs.existsSync(historyFlowDoc)) {
+      const historyLink = `[(_View History_)](${flowName + "-history.md"})`;
+      if (flowMarkdownDoc.includes("## Flow Diagram") && !flowMarkdownDoc.includes(historyLink)) {
+        flowMarkdownDoc = flowMarkdownDoc.replace("## Flow Diagram", `## Flow Diagram ${historyLink}`);
+      }
+    }
+
     await fs.writeFile(outputFlowMdFile, flowMarkdownDoc);
     uxLog(this, c.grey(`Written ${flowName} documentation in ${outputFlowMdFile}`));
     return true;


### PR DESCRIPTION
- Do not post comments with Flows if there is no real differences
- Truncate the number of flows git diff displayed in Pull Request comments to 30 (override the number using MAX_FLOW_DIFF_TO_SHOW )
- Keep history link in main flow doc if available and history not recalculated
- Remove Flows History mkdocs menu if present from an old sfdx-hardis doc generation