### PR TITLE
Allows override of Bulk API v2 settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Allow to override Bulk API v2 settings with env variables **BULKAPIV2_POLL_INTERVAL** and **BULKAPIV2_POLL_TIMEOUT**
+
 ## [6.4.0] 2025-09-08
 
 - [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/): New beta feature **useDeltaDeploymentWithDependencies** to add dependencies to the delta deployment package.

--- a/docs/all-env-variables.md
+++ b/docs/all-env-variables.md
@@ -17,6 +17,8 @@ This list has been generated with GitHub Copilot so if you see any incoherence p
    - [Deployment Control](#deployment-control)
    - [Monitoring & Debugging](#monitoring--debugging)
    - [System Configuration](#system-configuration)
+   - [Bulk API Settings](#bulk-api-settings)
+   
 2. [Tool-Specific Variables](#tool-specific-variables)
    - [Azure DevOps](#azure-devops)
    - [GitLab](#gitlab)
@@ -87,6 +89,13 @@ These variables control specific behaviors and configurations within sfdx-hardis
 | **NODE_OPTIONS**               | Node.js runtime options                   | Cleared if contains `--inspect-brk` | Valid Node.js options (e.g., `'--max-old-space-size=4096'`, `'--experimental-modules'`) | [`src/common/utils/index.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/utils/index.ts)         |
 | **PROJECT_NAME**               | Name of the sfdx-hardis project           | `undefined`                         | Any project name string (e.g., `'My Salesforce Project'`, `'CRM-Development'`)          | [`src/config/index.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/config/index.ts)                     |
 | **SFDX_HARDIS_WEBSOCKET_PORT** | Port for sfdx-hardis WebSocket server     | `2702`                              | Valid port numbers (e.g., `2702`)                                                       | [`src/common/websocketClient.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/websocketClient.ts) |
+
+### Bulk API Settings
+
+| Variable Name                  | Description                               | Default Value                       | Possible Values                                                                         | Usage Location                                                                                                           |
+|--------------------------------|-------------------------------------------|-------------------------------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| **BULKAPIV2_POLL_INTERVAL**    | Override BulkApiV2 Poll interval          | `5000`                              | Any number                                                                              | [`src/common/utils/apiUtils.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/utils/apiUtils.ts)   |
+| **BULKAPIV2_POLL_TIMEOUT**     | Override BulkApiv2 Poll Timeout           | `60000`                             | Any number                                                                              | [`src/common/utils/apiUtils.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/utils/apiUtils.ts)   |
 
 ---
 

--- a/src/common/utils/apiUtils.ts
+++ b/src/common/utils/apiUtils.ts
@@ -79,8 +79,8 @@ const maxRetry = Number(process.env.BULK_QUERY_RETRY || 5);
 export async function bulkQuery(soqlQuery: string, conn: Connection, retries = 3): Promise<any> {
   const queryLabel = soqlQuery.length > 500 ? soqlQuery.substr(0, 500) + '...' : soqlQuery;
   uxLog("log", this, c.grey('[BulkApiV2] ' + c.italic(queryLabel)));
-  conn.bulk.pollInterval = 5000; // 5 sec
-  conn.bulk.pollTimeout = 60000; // 60 sec
+  conn.bulk2.pollInterval = process.env.BULKAPIV2_POLL_INTERVAL ? Number(process.env.BULKAPIV2_POLL_INTERVAL) : 5000; // 5 sec
+  conn.bulk2.pollTimeout = process.env.BULKAPIV2_POLL_TIMEOUT ? Number(process.env.BULKAPIV2_POLL_TIMEOUT) : 60000; // 60 sec
   // Start query
   try {
     spinnerQ = ora({ text: `[BulkApiV2] Bulk Query: ${queryLabel}`, spinner: 'moon' }).start();


### PR DESCRIPTION
Enables users to override the default Bulk API v2 poll interval and timeout settings using environment variables.

This change provides greater flexibility and control over Bulk API v2 operations, especially in environments with specific performance or resource constraints.
