### PR TITLE
Fixes use of org API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
-## [5.43.3] 2025-06-25
+## [5.43.4] 2025-06-26
+
+- Fix use of org API version
+
+## [5.43.3] 2025-06-26
 
 - [hardis:project:audit:apiversion](https://sfdx-hardis.cloudity.com/hardis/project/audit/apiversion/): Add the newApiVersion parameter to specify the target version for the upgrade.
 

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { buildOrgManifest } from '../../../../common/utils/deployUtils.js';
 import { execCommand, filterPackageXml, uxLog } from '../../../../common/utils/index.js';
 import { MetadataUtils } from '../../../../common/metadata-utils/index.js';
-import { CONSTANTS, getConfig, getEnvVar } from '../../../../config/index.js';
+import { CONSTANTS, getApiVersion, getConfig, getEnvVar } from '../../../../config/index.js';
 import { NotifProvider, NotifSeverity } from '../../../../common/notifProvider/index.js';
 import { MessageAttachment } from '@slack/web-api';
 import { getNotificationButtons, getOrgMarkdown, getSeverityIcon } from '../../../../common/utils/notifUtils.js';
@@ -350,7 +350,7 @@ If Flow history doc always display a single state, you probably need to update y
         removeNamespaces: namespacesToFilter,
         removeStandard: this.fullApplyFilters,
         removeFromPackageXmlFile: this.packageXmlToRemove,
-        updateApiVersion: CONSTANTS.API_VERSION,
+        updateApiVersion: getApiVersion(),
       });
       packageXmlToExtract = packageXmlFullFileWithoutNamespace;
     }
@@ -452,7 +452,7 @@ If Flow history doc always display a single state, you probably need to update y
       removeNamespaces: this.namespaces,
       removeStandard: true,
       removeFromPackageXmlFile: this.packageXmlToRemove,
-      updateApiVersion: CONSTANTS.API_VERSION,
+      updateApiVersion: getApiVersion(),
     });
 
     // Retrieve sfdx sources in local git repo

--- a/src/commands/hardis/work/save.ts
+++ b/src/commands/hardis/work/save.ts
@@ -26,7 +26,7 @@ import {
   writeXmlFile,
 } from '../../../common/utils/xmlUtils.js';
 import { WebSocketClient } from '../../../common/websocketClient.js';
-import { CONSTANTS, getConfig, setConfig } from '../../../config/index.js';
+import { CONSTANTS, getApiVersion, getConfig, setConfig } from '../../../config/index.js';
 import CleanReferences from '../project/clean/references.js';
 import CleanXml from '../project/clean/xml.js';
 
@@ -343,7 +343,7 @@ autoRemoveUserPermissions:
         // Create default destructiveChanges.xml if not defined
         const blankDestructiveChanges = `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <version>${CONSTANTS.API_VERSION}</version>
+    <version>${getApiVersion()}</version>
 </Package>
 `;
         await fs.writeFile(localDestructiveChangesXml, blankDestructiveChanges);

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -15,7 +15,7 @@ import {
   sortCrossPlatform,
   uxLog,
 } from '../../common/utils/index.js';
-import { CONSTANTS } from '../../config/index.js';
+import { getApiVersion } from '../../config/index.js';
 import { PACKAGE_ROOT_DIR } from '../../settings.js';
 import { getCache, setCache } from '../cache/index.js';
 import { buildOrgManifest } from '../utils/deployUtils.js';
@@ -312,7 +312,7 @@ Issue tracking: https://github.com/forcedotcom/cli/issues/2426`)
         removeNamespaces: namespaces,
         removeStandard: removeStandard,
         removeFromPackageXmlFile: packageXmlToRemove,
-        updateApiVersion: CONSTANTS.API_VERSION,
+        updateApiVersion: getApiVersion(),
       });
       uxLog(commandThis, filterNamespaceRes.message);
     }
@@ -320,7 +320,7 @@ Issue tracking: https://github.com/forcedotcom/cli/issues/2426`)
     else if (fs.existsSync('./remove-items-package.xml')) {
       const filterNamespaceRes = await filterPackageXml(packageXml, packageXml, {
         removeFromPackageXmlFile: path.resolve('./remove-items-package.xml'),
-        updateApiVersion: CONSTANTS.API_VERSION,
+        updateApiVersion: getApiVersion(),
       });
       uxLog(commandThis, filterNamespaceRes.message);
     }

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -20,7 +20,7 @@ import {
   sortCrossPlatform,
   uxLog,
 } from './index.js';
