### PR TITLE
Clarifies JSON schema descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Set initPermissionSets config prop to array of strings
+
 ## [6.3.1] 2025-09-07
 
 - Update Grafana Home Dashboard to add Unsecure Connected Apps

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -847,7 +847,7 @@
     },
     "initPermissionSets": {
       "$id": "#/properties/initPermissionSets",
-      "description": "When creating a scratch org, Admin user will be automatically assigned to those permission sets",
+      "description": "When creating a scratch org, Admin user will be automatically assigned to those permission sets. Example: PS_Admin",
       "examples": [
         [
           "MyPermissionSet",
@@ -1424,7 +1424,7 @@
     },
     "scratchOrgInitApexScripts": {
       "$id": "#/properties/scratchOrgInitApexScripts",
-      "description": "Apex scripts to call after scratch org initialization",
+      "description": "Apex scripts to call after scratch org initialization. Example: scripts/apex/init-scratch.apex",
       "examples": [
         [
           "scripts/apex/init-scratch.apex",

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -855,28 +855,7 @@
         ]
       ],
       "items": {
-        "$id": "#/properties/initPermissionSets/items",
-        "type": [
-          "object",
-          "string"
-        ],
-        "additionalProperties": false,
-        "description": "Permission Set or Permission Set Group",
-        "properties": {
-          "name": {
-            "$Id": "#/properties/initPermissionSets/items/properties/name",
-            "description": "Permission Set or Permission Set Group name",
-            "examples": [
-              [
-                "MyPermissionSet",
-                "MyPermissionSetGroup",
-                "MyPermissionSetGroup2"
-              ]
-            ],
-            "title": "Name",
-            "type": "string"
-          }
-        }
+        "type": "string"
       },
       "title": "Initial Permission Sets",
       "type": "array"


### PR DESCRIPTION
Adds examples to the JSON schema descriptions for clarity.

- Provides examples for `initPermissionSets` and `scratchOrgInitApexScripts` properties.