### PR TITLE
Allow wildcards in package-skip-items.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [5.26.0] 2025-04-11
+
+- [hardis:org:monitor:backup](https://sfdx-hardis.cloudity.com/hardis/org/monitor/backup/): Allow wildcards in package-skip-items.xml (examples: `pi__*` , `*__dlm` , or `prefix*suffix` )
+
 ## [5.25.2] 2025-04-10
 
 - Display JIRA and Azure Boards issue labels in Pull Request comments

--- a/docs/salesforce-monitoring-config-home.md
+++ b/docs/salesforce-monitoring-config-home.md
@@ -107,6 +107,10 @@ If there are more than 10000 items, your monitoring job will crash.
 
 In that case, you can:
 
-- Single Branch scope: Manually update file `manifest/package-skip-items.xml` in the branch corresponding to an org, then commit and push
+- Single Branch scope: Manually update file `manifest/package-skip-items.xml` in the branch corresponding to an org, then commit and push. It works with:
+  - Full wildcard (`<members>*</members>`)
+  - Named metadata (`<members>Account.Name</members>`)
+  - Partial wildcards names (`<members>pi__*</members>` , `<members>*__dlm</members>` , or `<members>prefix*suffix</members>`)
+
 - All branches scope: Define CI/CD env var **MONITORING_BACKUP_SKIP_METADATA_TYPES** with the list of additional metadata types you want to skip
   - example: \`MONITORING_BACKUP_SKIP_METADATA_TYPES=CustomLabel,StaticResource,Translation\`

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -36,6 +36,8 @@ You can remove more metadata types from backup, especially in case you have too 
 
 - Manual update of \`manifest/package-skip-items.xml\` config file (then commit & push in the same branch)
 
+  - Works with full wildcard (\`<members>*</members>\`) , named metadata (\`<members>Account.Name</members>\`) or partial wildcards names (\`<members>pi__*</members>\` , \`<members>*__dlm</members>\` , or \`<members>prefix*suffix</members>\`)
+
 - Environment variable MONITORING_BACKUP_SKIP_METADATA_TYPES (example: \`MONITORING_BACKUP_SKIP_METADATA_TYPES=CustomLabel,StaticResource,Translation\`): that will be applied to all monitoring branches.
 
 ## Full mode

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -911,7 +911,7 @@ function shouldRetainMember(destructiveMembers: string[], member: string) {
     if (destructiveMember === member) {
       return true;
     }
-    // Handle cases wild wildcards, like copado__* , *__dlm , or begin*end
+    // Handle cases wild wildcards, like pi__* , *__dlm , or begin*end
     if (destructiveMember.includes('*')) {
       const regex = new RegExp(destructiveMember.replace(/\*/g, '.*'));
       if (regex.test(member)) {


### PR DESCRIPTION
  - Full wildcard (`<members>*</members>`)
  - Named metadata (`<members>Account.Name</members>`)
  - Partial wildcards names (`<members>pi__*</members>` , `<members>*__dlm</members>` , or `<members>prefix*suffix</members>`)

Fixes https://github.com/hardisgroupcom/sfdx-hardis/issues/1154
