### PR TITLE
Optimize member sorting during manifest generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,12 @@
 # Changelog
 
-## 5.37.2] 2025-05-27
-
-- Defer the `sortCrossPlatform` operation for member lists until after all elements for a specific metadata type have been collected. Sorting is now performed only once per type improving the overall performance
-
 ## [beta] (master)
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
 - New command [hardis:misc:servicenow-report](https://sfdx-hardis.cloudity.com/hardis/misc/servicenow-report/) to generate reports crossing data from a Salesforce object and related entries in ServiceNow
 - Automatically open Excel report files when possible (disable with env var `NO_OPEN=true`)
+- Defer the `sortCrossPlatform` operation for member lists until after all elements for a specific metadata type have been collected. Sorting is now performed only once per type improving the overall performance
 
 ## [5.37.1] 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.37.2] 2025-05-27
+
+- Defer the `sortCrossPlatform` operation for member lists until after all elements for a specific metadata type have been collected. Sorting is now performed only once per type improving the overall performance
+
 ## [beta] (master)
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -1127,7 +1127,7 @@ export async function buildOrgManifest(
         // Add member in existing types
         const members = matchTypes[0].members || [];
         members.push(element.fullName);
-        matchTypes[0].members = sortCrossPlatform(members);
+        matchTypes[0].members = members;
         parsedPackageXml.Package.types = parsedPackageXml.Package.types.map((type) =>
           type.name[0] === matchTypes[0].name ? matchTypes[0] : type
         );
@@ -1140,7 +1140,13 @@ export async function buildOrgManifest(
         parsedPackageXml.Package.types.push(newType);
       }
     }
-
+    // Sort members for each type once after the loop
+    for (const type of parsedPackageXml.Package.types) {
+      if (type.members && Array.isArray(type.members)) {
+        type.members = sortCrossPlatform(type.members);
+      }
+    }
+  
     // Complete with missing WaveDataflow Ids build from WaveRecipe Ids
     const waveRecipeTypeList = parsedPackageXml.Package.types.filter((type) => type.name[0] === 'WaveRecipe');
     if (waveRecipeTypeList.length === 1) {

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -1140,10 +1140,12 @@ export async function buildOrgManifest(
         parsedPackageXml.Package.types.push(newType);
       }
     }
-    // Sort members for each type once after the loop
-    for (const type of parsedPackageXml.Package.types) {
-      if (type.members && Array.isArray(type.members)) {
-        type.members = sortCrossPlatform(type.members);
+    // Sort members only for the types that were potentially modified
+    for (const mdType of mdTypes) { // mdTypes is [{ type: 'ListView' }, { type: 'CustomLabel' }]
+      const typeName = mdType.type;
+      const matchedType = parsedPackageXml.Package.types.find(t => t.name[0] === typeName);
+      if (matchedType && matchedType.members && Array.isArray(matchedType.members)) {
+        matchedType.members = sortCrossPlatform(matchedType.members);
       }
     }
   


### PR DESCRIPTION
Previously, when generating the org manifest, the members list for metadata types (e.g., ListView, CustomLabel) was sorted upon each individual member addition within the main processing loop. This caused redundant sorting operations, significantly degrading performance—especially in Salesforce orgs with a large number of components. In one recent real-world scenario, this step alone took over 60 minutes to complete.

This commit refactors the logic in buildOrgManifest to:

1. Defer sorting (sortCrossPlatform) until after all elements for a metadata type have been collected, thus performing sorting only once per type.

With these changes, the sorting process now completes in just a few moments, drastically improving the manifest generation speed and efficiency.