### PR TITLE
Adds option to hide apex source code in generated documentation

### DIFF
--- a/src/commands/hardis/doc/project2markdown.ts
+++ b/src/commands/hardis/doc/project2markdown.ts
@@ -210,7 +210,7 @@ ${this.htmlInstructions}
     this.diffOnly = flags["diff-only"] === true ? true : false;
     this.withHistory = flags["with-history"] === true ? true : false;
     this.withPdf = flags.pdf === true ? true : false;
-    this.hideApexCode = flags["hide-apex-code"] === true ? true : false;
+    this.hideApexCode = flags["hide-apex-code"] === true || process?.env?.HIDE_APEX_CODE === 'true' ? true : false;
     this.debugMode = flags.debug || false;
     await setConnectionVariables(flags['target-org']?.getConnection(), true);// Required for some notifications providers like Email, or for Agentforce
 


### PR DESCRIPTION
Adds a `--hide-apex-code` flag to `sf hardis:doc:project2markdown` command.

This would allow a user to control whether apex source code is outputted into the apex code documentation pages.