### PR TITLE
Updates project API version and default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Update default API version to 64.0
+
 ## [5.43.1] 2025-06-24
 
 - Refactor part of the documentation + add pages about events and videos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
-- Update default API version to 64.0
+- Update default API version to 63.0, but if --skipauth is not used, get the apiVersion of default org
+- [hardis:org:monitor:backup](https://sfdx-hardis.cloudity.com/hardis/org/monitor/backup/): Automate update of sfdx-project.json and package.xml at the beginning of the command
 
 ## [5.43.1] 2025-06-24
 

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -19,6 +19,7 @@ import MkDocsToSalesforce from '../../doc/mkdocs-to-salesforce.js';
 import MkDocsToCloudflare from '../../doc/mkdocs-to-cf.js';
 import { setConnectionVariables } from '../../../../common/utils/orgUtils.js';
 import { makeFileNameGitCompliant } from '../../../../common/utils/gitUtils.js';
+import { updateSfdxProjectApiVersion } from '../../../../common/utils/projectUtils.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sfdx-hardis', 'org');
@@ -179,6 +180,9 @@ If Flow history doc always display a single state, you probably need to update y
     this.skipDoc = flags["skip-doc"] === true ? true : false;
     this.outputFile = flags.outputfile || null;
     this.debugMode = flags.debug || false;
+
+    // Update apiVersion if necessary
+    await updateSfdxProjectApiVersion();
 
     // Build target org full manifest
     uxLog(

--- a/src/common/utils/authUtils.ts
+++ b/src/common/utils/authUtils.ts
@@ -68,13 +68,17 @@ export async function authOrg(orgAlias: string, options: any) {
         (orgInfoResult.result.username === orgAlias && orgInfoResult.result.id != null) ||
         (isDevHub && orgInfoResult.result.id != null))
     ) {
+      if (orgInfoResult.result.apiVersion) {
+        globalThis.currentOrgApiVersion = orgInfoResult.result.apiVersion;
+      }
       // Set as default username or devhubusername
       uxLog(
         this,
         `[sfdx-hardis] You are already ${c.green('connected')} as ${c.green(
           orgInfoResult.result.username
-        )} on org ${c.green(orgInfoResult.result.instanceUrl)}`
+        )} on org ${c.green(orgInfoResult.result.instanceUrl)} (apiVersion ${globalThis.currentOrgApiVersion})`
       );
+
       if (orgInfoResult.result.expirationDate) {
         uxLog(this, c.cyan(`[sfdx-hardis] Org expiration date: ${c.yellow(orgInfoResult.result.expirationDate)}`));
       }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -34,7 +34,7 @@ const userConfigFiles = [`config/user/.${moduleName}.${username}.yaml`, `config/
 const REMOTE_CONFIGS: any = {};
 
 export const CONSTANTS = {
-  API_VERSION: process.env.SFDX_API_VERSION || '62.0',
+  API_VERSION: process.env.SFDX_API_VERSION || '64.0',
   DOC_URL_ROOT: "https://sfdx-hardis.cloudity.com",
   WEBSITE_URL: "https://cloudity.com",
   CONTACT_URL: "https://cloudity.com/#form",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -34,7 +34,8 @@ const userConfigFiles = [`config/user/.${moduleName}.${username}.yaml`, `config/
 const REMOTE_CONFIGS: any = {};
 
 export const CONSTANTS = {
-  API_VERSION: process.env.SFDX_API_VERSION || '64.0',
+  // globalThis.currentOrgApiVersion is set during authentication check (so not set if --skipauth option is used)
+  API_VERSION: process.env.SFDX_API_VERSION || globalThis.currentOrgApiVersion || '63.0',
   DOC_URL_ROOT: "https://sfdx-hardis.cloudity.com",
   WEBSITE_URL: "https://cloudity.com",
   CONTACT_URL: "https://cloudity.com/#form",


### PR DESCRIPTION
- Updates the default API version to 63.0 in `config/index.ts`.
- Automates the update of `sfdx-project.json` and `package.xml` files at the beginning of the `hardis:org:monitor:backup` command, ensuring the project uses the latest API version.
- If `--skipauth` is not used, the command retrieves the API version from the default org.