### PR TITLE
Improves merge request creation and display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- [hardis:work:save](https://sfdx-hardis.cloudity.com/hardis/work/save/): Always display a button to create Merge Request
+- Update GitProvider to make it compliant with GitHub Enterprise hosted on ghe.com
+
 ## [6.2.0] 2025-09-01
 
 - [hardis:org:refresh:before-refresh](https://sfdx-hardis.cloudity.com/hardis/org/refresh/before-refresh/)

--- a/src/commands/hardis/work/save.ts
+++ b/src/commands/hardis/work/save.ts
@@ -203,18 +203,17 @@ The command's technical implementation involves a series of orchestrated steps:
     await this.manageCommitPush(gitStatusWithConfig, gitStatusAfterDeployPlan);
 
 
-    const mergeRequestUrl = GitProvider.getMergeRequestCreateUrl(this.gitUrl, this.targetBranch || '', this.currentBranch);
+    let mergeRequestUrl = GitProvider.getMergeRequestCreateUrl(this.gitUrl, this.targetBranch || '', this.currentBranch);
+    mergeRequestUrl = mergeRequestUrl || this.gitUrl.replace('.git', '');
 
     // Merge request
     uxLog("action", this, c.cyan(`If your work is ${c.bold('completed')}, you can create a ${c.bold(GitProvider.getMergeRequestName(this.gitUrl))}, otherwise you can push new commits on ${c.green(this.currentBranch)} branch.`));
     let summaryMsg = c.grey("");
-    if (mergeRequestUrl) {
-      if (WebSocketClient.isAliveWithLwcUI()) {
-        WebSocketClient.sendReportFileMessage(mergeRequestUrl, `Create ${GitProvider.getMergeRequestName(this.gitUrl)}`, 'actionUrl');
-      }
-      else {
-        summaryMsg += c.grey(`- New ${GitProvider.getMergeRequestName(this.gitUrl)} URL: ${c.green(mergeRequestUrl)}\n`);
-      }
+    if (WebSocketClient.isAliveWithLwcUI()) {
+      WebSocketClient.sendReportFileMessage(mergeRequestUrl, `Create ${GitProvider.getMergeRequestName(this.gitUrl)}`, 'actionUrl');
+    }
+    else {
+      summaryMsg += c.grey(`- New ${GitProvider.getMergeRequestName(this.gitUrl)} URL: ${c.green(mergeRequestUrl)}\n`);
     }
     const mergeRequestDoc = `${CONSTANTS.DOC_URL_ROOT}/salesforce-ci-cd-publish-task/#create-merge-request`;
     summaryMsg += c.grey(`- Repository: ${c.green(this.gitUrl.replace('.git', ''))}\n`);

--- a/src/common/gitProvider/index.ts
+++ b/src/common/gitProvider/index.ts
@@ -259,7 +259,7 @@ export abstract class GitProvider {
       return `${gitUrlHttp}/-/merge_requests/new?merge_request[source_branch]=${encodeURIComponent(sourceBranch)}&merge_request[target_branch]=${encodeURIComponent(targetBranch)}`;
     }
     // GitHub
-    if (gitUrlHttp.includes("github")) {
+    if (gitUrlHttp.includes("github") || gitUrlHttp.includes("ghe.com")) {
       // https://github.com/org/repo/compare/main...feature?expand=1
       return `${gitUrlHttp}/compare/${encodeURIComponent(targetBranch)}...${encodeURIComponent(sourceBranch)}?expand=1`;
     }

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -256,7 +256,7 @@ Issue tracking: https://github.com/forcedotcom/cli/issues/2426`)
             this,
             c.yellow(
               `${c.bold('This is not a real error')}: A newer version of ${package1.SubscriberPackageName
-              } has been found. You may update installedPackages property in .sfdx-hardis.yml`
+              } has been found. You may upgrade stored package version using VsCode SFDX-Hardis "Installed Packages" feature in menu "DevOps Pipeline" (it will update installedPackages property in .sfdx-hardis.yml)`
             )
           );
           uxLog(


### PR DESCRIPTION
Updates merge request URL generation and display logic:

- Ensures a button to create a Merge Request is always displayed.
- If `getMergeRequestCreateUrl` returns null, defaults to displaying the repository URL.
- Adapts GitProvider to support GitHub Enterprise instances hosted on `ghe.com`.