### PR TITLE
fix: delta after merge is not working as expected

### DIFF
--- a/src/commands/hardis/project/deploy/smart.ts
+++ b/src/commands/hardis/project/deploy/smart.ts
@@ -383,8 +383,8 @@ If testlevel=RunRepositoryTests, can contain a regular expression to keep only c
       this.delta = true;
       this.smartDeployOptions.delta = true;
       // Define delta deployment depending on context
-      let fromCommit = 'HEAD';
-      let toCommit = 'HEAD^';
+      let fromCommit = 'HEAD^';
+      let toCommit = 'HEAD';
       if (this.checkOnly) {
         // In deployment check context
         const prInfo = await GitProvider.getPullRequestInfo();

--- a/src/commands/hardis/project/deploy/smart.ts
+++ b/src/commands/hardis/project/deploy/smart.ts
@@ -601,7 +601,7 @@ If testlevel=RunRepositoryTests, can contain a regular expression to keep only c
       uxLog(
         this,
         c.yellow(
-          `[DeltaDeployment] It is recommended to use delta deployments for merges between major branches, use this config at your own responsibility`
+          `[DeltaDeployment] It is not recommended to use delta deployments for merges between major branches, use this config at your own responsibility`
         )
       );
       return true;


### PR DESCRIPTION
Fixes an issue where delta deployment after merging a PR isn't calculated correctly.

The issues seems to be the orientation of the delta calculation from "HEAD" to "HEAD^", generating destructive changes if the metadata is new.

inverting the references fixes the issue.

> Thus, the way sfdx-git-delta is used while deploying, it will only generate the delta with the latest commit.
> A temporary workaround would be to activate Squash Commits in the merge request.