-import { CONSTANTS, getConfig, getReportDirectory, setConfig } from '../../config/index.js';
+import { getApiVersion, getConfig, getReportDirectory, setConfig } from '../../config/index.js';
 import { GitProvider } from '../gitProvider/index.js';
 import { deployCodeCoverageToMarkdown } from '../gitProvider/utilsMarkdown.js';
 import { MetadataUtils } from '../metadata-utils/index.js';
@@ -899,7 +899,7 @@ export async function deployDestructiveChanges(
     emptyPackageXmlFile,
     `<?xml version="1.0" encoding="UTF-8"?>
     <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-        <version>${CONSTANTS.API_VERSION}</version>
+        <version>${getApiVersion()}</version>
     </Package>`,
     'utf8'
   );
@@ -963,7 +963,7 @@ export async function deployMetadatas(
     ` --metadata-dir ${options.deployDir || '.'}` +
     ` --wait ${process.env.SFDX_DEPLOY_WAIT_MINUTES || '120'}` +
     ` --test-level ${options.testlevel || 'RunLocalTests'}` +
-    ` --api-version ${options.apiVersion || CONSTANTS.API_VERSION}` +
+    ` --api-version ${options.apiVersion || getApiVersion()}` +
     (options.targetUsername ? ` --target-org ${options.targetUsername}` : '') +
     (options.debug ? ' --verbose' : '') +
     ' --json';
@@ -1129,7 +1129,7 @@ export async function buildOrgManifest(
   if (conn) {
     uxLog(this, c.grey('Looking for package.xml elements that are not returned by manifest create command...'));
     const mdTypes = [{ type: 'ListView' }, { type: 'CustomLabel' }];
-    const mdList = await conn.metadata.list(mdTypes, CONSTANTS.API_VERSION);
+    const mdList = await conn.metadata.list(mdTypes, getApiVersion());
     const parsedPackageXml = await parseXmlFile(packageXmlFull);
     for (const element of mdList) {
       const matchTypes = parsedPackageXml.Package.types.filter((type) => type.name[0] === element.type);
@@ -1215,7 +1215,7 @@ export async function createEmptyPackageXml(): Promise<string> {
     emptyPackageXmlPath,
     `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <version>${CONSTANTS.API_VERSION}</version>
+    <version>${getApiVersion()}</version>
 </Package>`,
     'utf8'
   );

--- a/src/common/utils/filesUtils.ts
+++ b/src/common/utils/filesUtils.ts
@@ -15,7 +15,7 @@ import ExcelJS from 'exceljs';
 import { getCurrentGitBranch, isCI, isGitRepo, uxLog } from './index.js';
 import { bulkQuery, soqlQuery, bulkQueryByChunks } from './apiUtils.js';
 import { prompts } from './prompts.js';
-import { CONSTANTS, getReportDirectory } from '../../config/index.js';
+import { getApiVersion, getReportDirectory } from '../../config/index.js';
 import { WebSocketClient } from '../websocketClient.js';
 import { FileDownloader } from './fileDownloader.js';
 
@@ -342,7 +342,7 @@ export class FilesExporter {
     // Create directory if not existing
     await fs.ensureDir(parentRecordFolderForFiles);
     // Download file locally
-    const fetchUrl = `${this.conn.instanceUrl}/services/data/v${CONSTANTS.API_VERSION}/sobjects/Attachment/${attachment.Id}/Body`;
+    const fetchUrl = `${this.conn.instanceUrl}/services/data/v${getApiVersion()}/sobjects/Attachment/${attachment.Id}/Body`;
     await this.downloadFile(fetchUrl, outputFile);
   }
 
@@ -394,7 +394,7 @@ export class FilesExporter {
     // Create directory if not existing
     await fs.ensureDir(parentRecordFolderForFiles);
     // Download file locally
-    const fetchUrl = `${this.conn.instanceUrl}/services/data/v${CONSTANTS.API_VERSION}/sobjects/ContentVersion/${contentVersion.Id}/VersionData`;
+    const fetchUrl = `${this.conn.instanceUrl}/services/data/v${getApiVersion()}/sobjects/ContentVersion/${contentVersion.Id}/VersionData`;
     await this.downloadFile(fetchUrl, outputFile);
   }
   // Build stats & result

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -14,7 +14,7 @@ const exec = util.promisify(child.exec);
 import { SfError } from '@salesforce/core';
 import ora from 'ora';
 import { simpleGit, FileStatusResult, SimpleGit } from 'simple-git';
-import { CONSTANTS, getConfig, getReportDirectory, setConfig } from '../../config/index.js';
+import { CONSTANTS, getApiVersion, getConfig, getReportDirectory, setConfig } from '../../config/index.js';
 import { prompts } from './prompts.js';
 import { encryptFile } from '../cryptoUtils.js';
 import { deployMetadatas, shortenLogLines } from './deployUtils.js';
@@ -1264,7 +1264,7 @@ export async function generateSSLCertificate(
     <members>${promptResponses.appName}</members>
     <name>ConnectedApp</name>
   </types>
-  <version>${CONSTANTS.API_VERSION}</version>
+  <version>${getApiVersion()}</version>
 </Package>
 `;
     // create metadata folder

--- a/src/common/utils/projectUtils.ts
+++ b/src/common/utils/projectUtils.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { execCommand, sortCrossPlatform, uxLog } from './index.js';
 import { glob } from 'glob';
 import { parseXmlFile } from './xmlUtils.js';
-import { CONSTANTS } from '../../config/index.js';
+import { getApiVersion } from '../../config/index.js';
 
 export const GLOB_IGNORE_PATTERNS = [
   '**/node_modules/**',
@@ -154,7 +154,7 @@ export function returnApexType(apexCode: string) {
 
 // Update only if found API version is inferior to the candidate API version (convert to number)
 export async function updateSfdxProjectApiVersion() {
-  const candidateApiVersion: string = CONSTANTS.API_VERSION;
+  const candidateApiVersion: string = getApiVersion();
   // Handle sfdx-project.json file
   const sfdxProjectFile = path.join(process.cwd(), 'sfdx-project.json');
   if (await fs.pathExists(sfdxProjectFile)) {

--- a/src/common/utils/xmlUtils.ts
+++ b/src/common/utils/xmlUtils.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as util from 'util';
 import * as xml2js from 'xml2js';
 import { sortCrossPlatform, uxLog } from './index.js';
-import { CONSTANTS } from '../../config/index.js';
+import { getApiVersion } from '../../config/index.js';
 
 export async function parseXmlFile(xmlFile: string) {
   const packageXmlString = await fs.readFile(xmlFile, 'utf8');
@@ -61,7 +61,7 @@ export async function countPackageXmlItems(packageXmlFile: string): Promise<numb
 }
 
 export async function writePackageXmlFile(packageXmlFile: string, packageXmlObject: any) {
-  let packageXmlContent: any = { Package: { types: [], version: [CONSTANTS.API_VERSION] } };
+  let packageXmlContent: any = { Package: { types: [], version: [getApiVersion()] } };
   if (fs.existsSync(packageXmlFile)) {
     packageXmlContent = await parseXmlFile(packageXmlFile);
   }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,9 +33,12 @@ const username = os.userInfo().username;
 const userConfigFiles = [`config/user/.${moduleName}.${username}.yaml`, `config/user/.${moduleName}.${username}.yml`];
 const REMOTE_CONFIGS: any = {};
 
-export const CONSTANTS = {
+export const getApiVersion = () => {
   // globalThis.currentOrgApiVersion is set during authentication check (so not set if --skipauth option is used)
-  API_VERSION: process.env.SFDX_API_VERSION || globalThis.currentOrgApiVersion || '63.0',
+  return process.env.SFDX_API_VERSION || globalThis.currentOrgApiVersion || '63.0';
+}
+
+export const CONSTANTS = {
   DOC_URL_ROOT: "https://sfdx-hardis.cloudity.com",
   WEBSITE_URL: "https://cloudity.com",
   CONTACT_URL: "https://cloudity.com/#form",


### PR DESCRIPTION
The changes replace the hardcoded API version with a dynamic retrieval using `getApiVersion()` function.
This ensures that the tool uses the API version of the target org, preventing potential compatibility issues.
