### PR TITLE
Improves OAuth token retrieval for large orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [6.4.4] 2025-09-16
+
 - When prompting for org instance URL, allow to copy-paste the full URL to gain time
+- [hardis:org:diagnose:unsecure-connected-apps](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/unsecure-connected-apps/): Salesforce limits OAuthToken queries to 2500 results. Be sneaky to get all results :)
 
 ## [6.4.3] 2025-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- When prompting for org instance URL, allow to copy-paste the full URL to gain time
+
 ## [6.4.3] 2025-09-14
 
 - [hardis:org:file:export](https://sfdx-hardis.cloudity.com/hardis/org/files/export/) and [hardis:org:file:import](https://sfdx-hardis.cloudity.com/hardis/org/files/import/):

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -243,12 +243,16 @@ export async function promptInstanceUrl(
     type: 'text',
     name: 'value',
     message: c.cyanBright('Please input the base URL of the salesforce org'),
-    description: 'Enter the custom Salesforce org URL for authentication',
+    description: 'Copy paste the full URL of your currently open Salesforce org :)',
     placeholder: 'Ex: https://myclient.my.salesforce.com',
   });
-  const urlCustom = (customUrlResponse?.value || "")
+  let urlCustom = (customUrlResponse?.value || "")
     .replace('.lightning.force.com', '.my.salesforce.com')
     .replace('.my.salesforce-setup.com', '.my.salesforce.com');
+  // Remove everything after '.my.salesforce.com' if existing
+  if (urlCustom.includes('.my.salesforce.com')) {
+    urlCustom = urlCustom.substring(0, urlCustom.indexOf('.my.salesforce.com') + '.my.salesforce.com'.length);
+  }
   return urlCustom;
 }
 


### PR DESCRIPTION
Improves the retrieval of OAuth tokens for organizations with a large number of tokens. It addresses an issue where Salesforce API limits the number of OAuth tokens returned in a single query.

- Implements a mechanism to recursively query for remaining tokens when the initial query hits the limit of 2500 OAuth Tokens.
- Uses the latest found token's creation date as a constraint for subsequent queries.
- Sorts the OAuth tokens by AppName