### PR TITLE
Filters WorkflowFlowAutomation from package.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [5.43.5] 2025-06-27
+
+- Filter WorkflowFlowAutomation from org-generated package.xml (workaround attempt for https://github.com/forcedotcom/cli/issues/3324)
+
 ## [5.43.4] 2025-06-26
 
 - Fix use of org API version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 ## [5.43.5] 2025-06-27
 
-- Filter WorkflowFlowAutomation from org-generated package.xml (workaround attempt for https://github.com/forcedotcom/cli/issues/3324)
+- Filter WorkflowFlowAutomation from org-generated package.xml (workaround attempt for <https://github.com/forcedotcom/cli/issues/3324>)
 
 ## [5.43.4] 2025-06-26
 

--- a/src/common/utils/deployUtils.ts
+++ b/src/common/utils/deployUtils.ts
@@ -1189,9 +1189,18 @@ export async function buildOrgManifest(
     }
 
     // Delete stuff we don't want
-    parsedPackageXml.Package.types = parsedPackageXml.Package.types.filter(
-      (type) => !['CustomLabels'].includes(type.name[0])
-    );
+    const filteredTypes = [
+      'CustomLabels',
+      'WorkflowFlowAutomation' // Added as a workaround for https://github.com/forcedotcom/cli/issues/3324
+    ];
+    const typesToRemove = parsedPackageXml.Package.types.filter(type => filteredTypes.includes(type.name[0]));
+
+    if (typesToRemove.length > 0) {
+      uxLog(this, c.grey(`Force filtering out metadata types from org-generated package.xml: ${typesToRemove.map(type => type.name[0]).join(', ')}`));
+      parsedPackageXml.Package.types = parsedPackageXml.Package.types.filter(
+        (type) => !filteredTypes.includes(type.name[0])
+      );
+    }
     await writeXmlFile(packageXmlFull, parsedPackageXml);
   }
 


### PR DESCRIPTION
Addresses an issue with the Salesforce CLI where it incorrectly includes WorkflowFlowAutomation metadata in org-generated package.xml files.

This change filters out the `WorkflowFlowAutomation` metadata type when building the package.xml to avoid errors during deployment.
