### PR TITLE
Adds project name option to data commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- [hardis:org:data:export](https://sfdx-hardis.cloudity.com/hardis/org/data/export/) & [hardis:org:data:import](https://sfdx-hardis.cloudity.com/hardis/org/data/export/):
+  - Add --project-name and --no-prompts arguments
+  - Add more examples of commands calls
+
 ## [6.1.4] 2025-08-25
 
 - Update Integrations & DevOps Documentation

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -1340,6 +1340,30 @@
       "title": "Project Name",
       "type": "string"
     },
+    "refreshSandboxConfig": {
+      "$id": "#/properties/refreshSandboxConfig",
+      "description": "Configuration for sandbox refresh. Will be used by command hardis:org:refresh:before-refresh and hardis:org:refresh:after-refresh",
+      "properties": {
+        "connectedApps": {
+          "$id": "#/properties/refreshSandboxConfig/connectedApps",
+          "description": "List of connected apps to download before refresh and to upload after refresh",
+          "examples": [
+            [
+              "My_Connected_App_1",
+              "My_Connected_App_2"
+            ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Connected Apps",
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "title": "Refresh Sandbox Configuration",
+      "type": "object"
+    },
     "retrofitBranch": {
       "$id": "#/properties/retrofitBranch",
       "default": "",

--- a/src/commands/hardis/org/configure/data.ts
+++ b/src/commands/hardis/org/configure/data.ts
@@ -7,7 +7,7 @@ import fs from 'fs-extra';
 import pascalcase from 'pascalcase';
 import * as path from 'path';
 import { uxLog } from '../../../../common/utils/index.js';
-import { dataFolderRoot } from '../../../../common/utils/dataUtils.js';
+import { DATA_FOLDERS_ROOT } from '../../../../common/utils/dataUtils.js';
 import { prompts } from '../../../../common/utils/prompts.js';
 import { WebSocketClient } from '../../../../common/websocketClient.js';
 import { getConfig, setConfig } from '../../../../config/index.js';
@@ -121,7 +121,7 @@ The command's technical implementation involves:
   }
 
   private async generateConfigurationFiles() {
-    const sfdmuProjectFolder = path.join(dataFolderRoot, this.dataPath);
+    const sfdmuProjectFolder = path.join(DATA_FOLDERS_ROOT, this.dataPath);
     if (fs.existsSync(sfdmuProjectFolder)) {
       throw new SfError(`[sfdx-hardis]${c.red(`Folder ${c.bold(sfdmuProjectFolder)} already exists`)}`);
     }

--- a/src/common/utils/dataUtils.ts
+++ b/src/common/utils/dataUtils.ts
@@ -7,7 +7,7 @@ import { getConfig } from '../../config/index.js';
 import { prompts } from './prompts.js';
 import { isProductionOrg } from './orgUtils.js';
 
-export const dataFolderRoot = path.join('.', 'scripts', 'data');
+export const DATA_FOLDERS_ROOT = path.join(process.cwd(), 'scripts', 'data');
 
 // Import data from sfdmu folder
 export async function importData(sfdmuPath: string, commandThis: any, options: any = {}) {
@@ -93,15 +93,23 @@ export async function exportData(sfdmuPath: string, commandThis: any, options: a
   });
 }
 
+export async function findDataWorkspaceByName(projectName: string) {
+  const folderPath = path.join(DATA_FOLDERS_ROOT, projectName);
+  if (fs.existsSync(folderPath)) {
+    return folderPath;
+  }
+  throw new SfError(`There is no sfdmu folder named ${projectName} in your workspace (${DATA_FOLDERS_ROOT})`);
+}
+
 export async function selectDataWorkspace(opts = { selectDataLabel: 'Please select a data workspace to export' }) {
-  if (!fs.existsSync(dataFolderRoot)) {
+  if (!fs.existsSync(DATA_FOLDERS_ROOT)) {
     throw new SfError(
       "There is no sfdmu root folder 'scripts/data' in your workspace. Create it and define sfdmu exports using sfdmu: https://help.sfdmu.com/"
     );
   }
 
   const sfdmuFolders = fs
-    .readdirSync(dataFolderRoot, { withFileTypes: true })
+    .readdirSync(DATA_FOLDERS_ROOT, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => path.join('.', 'scripts', 'data', dirent.name));
   if (sfdmuFolders.length === 0) {


### PR DESCRIPTION
Adds the `--project-name` option to the `hardis:org:data:export` and `hardis:org:data:import` commands.

This allows users to specify a project name when exporting or importing data, which can be useful for organizing and managing data across multiple projects.

Also adds the `--no-prompts` option and more examples to the documentation.