### PR TITLE
Extends audit trail diagnostics

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -361,6 +361,7 @@
         "changedsenderemail",
         "changedsfcontentuseroffon",
         "changedsupportuseroffon",
+        "changedusername",
         "changements",
         "changemgmt",
         "chang\u00e9",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- [hardis:org:diagnose:audittrail](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/audittrail/):Add new ignored items in audit trail
+
 ## [5.44.0] 2025-06-29
 
 - [hardis:project:generate:bypass](https://sfdx-hardis.cloudity.com/hardis/project/generate/bypass/): Code rework + removed global flag + Added ability to apply the bypass to VRs and Triggers

--- a/src/commands/hardis/org/diagnose/audittrail.ts
+++ b/src/commands/hardis/org/diagnose/audittrail.ts
@@ -46,6 +46,8 @@ Regular setup actions performed in major orgs are filtered.
 - Email Administration
   - dkimRotationPreparationSuccessful
   - dkimRotationSuccessful
+- External Objects
+  - xdsEncryptedFieldChange
 - Groups
   - groupMembership
 - Holidays
@@ -71,13 +73,16 @@ Regular setup actions performed in major orgs are filtered.
   - changedroleforusertonone
   - changedroleforuser
   - changedroleforuserfromnone
+  - changedUserAdminVerifiedStatusVerified
   - changedUserEmailVerifiedStatusUnverified
   - changedUserEmailVerifiedStatusVerified
   - changedknowledgeuseroffon
   - changedsfcontentuseroffon
   - changedsupportuseroffon
+  - changedusername
   - changedUserPhoneNumber
   - changedUserPhoneVerifiedStatusUnverified
+  - changedUserPhoneVerifiedStatusVerified
   - deactivateduser
   - deleteAuthenticatorPairing
   - deleteTwoFactorInfo2
@@ -453,6 +458,7 @@ This command is part of [sfdx-hardis Monitoring](${CONSTANTS.DOC_URL_ROOT}/sales
       Currency: ['updateddatedexchrate'],
       'Data Management': ['queueMembership'],
       'Email Administration': ['dkimRotationSuccessful', 'dkimRotationPreparationSuccessful'],
+      'External Objects': ['xdsEncryptedFieldChange'],
       Holidays: ['holiday_insert'],
       'Inbox mobile and legacy desktop apps': ['enableSIQUserNonEAC'],
       Groups: ['groupMembership'],
@@ -478,12 +484,15 @@ This command is part of [sfdx-hardis Monitoring](${CONSTANTS.DOC_URL_ROOT}/sales
         'changedpassword',
         "changedprofileforuserstdtostd",
         'changedsfcontentuseroffon',
+        'changedUserAdminVerifiedStatusVerified',
         'changedUserEmailVerifiedStatusUnverified',
         'changedUserEmailVerifiedStatusVerified',
         'changedknowledgeuseroffon',
         'changedsupportuseroffon',
+        'changedusername',
         'changedUserPhoneNumber',
         'changedUserPhoneVerifiedStatusUnverified',
+        'changedUserPhoneVerifiedStatusVerified',
         'deactivateduser',
         'deleteAuthenticatorPairing',
         'deleteTwoFactorInfo2',


### PR DESCRIPTION
Extends the audit trail diagnostics by adding new ignored items.

- Updates the list of filtered audit trail events to reduce noise and focus on relevant security events.
- Adds specific events related to external objects, user admin verification, and phone verification to the ignored items list.