### PR TITLE
Generates documentation pages from README + add pages for events & videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ _See Dreamforce presentation_
 
 ## Installation
 
+<!-- installation.md start -->
+
 ### With IDE
 
 You can install [Visual Studio Code](https://code.visualstudio.com/) extension [VsCode SFDX Hardis](https://marketplace.visualstudio.com/items?itemName=NicolasVuillamy.vscode-sfdx-hardis)
@@ -99,13 +101,79 @@ You can use sfdx-hardis docker images to run in CI
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
+<!-- installation.md end -->
+
 ## Usage
 
 ```sh-session
 sf hardis:<COMMAND> <OPTIONS>
 ```
 
-## Articles
+## Events
+
+<!-- events.md start -->
+
+### London's Calling '25, London
+
+Auto-generate your SF project Documentation site with open-source and Agentforce
+
+![image](https://github.com/user-attachments/assets/9b99120c-b660-4f67-b734-793148ac9d00)
+
+### Czech Dreamin '25, Prague
+
+Auto-generate your SF project Documentation site with open-source and Agentfforce, with [Mariia Pyvovarchuk](https://www.linkedin.com/in/mpyvo/)
+
+![Czech Dreamin 2025](https://github.com/user-attachments/assets/fa7b7f12-6d6a-437c-badd-20a626bb2163)
+
+### Trailblazer Admin Group '25, Lyon
+
+Techs for Admins: Afterwork Salesforce Inspector Reloaded & sfdx-hardis, with Thomas Prouvot
+
+![](https://github.com/user-attachments/assets/90621fe0-6527-4a34-8a0b-c14bd6d21cbd)
+
+### Dreamforce 2024, San Francisco
+
+[Save the Day by Monitoring Your Org with Open-Source Tools](https://reg.salesforce.com/flow/plus/df24/sessioncatalog/page/catalog/session/1718915808069001Q7HH), with Olga Shirikova
+
+[![Dreamforce 2024 Video](https://img.youtube.com/vi/NxiLiYeo11A/0.jpg)](https://www.youtube.com/watch?v=NxiLiYeo11A)
+
+### Wir Sind Ohana '24, Berlin
+
+Automate the Monitoring of your Salesforce orgs with open-source tools only!, with Yosra Saidani
+
+[![Wir Sind Ohana Video](https://img.youtube.com/vi/xGbT6at7RZ0/0.jpg)](https://www.youtube.com/watch?v=xGbT6at7RZ0)
+
+### Polish Dreamin '24, Wroclaw, Poland
+
+[Easy and complete Salesforce CI/CD with open-source only!](https://coffeeforce.pl/dreamin/speaker/nicolas-vuillamy/), with Wojciech Suwiński
+
+![Polish Dreamin 2024](https://github.com/nvuillam/nvuillam/assets/17500430/e843cc08-bf8a-452d-b7f0-c64a314f1b60)
+
+### French Touch Dreamin '23, Paris
+
+[Automate the Monitoring of your Salesforce orgs with open-source tools only!](https://frenchtouchdreamin.com/index.php/schedule/), with Maxime Guenego
+
+![French Touch Dreamin 2023](https://github.com/nvuillam/nvuillam/assets/17500430/8a2e1bbf-3402-4929-966d-5f99cb13cd29)
+
+### Dreamforce 2023, San Francisco
+
+[Easy Salesforce CI/CD with open-source and clicks only thanks to sfdx-hardis!](https://reg.salesforce.com/flow/plus/df23/sessioncatalog/page/catalog/session/1684196389783001OqEl), with Jean-Pierre Rizzi
+
+[![Dreamforce 2023 Video](https://img.youtube.com/vi/o0Mm9F07UFs/0.jpg)](https://www.youtube.com/watch?v=o0Mm9F07UFs)
+
+### Yeur Dreamin' 2023, Brussels
+
+An easy and complete Salesforce CI/CD release management with open-source only !, with Angélique Picoreau
+
+[![image](https://github.com/nvuillam/nvuillam/assets/17500430/6470df20-7449-444b-a0a5-7dc22f5f6188)](https://www.linkedin.com/posts/nicolas-vuillamy_cicd-opensource-trailblazercommunity-activity-7076859027321704448-F1g-?utm_source=share&utm_medium=member_desktop)
+
+<!-- events.md end -->
+
+## Articles & Videos
+
+<!-- articles-videos.md start -->
+
+### Web Articles
 
 Here are some articles about [sfdx-hardis](https://sfdx-hardis.cloudity.com/)
 
@@ -128,7 +196,113 @@ Here are some articles about [sfdx-hardis](https://sfdx-hardis.cloudity.com/)
   - [Exporter en masse les fichiers d’une org Salesforce](https://leblog.hardis-group.com/portfolio/exporter-en-masse-les-fichiers-dune-org-salesforce/)
   - [Suspendre l’accès aux utilisateurs lors d’une mise en production Salesforce](https://leblog.hardis-group.com/portfolio/suspendre-lacces-aux-utilisateurs-lors-dune-mise-en-production-salesforce/)
 
+### Recorded Conferences
+
+#### Dreamforce Sessions
+
+- Dreamforce 2024 - Save the Day by Monitoring Your Org with Open-Source Tools (with Olga Shirikova)
+
+[![Dreamforce 2024: Save the Day by Monitoring Your Org with Open-Source Tools](https://img.youtube.com/vi/NxiLiYeo11A/0.jpg)](https://www.youtube.com/watch?v=NxiLiYeo11A){target=blank}
+
+- Dreamforce 2023 - Easy Salesforce CI/CD with open-source and clicks only thanks to sfdx-hardis! (with Jean-Pierre Rizzi)
+
+[![Dreamforce 2023: Easy Salesforce CI/CD with open-source](https://img.youtube.com/vi/o0Mm9F07UFs/0.jpg)](https://www.youtube.com/watch?v=o0Mm9F07UFs){target=blank}
+
+#### Community Events
+
+- Wir Sind Ohana 2024 - Automate the Monitoring of your Salesforce orgs with open-source tools only! (with Yosra Saidani)
+
+[![Wir Sind Ohana 2024: Automate Monitoring with Open-Source](https://img.youtube.com/vi/xGbT6at7RZ0/0.jpg)](https://www.youtube.com/watch?v=xGbT6at7RZ0){target=blank}
+
+### Podcasts
+
+- Apex Hours 2025 - Org monitoring with Grafana + AI generated doc
+
+[![Apex Hours 2025: Org monitoring with Grafana + AI generated doc](https://img.youtube.com/vi/oDaCh66pRcI/0.jpg)](https://www.youtube.com/watch?v=oDaCh66pRcI){target=blank}
+
+- Salesforce Way Podcast #102 - Sfdx-hardis with Nicolas Vuillamy
+
+[![Salesforce Way Podcast: Sfdx-hardis](https://img.youtube.com/vi/sfdx-hardis/0.jpg)](https://salesforceway.com/podcast/sfdx-hardis/){target=blank}
+
+- Salesforce Developers Podcast Episode 182: SFDX-Hardis with Nicolas Vuillamy
+
+[![Salesforce Developers Podcast](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-sfdev.jpg)](https://developer.salesforce.com/podcast/2023/06/sfdx){target=blank}
+
+### sfdx-hardis Usage
+
+#### Features Overview
+
+- sfdx-hardis 2025 new features overview
+
+[![sfdx-hardis 2025 new features](https://img.youtube.com/vi/JRKH5COUVQ0/0.jpg)](https://youtu.be/JRKH5COUVQ0){target=blank}
+
+- SFDX-HARDIS – A demo with Nicolas Vuillamy from Cloudity
+
+[![SalesforceDevOps.net Demo](https://img.youtube.com/vi/qP6MaZUGzik/0.jpg)](https://www.youtube.com/watch?v=qP6MaZUGzik){target=blank}
+
+#### Installation & Setup
+
+- Complete installation tutorial for sfdx-hardis - [📖 Documentation](https://sfdx-hardis.cloudity.com/installation/)
+
+[![Installation Tutorial](https://img.youtube.com/vi/LA8m-t7CjHA/0.jpg)](https://www.youtube.com/watch?v=LA8m-t7CjHA){target=blank}
+
+#### CI/CD Workflows
+
+- Complete CI/CD workflow for Salesforce projects - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-home/)
+
+[![Dreamforce demo video: Easy Salesforce CI/CD with sdfx-hardis and open-source only !](https://img.youtube.com/vi/zEYqTd2txU4/0.jpg)](https://www.youtube.com/watch?v=zEYqTd2txU4){target=blank}
+
+- How to start a new task in sandbox - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-create-new-task/)
+
+[![Create New Task](https://img.youtube.com/vi/WOqssZwjPhw/0.jpg)](https://www.youtube.com/watch?v=WOqssZwjPhw){target=blank}
+
+- How to commit updates and create merge requests - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-publish-task/)
+
+[![Publish Task Tutorial](https://img.youtube.com/vi/Ik6whtflmfY/0.jpg)](https://www.youtube.com/watch?v=Ik6whtflmfY){target=blank}
+
+- How to resolve git merge conflicts in Visual Studio Code - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-validate-merge-request/)
+
+[![Merge Conflicts Resolution](https://img.youtube.com/vi/lz5OuKzvadQ/0.jpg)](https://www.youtube.com/watch?v=lz5OuKzvadQ){target=blank}
+
+- How to install packages in your org - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-work-on-task-install-packages/)
+
+[![Install Packages Tutorial](https://img.youtube.com/vi/5-MgqoSLUls/0.jpg)](https://www.youtube.com/watch?v=5-MgqoSLUls){target=blank}
+
+- Configure CI server authentication to Salesforce orgs - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-auth/)
+
+[![Configure CI Authentication](https://img.youtube.com/vi/OzREUu5utVI/0.jpg)](https://www.youtube.com/watch?v=OzREUu5utVI){target=blank}
+
+#### Monitoring
+
+- How to configure monitoring for your Salesforce org - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-monitoring-config-home/)
+
+[![Org Monitoring Setup](https://img.youtube.com/vi/bcVdN0XItSc/0.jpg)](https://www.youtube.com/watch?v=bcVdN0XItSc){target=blank}
+
+#### Integrations
+
+- Configure Slack integration for deployment notifications - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-integration-slack/)
+
+[![Slack Integration](https://img.youtube.com/vi/se292ABGUmI/0.jpg)](https://www.youtube.com/watch?v=se292ABGUmI){target=blank}
+
+- How to create a Personal Access Token in GitLab - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-clone-repository/)
+
+[![GitLab Personal Access Token](https://img.youtube.com/vi/9y5VmmYHuIg/0.jpg)](https://www.youtube.com/watch?v=9y5VmmYHuIg){target=blank}
+
+#### Documentation
+
+- How to generate AI-enhanced Salesforce project documentation - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-project-doc-generate/)
+
+[![Generate Project Documentation](https://img.youtube.com/vi/ZrVPN3jp1Ac/0.jpg)](https://www.youtube.com/watch?v=ZrVPN3jp1Ac){target=blank}
+
+- Host your documentation on Cloudflare free tier - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-project-doc-cloudflare/)
+
+[![Cloudflare Doc Hosting Setup](https://img.youtube.com/vi/AUipbKjgsDI/0.jpg)](https://www.youtube.com/watch?v=AUipbKjgsDI){target=blank}
+
+<!-- articles-videos.md end -->
+
 ## Contributing
+
+<!-- contributing.md start -->
 
 Everyone is welcome to contribute to sfdx-hardis (even juniors: we'll assist you !)
 
@@ -143,6 +317,8 @@ Everyone is welcome to contribute to sfdx-hardis (even juniors: we'll assist you
   - Run `tsc --watch` to transpile typescript into js everytime you update a TS file
 - Debug commands using `NODE_OPTIONS=--inspect-brk sf hardis:somecommand -someparameter somevalue`
 
+<!-- contributing.md end -->
+
 ## Dependencies
 
 **sfdx-hardis** partially relies on the following SFDX Open-Source packages
@@ -153,9 +329,29 @@ Everyone is welcome to contribute to sfdx-hardis (even juniors: we'll assist you
 
 ## Contributors
 
+<!-- contributors.md start -->
+
+### Organization
+
+sfdx-hardis is primarely led by Nicolas Vuillamy & [Cloudity](https://www.cloudity.com/), but has many external contributors that we cant thank enough !
+
+### Pull Requests Authors
+
 <a href="https://github.com/hardisgroupcom/sfdx-hardis/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=hardisgroupcom/sfdx-hardis" />
 </a>
+
+### Special Thanks
+
+- [Roman Hentschke](https://www.linkedin.com/in/derroman/), for building the BitBucket CI/CD integration
+- [Leo Jokinen](https://www.linkedin.com/in/leojokinen/), for building the GitHub CI/CD integration
+- [Mariia Pyvovarchuk](https://www.linkedin.com/in/mpyvo/), for her work about generating automations documentation
+- [Matheus Delazeri](https://www.linkedin.com/in/matheus-delazeri-souza/), for the PDF output of documentation
+- [Taha Basri](https://www.linkedin.com/in/tahabasri/), for his work about generating documentation of LWC
+- [Anush Poudel](https://www.linkedin.com/in/anushpoudel/), for integrating sfdx-hardis with multiple LLMs using langchainJs
+- [Sebastien Colladon](https://www.linkedin.com/in/sebastien-colladon/), for providing sfdx-git-delta which is highly used within sfdx-hardis
+
+<!-- contributors.md end -->
 
 ## Commands
 

--- a/build.cjs
+++ b/build.cjs
@@ -6,6 +6,7 @@ const yaml = require("js-yaml");
 class SfdxHardisBuilder {
   async run() {
     console.log("Start additional building of sfdx-hardis repository...");
+    await this.generatePagesFromReadme();
     await this.buildDeployTipsDoc();
     await this.buildPromptTemplatesDocs();
     this.truncateReadme();
@@ -190,6 +191,25 @@ class SfdxHardisBuilder {
     }
 
     console.log("Prompt templates and variables documentation generated");
+  }
+
+  // Read README.md 
+  // Find sub-content between HTML comments <!-- PAGENAME.md start --> and <!-- PAGENAME.md end --> (example: <!-- contributing.md start --> & <!-- contributing.md end -->)
+  // For each start & and found, generate a new markdown file in docs/ folder with the name PAGENAME.md (example: contributing.md)
+  async generatePagesFromReadme() {
+    console.log("Generating pages from README.md...");
+    const readmeFile = "./README.md";
+    const readmeContent = fs.readFileSync(readmeFile, "utf-8");
+    const regex = /<!-- (.+?) start -->([\s\S]*?)<!-- \1 end -->/g;
+    let match;
+    while ((match = regex.exec(readmeContent)) !== null) {
+      const pageName = match[1].trim();
+      const pageContent = match[2].trim();
+      const pageFile = `./docs/${pageName}`;
+      fs.writeFileSync(pageFile, pageContent + "\n");
+      console.log(`Generated ${pageFile}`);
+    }
+    console.log("All pages generated from README.md");
   }
 
   truncateReadme() {

--- a/docs/articles-videos.md
+++ b/docs/articles-videos.md
@@ -1,0 +1,124 @@
+### Web Articles
+
+Here are some articles about [sfdx-hardis](https://sfdx-hardis.cloudity.com/)
+
+- English
+
+[![Conga Deployment Cheat Sheet](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-conga-banner.jpg)](https://nicolas.vuillamy.fr/how-to-deploy-conga-composer-configuration-using-salesforce-cli-plugins-c2899641f36b)
+[![Questions/Answers](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-questions-answers.jpg)](https://nicolas.vuillamy.fr/what-devops-experts-want-to-know-about-salesforce-ci-cd-with-sfdx-hardis-q-a-1f412db34476)
+[![Salesforce Developers Podcast](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-sfdev.jpg)](https://developer.salesforce.com/podcast/2023/06/sfdx)
+[![sfdx-hardis: A release management tool for open-source](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-cicd-salesforcedevopsnet.jpg)](https://salesforcedevops.net/index.php/2023/03/01/sfdx-hardis-open-source-salesforce-release-management/)
+[![Assisted solving of Salesforce deployments errors](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-deployment-errors.jpg)](https://nicolas.vuillamy.fr/assisted-solving-of-salesforce-deployments-errors-47f3666a9ed0)
+[![Handle Salesforce API versions Deprecation like a pro](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-deprecated-api.jpg)](https://nicolas.vuillamy.fr/handle-salesforce-api-versions-deprecation-like-a-pro-335065f52238)
+[![How to mass download notes and attachments files from a Salesforce org](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-mass-download.jpg)](https://nicolas.vuillamy.fr/how-to-mass-download-notes-and-attachments-files-from-a-salesforce-org-83a028824afd)
+[![How to freeze / unfreeze users during a Salesforce deployment](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-freeze.jpg)](https://medium.com/@dimitrimonge/freeze-unfreeze-users-during-salesforce-deployment-8a1488bf8dd3)
+[![How to detect bad words in Salesforce records using SFDX Data Loader and sfdx-hardis](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-badwords.jpg)](https://nicolas.vuillamy.fr/how-to-detect-bad-words-in-salesforce-records-using-sfdx-data-loader-and-sfdx-hardis-171db40a9bac)
+[![Reactivate all the sandbox users with .invalid emails in 3 clicks](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-invalid-email.jpg)](https://nicolas.vuillamy.fr/reactivate-all-the-sandbox-users-with-invalid-emails-in-3-clicks-2265af4e3a3d)
+[![Invalid scope:Mine, not allowed ? Deploy your ListViews anyway !](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-invalid-scope-mine.jpg)](https://nicolas.vuillamy.fr/invalid-scope-mine-not-allowed-deploy-your-listviews-anyway-443aceca8ac7)
+
+- French
+  - [Versions d'API Salesforce décommissionnées: Que faire ?](https://leblog.hardis-group.com/portfolio/versions-dapi-salesforce-decommissionnees-que-faire/)
+  - [Exporter en masse les fichiers d’une org Salesforce](https://leblog.hardis-group.com/portfolio/exporter-en-masse-les-fichiers-dune-org-salesforce/)
+  - [Suspendre l’accès aux utilisateurs lors d’une mise en production Salesforce](https://leblog.hardis-group.com/portfolio/suspendre-lacces-aux-utilisateurs-lors-dune-mise-en-production-salesforce/)
+
+### Recorded Conferences
+
+#### Dreamforce Sessions
+
+- Dreamforce 2024 - Save the Day by Monitoring Your Org with Open-Source Tools (with Olga Shirikova)
+
+[![Dreamforce 2024: Save the Day by Monitoring Your Org with Open-Source Tools](https://img.youtube.com/vi/NxiLiYeo11A/0.jpg)](https://www.youtube.com/watch?v=NxiLiYeo11A){target=blank}
+
+- Dreamforce 2023 - Easy Salesforce CI/CD with open-source and clicks only thanks to sfdx-hardis! (with Jean-Pierre Rizzi)
+
+[![Dreamforce 2023: Easy Salesforce CI/CD with open-source](https://img.youtube.com/vi/o0Mm9F07UFs/0.jpg)](https://www.youtube.com/watch?v=o0Mm9F07UFs){target=blank}
+
+#### Community Events
+
+- Wir Sind Ohana 2024 - Automate the Monitoring of your Salesforce orgs with open-source tools only! (with Yosra Saidani)
+
+[![Wir Sind Ohana 2024: Automate Monitoring with Open-Source](https://img.youtube.com/vi/xGbT6at7RZ0/0.jpg)](https://www.youtube.com/watch?v=xGbT6at7RZ0){target=blank}
+
+### Podcasts
+
+- Apex Hours 2025 - Org monitoring with Grafana + AI generated doc
+
+[![Apex Hours 2025: Org monitoring with Grafana + AI generated doc](https://img.youtube.com/vi/oDaCh66pRcI/0.jpg)](https://www.youtube.com/watch?v=oDaCh66pRcI){target=blank}
+
+- Salesforce Way Podcast #102 - Sfdx-hardis with Nicolas Vuillamy
+
+[![Salesforce Way Podcast: Sfdx-hardis](https://img.youtube.com/vi/sfdx-hardis/0.jpg)](https://salesforceway.com/podcast/sfdx-hardis/){target=blank}
+
+- Salesforce Developers Podcast Episode 182: SFDX-Hardis with Nicolas Vuillamy
+
+[![Salesforce Developers Podcast](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/article-sfdev.jpg)](https://developer.salesforce.com/podcast/2023/06/sfdx){target=blank}
+
+### sfdx-hardis Usage
+
+#### Features Overview
+
+- sfdx-hardis 2025 new features overview
+
+[![sfdx-hardis 2025 new features](https://img.youtube.com/vi/JRKH5COUVQ0/0.jpg)](https://youtu.be/JRKH5COUVQ0){target=blank}
+
+- SFDX-HARDIS – A demo with Nicolas Vuillamy from Cloudity
+
+[![SalesforceDevOps.net Demo](https://img.youtube.com/vi/qP6MaZUGzik/0.jpg)](https://www.youtube.com/watch?v=qP6MaZUGzik){target=blank}
+
+#### Installation & Setup
+
+- Complete installation tutorial for sfdx-hardis - [📖 Documentation](https://sfdx-hardis.cloudity.com/installation/)
+
+[![Installation Tutorial](https://img.youtube.com/vi/LA8m-t7CjHA/0.jpg)](https://www.youtube.com/watch?v=LA8m-t7CjHA){target=blank}
+
+#### CI/CD Workflows
+
+- Complete CI/CD workflow for Salesforce projects - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-home/)
+
+[![Dreamforce demo video: Easy Salesforce CI/CD with sdfx-hardis and open-source only !](https://img.youtube.com/vi/zEYqTd2txU4/0.jpg)](https://www.youtube.com/watch?v=zEYqTd2txU4){target=blank}
+
+- How to start a new task in sandbox - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-create-new-task/)
+
+[![Create New Task](https://img.youtube.com/vi/WOqssZwjPhw/0.jpg)](https://www.youtube.com/watch?v=WOqssZwjPhw){target=blank}
+
+- How to commit updates and create merge requests - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-publish-task/)
+
+[![Publish Task Tutorial](https://img.youtube.com/vi/Ik6whtflmfY/0.jpg)](https://www.youtube.com/watch?v=Ik6whtflmfY){target=blank}
+
+- How to resolve git merge conflicts in Visual Studio Code - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-validate-merge-request/)
+
+[![Merge Conflicts Resolution](https://img.youtube.com/vi/lz5OuKzvadQ/0.jpg)](https://www.youtube.com/watch?v=lz5OuKzvadQ){target=blank}
+
+- How to install packages in your org - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-work-on-task-install-packages/)
+
+[![Install Packages Tutorial](https://img.youtube.com/vi/5-MgqoSLUls/0.jpg)](https://www.youtube.com/watch?v=5-MgqoSLUls){target=blank}
+
+- Configure CI server authentication to Salesforce orgs - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-auth/)
+
+[![Configure CI Authentication](https://img.youtube.com/vi/OzREUu5utVI/0.jpg)](https://www.youtube.com/watch?v=OzREUu5utVI){target=blank}
+
+#### Monitoring
+
+- How to configure monitoring for your Salesforce org - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-monitoring-config-home/)
+
+[![Org Monitoring Setup](https://img.youtube.com/vi/bcVdN0XItSc/0.jpg)](https://www.youtube.com/watch?v=bcVdN0XItSc){target=blank}
+
+#### Integrations
+
+- Configure Slack integration for deployment notifications - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-integration-slack/)
+
+[![Slack Integration](https://img.youtube.com/vi/se292ABGUmI/0.jpg)](https://www.youtube.com/watch?v=se292ABGUmI){target=blank}
+
+- How to create a Personal Access Token in GitLab - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-clone-repository/)
+
+[![GitLab Personal Access Token](https://img.youtube.com/vi/9y5VmmYHuIg/0.jpg)](https://www.youtube.com/watch?v=9y5VmmYHuIg){target=blank}
+
+#### Documentation
+
+- How to generate AI-enhanced Salesforce project documentation - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-project-doc-generate/)
+
+[![Generate Project Documentation](https://img.youtube.com/vi/ZrVPN3jp1Ac/0.jpg)](https://www.youtube.com/watch?v=ZrVPN3jp1Ac){target=blank}
+
+- Host your documentation on Cloudflare free tier - [📖 Documentation](https://sfdx-hardis.cloudity.com/salesforce-project-doc-cloudflare/)
+
+[![Cloudflare Doc Hosting Setup](https://img.youtube.com/vi/AUipbKjgsDI/0.jpg)](https://www.youtube.com/watch?v=AUipbKjgsDI){target=blank}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,12 @@
+Everyone is welcome to contribute to sfdx-hardis (even juniors: we'll assist you !)
+
+- Install Node.js ([recommended version](https://nodejs.org/en/))
+- Install typescript by running `npm install typescript --global`
+- Install yarn by running `npm install yarn --global`
+- Install Salesforce DX by running `npm install @salesforce/cli --global` command line
+- Fork this repo and clone it (or just clone if you are an internal contributor)
+- At the root of the repository:
+  - Run `yarn` to install dependencies
+  - Run `sf plugins link` to link the local sfdx-hardis to SFDX CLI
+  - Run `tsc --watch` to transpile typescript into js everytime you update a TS file
+- Debug commands using `NODE_OPTIONS=--inspect-brk sf hardis:somecommand -someparameter somevalue`

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,0 +1,19 @@
+### Organization
+
+sfdx-hardis is primarely led by Nicolas Vuillamy & [Cloudity](https://www.cloudity.com/), but has many external contributors that we cant thank enough !
+
+### Pull Requests Authors
+
+<a href="https://github.com/hardisgroupcom/sfdx-hardis/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=hardisgroupcom/sfdx-hardis" />
+</a>
+
+### Special Thanks
+
+- [Roman Hentschke](https://www.linkedin.com/in/derroman/), for building the BitBucket CI/CD integration
+- [Leo Jokinen](https://www.linkedin.com/in/leojokinen/), for building the GitHub CI/CD integration
+- [Mariia Pyvovarchuk](https://www.linkedin.com/in/mpyvo/), for her work about generating automations documentation
+- [Matheus Delazeri](https://www.linkedin.com/in/matheus-delazeri-souza/), for the PDF output of documentation
+- [Taha Basri](https://www.linkedin.com/in/tahabasri/), for his work about generating documentation of LWC
+- [Anush Poudel](https://www.linkedin.com/in/anushpoudel/), for integrating sfdx-hardis with multiple LLMs using langchainJs
+- [Sebastien Colladon](https://www.linkedin.com/in/sebastien-colladon/), for providing sfdx-git-delta which is highly used within sfdx-hardis

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,53 @@
+### London's Calling '25, London
+
+Auto-generate your SF project Documentation site with open-source and Agentforce
+
+![image](https://github.com/user-attachments/assets/9b99120c-b660-4f67-b734-793148ac9d00)
+
+### Czech Dreamin '25, Prague
+
+Auto-generate your SF project Documentation site with open-source and Agentfforce, with [Mariia Pyvovarchuk](https://www.linkedin.com/in/mpyvo/)
+
+![Czech Dreamin 2025](https://github.com/user-attachments/assets/fa7b7f12-6d6a-437c-badd-20a626bb2163)
+
+### Trailblazer Admin Group '25, Lyon
+
+Techs for Admins: Afterwork Salesforce Inspector Reloaded & sfdx-hardis, with Thomas Prouvot
+
+![](https://github.com/user-attachments/assets/90621fe0-6527-4a34-8a0b-c14bd6d21cbd)
+
+### Dreamforce 2024, San Francisco
+
+[Save the Day by Monitoring Your Org with Open-Source Tools](https://reg.salesforce.com/flow/plus/df24/sessioncatalog/page/catalog/session/1718915808069001Q7HH), with Olga Shirikova
+
+[![Dreamforce 2024 Video](https://img.youtube.com/vi/NxiLiYeo11A/0.jpg)](https://www.youtube.com/watch?v=NxiLiYeo11A)
+
+### Wir Sind Ohana '24, Berlin
+
+Automate the Monitoring of your Salesforce orgs with open-source tools only!, with Yosra Saidani
+
+[![Wir Sind Ohana Video](https://img.youtube.com/vi/xGbT6at7RZ0/0.jpg)](https://www.youtube.com/watch?v=xGbT6at7RZ0)
+
+### Polish Dreamin '24, Wroclaw, Poland
+
+[Easy and complete Salesforce CI/CD with open-source only!](https://coffeeforce.pl/dreamin/speaker/nicolas-vuillamy/), with Wojciech Suwiński
+
+![Polish Dreamin 2024](https://github.com/nvuillam/nvuillam/assets/17500430/e843cc08-bf8a-452d-b7f0-c64a314f1b60)
+
+### French Touch Dreamin '23, Paris
+
+[Automate the Monitoring of your Salesforce orgs with open-source tools only!](https://frenchtouchdreamin.com/index.php/schedule/), with Maxime Guenego
+
+![French Touch Dreamin 2023](https://github.com/nvuillam/nvuillam/assets/17500430/8a2e1bbf-3402-4929-966d-5f99cb13cd29)
+
+### Dreamforce 2023, San Francisco
+
+[Easy Salesforce CI/CD with open-source and clicks only thanks to sfdx-hardis!](https://reg.salesforce.com/flow/plus/df23/sessioncatalog/page/catalog/session/1684196389783001OqEl), with Jean-Pierre Rizzi
+
+[![Dreamforce 2023 Video](https://img.youtube.com/vi/o0Mm9F07UFs/0.jpg)](https://www.youtube.com/watch?v=o0Mm9F07UFs)
+
+### Yeur Dreamin' 2023, Brussels
+
+An easy and complete Salesforce CI/CD release management with open-source only !, with Angélique Picoreau
+
+[![image](https://github.com/nvuillam/nvuillam/assets/17500430/6470df20-7449-444b-a0a5-7dc22f5f6188)](https://www.linkedin.com/posts/nicolas-vuillamy_cicd-opensource-trailblazercommunity-activity-7076859027321704448-F1g-?utm_source=share&utm_medium=member_desktop)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,50 @@
+### With IDE
+
+You can install [Visual Studio Code](https://code.visualstudio.com/) extension [VsCode SFDX Hardis](https://marketplace.visualstudio.com/items?itemName=NicolasVuillamy.vscode-sfdx-hardis)
+
+Once installed, click on ![Hardis Group button](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/hardis-button.jpg) in VsCode left bar, and follow the additional installation instructions
+
+[![Installation tutorial](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/play-install-tuto.png)](https://www.youtube.com/watch?v=LA8m-t7CjHA)
+
+___
+
+### As SFDX Plugin
+
+#### Pre-requisites
+
+- Install Node.js ([recommended version](https://nodejs.org/en/))
+- Install Salesforce DX by running `npm install @salesforce/cli --global` command line
+
+#### Plugin installation
+
+```sh-session
+sf plugins install sfdx-hardis
+```
+
+For advanced use, please also install dependencies
+
+```sh-session
+sf plugins install @salesforce/plugin-packaging
+sf plugins install sfdmu
+sf plugins install sfdx-git-delta
+sf plugins install texei-sfdx-plugin
+```
+
+If you are using CI/CD scripts, use `echo y | sf plugins install ...` to bypass prompt.
+
+___
+
+### Docker
+
+You can use sfdx-hardis docker images to run in CI
+
+- Docker Hub
+
+  - [**hardisgroupcom/sfdx-hardis:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with latest @salesforce/cli version)
+  - [**hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+
+- GitHub Packages (ghcr.io)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/orgs/hardisgroupcom/packages) (with latest @salesforce/cli version)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/orgs/hardisgroupcom/packages) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+
+_See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ extra:
   generator: false
 nav:
   - Home: index.md
-  - Installation: https://sfdx-hardis.cloudity.com/#installation
+  - Installation: installation.md
   - Salesforce CI/CD:
       - CI/CD Home: salesforce-ci-cd-home.md
       - Contributor Guide:
@@ -363,11 +363,13 @@ nav:
           ws: hardis/work/ws.md
       hello:
         world: hello/world.md
-  - Articles / Tutorials: https://sfdx-hardis.cloudity.com/#articles
+
+  - Community Events: events.md
+  - Articles & Videos: articles-videos.md
+  - Meet the team: contributors.md
   - Configuration reference: sfdx-hardis-config-file.md
-  - Special Thanks: special-thanks.md
   - Frequently Asked Questions: https://nicolas.vuillamy.fr/what-devops-experts-want-to-know-about-salesforce-ci-cd-with-sfdx-hardis-q-a-1f412db34476
-  - Contributing: https://sfdx-hardis.cloudity.com/#contributing
+  - Contributing: contributing.md
   - License: license.md
   - Security: SECURITY.md
   - Changelog: CHANGELOG.md


### PR DESCRIPTION
Extracts documentation content from the README file using HTML comments and generates individual markdown files for each section.

- Simplifies documentation management by centralizing content in the README.
- Improves navigation and readability by creating separate pages for key topics like installation, events, articles/videos, contributing, and team members.
- 