### PR TITLE
Handles missing OAuth Token App menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [6.3.2] 2025-09-07
+
 - Set initPermissionSets config prop to array of strings
+- [hardis:org:diagnose:unsecure-connected-apps](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/unsecure-connected-apps/): Handle case where OAuth Token App menu item is not found
 
 ## [6.3.1] 2025-09-07
 

--- a/src/commands/hardis/org/diagnose/unsecure-connected-apps.ts
+++ b/src/commands/hardis/org/diagnose/unsecure-connected-apps.ts
@@ -107,9 +107,9 @@ The command's technical implementation involves:
       const toAdd: any = {
         AppName: app.AppName,
         User: app.User ? app.User.Name : 'N/A',
-        IsUsingAdminAuthorization: app.AppMenuItem ? app.AppMenuItem.IsUsingAdminAuthorization : "N/A"
+        IsUsingAdminAuthorization: app.AppMenuItem ? app.AppMenuItem.IsUsingAdminAuthorization : false
       };
-      if (app.AppMenuItem && app.AppMenuItem.IsUsingAdminAuthorization === false) {
+      if (toAdd.IsUsingAdminAuthorization === false) {
         toAdd.statusIcon = '❌';
         toAdd.status = 'Unsecured';
       } else {


### PR DESCRIPTION
Addresses a scenario where the OAuth Token App menu item is not found during the unsecure connected apps diagnosis.

This prevents errors and ensures the command functions correctly even when the menu item is absent.
