### PR TITLE
Files export: resume + validate downloaded file + better API limits handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [6.4.5] 2025-09-17
+
+- Files export: resume + validate downloaded file
+
 ## [6.4.4] 2025-09-16
 
 - When prompting for org instance URL, allow to copy-paste the full URL to gain time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
-## [6.4.5] 2025-09-17
+## [6.5.0] 2025-09-17
 
 - Files export enhancements:
   - Resume + validate downloaded files
   - Improves API limit handling for file export/import
+- When prompting for org url, allow to input just the domain (ex: `hardis-group`) and sfdx-hardis will build the rest of the url
 
 ## [6.4.4] 2025-09-16
 
@@ -35,7 +36,6 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 - Allow to override Bulk API v2 settings with env variables **BULKAPIV2_POLL_INTERVAL**, **BULKAPIV2_POLL_TIMEOUT** and **BULK_QUERY_RETRY**
 
-
 ## [6.4.0] 2025-09-08
 
 - [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/): New beta feature **useDeltaDeploymentWithDependencies** to add dependencies to the delta deployment package.
@@ -54,13 +54,12 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 - Set initPermissionSets config prop to array of strings
 - [hardis:org:diagnose:unsecure-connected-apps](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/unsecure-connected-apps/): Handle case where OAuth Token App menu item is not found
 
-
 ## [6.3.1] 2025-09-07
 
 - Update Grafana Home Dashboard to add Unsecure Connected Apps
 - Fix Auth configuration command for Dev Hub
 - Allow to use org shapes for scratch org creation with env variable **SCRATCH_ORG_SHAPE**
-- Replace `my.salesforce-setup.com` by `my.salesforce.com` when prompting instance URL 
+- Replace `my.salesforce-setup.com` by `my.salesforce.com` when prompting instance URL
 
 ## [6.3.0] 2025-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 ## [6.4.5] 2025-09-17
 
-- Files export: resume + validate downloaded file
+- Files export enhancements:
+  - Resume + validate downloaded files
+  - Improves API limit handling for file export/import
 
 ## [6.4.4] 2025-09-16
 

--- a/src/commands/hardis/org/files/export.ts
+++ b/src/commands/hardis/org/files/export.ts
@@ -3,7 +3,9 @@ import { SfCommand, Flags, requiredOrgFlagWithDeprecations } from '@salesforce/s
 import { Messages } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
 import c from 'chalk';
-import { humanizeObjectKeys, uxLog, uxLogTable } from '../../../../common/utils/index.js';
+import fs from 'fs-extra';
+import path from 'path';
+import { humanizeObjectKeys, uxLog, uxLogTable, isCI } from '../../../../common/utils/index.js';
 import {
   FilesExporter,
   getFilesWorkspaceDetail,
@@ -29,6 +31,15 @@ Key functionalities:
 
 - **Configuration-Driven Export:** Relies on an \`export.json\` file within a designated file export project to define the export criteria, including the SOQL query for parent records, file types to export, output naming conventions, and file size filtering.
 - **File Size Filtering:** Supports minimum file size filtering via the \`fileSizeMin\` configuration parameter (in KB). Files smaller than the specified size will be skipped during export.
+- **File Validation:** After downloading each file, validates the integrity by:
+  - **Checksum Validation:** For ContentVersion files, compares MD5 checksum with Salesforce's stored checksum
+  - **Size Validation:** For both ContentVersion and Attachment files, verifies actual file size matches expected size
+  - **Status Tracking:** Files are categorized with specific statuses: \`success\` (valid files), \`failed\` (download errors), \`skipped\` (filtered files), \`invalid\` (downloaded but failed validation)
+  - All validation results are logged in the CSV export log for audit purposes
+- **Resume/Restart Capability:** 
+  - **Resume Mode:** When \`--resume\` flag is used (default in CI environments), checks existing downloaded files for validity. Valid files are skipped, invalid files are re-downloaded.
+  - **Restart Mode:** When resume is disabled, clears the output folder and starts a fresh export.
+  - **Interactive Mode:** When existing files are found and \`--resume\` is not explicitly specified (non-CI environments), prompts the user to choose between resume or restart.
 - **Interactive Project Selection:** If the file export project path is not provided via the \`--path\` flag, it interactively prompts the user to select one.
 - **Configurable Export Options:** Allows overriding default export settings such as \`chunksize\` (number of records processed in a batch), \`polltimeout\` (timeout for Bulk API calls), and \`startchunknumber\` (to resume a failed export).
 - **Support for ContentVersion and Attachment:** Handles both modern Salesforce Files (ContentVersion) and older Attachments.
@@ -43,12 +54,14 @@ See this article for a practical example:
 The command's technical implementation involves:
 
 - **FilesExporter Class:** The core logic is encapsulated within the \`FilesExporter\` class, which orchestrates the entire export process.
-- **SOQL Queries (Bulk API):** It uses Salesforce Bulk API queries to efficiently retrieve large volumes of parent record IDs and file metadata.
+- **SOQL Queries (Bulk API):** It uses Salesforce Bulk API queries to efficiently retrieve large volumes of parent record IDs and file metadata, including checksums and file sizes.
 - **File Download:** Downloads the actual file content from Salesforce.
+- **File Validation:** After each successful download, validates file integrity by comparing checksums (ContentVersion) and file sizes (both ContentVersion and Attachment) against Salesforce metadata.
+- **Resume Logic:** In resume mode, checks for existing files before downloading, validates their integrity, and only re-downloads invalid or missing files. This enables efficient recovery from interrupted exports.
 - **File System Operations:** Writes the downloaded files to the local file system, organizing them into folders based on the configured naming conventions.
 - **Configuration Loading:** Reads the \`export.json\` file to get the export configuration. It also allows for interactive overriding of these settings.
-- **Interactive Prompts:** Uses \`selectFilesWorkspace\` to allow the user to choose a file export project and \`promptFilesExportConfiguration\` for customizing export options.
-- **Error Handling:** Includes mechanisms to handle potential errors during the export process, such as network issues or API limits.
+- **Interactive Prompts:** Uses \`selectFilesWorkspace\` to allow the user to choose a file export project, \`promptFilesExportConfiguration\` for customizing export options, and prompts for resume/restart choice when existing files are found.
+- **Error Handling:** Includes mechanisms to handle potential errors during the export process, such as network issues, API limits, and file validation failures. Each file is assigned a specific status (\`success\`, \`failed\`, \`skipped\`, \`invalid\`) for comprehensive tracking and troubleshooting.
 </details>
 `;
 
@@ -73,6 +86,11 @@ The command's technical implementation involves:
       char: 's',
       description: 'Chunk number to start from',
       default: 0,
+    }),
+    resume: Flags.boolean({
+      char: 'r',
+      description: 'Resume previous export by checking existing files (default in CI)',
+      default: false,
     }),
     debug: Flags.boolean({
       char: 'd',
@@ -99,12 +117,14 @@ The command's technical implementation involves:
     const recordsChunkSize = flags.chunksize;
     const pollTimeout = flags.polltimeout;
     const startChunkNumber = flags.startchunknumber || 0;
+    const resumeExport = flags.resume || isCI; // Default to resume in CI environments
     //const debugMode = flags.debug || false;
 
     const exportOptions: any = {
       pollTimeout: pollTimeout,
       recordsChunkSize: recordsChunkSize,
       startChunkNumber: startChunkNumber,
+      resumeExport: resumeExport,
     };
 
     // Identify files workspace if not defined
@@ -132,6 +152,40 @@ The command's technical implementation involves:
     const exportConfigHuman = humanizeObjectKeys(exportConfigFinal || {});
     uxLog("action", this, c.cyan(`Export configuration has been defined (see details below)`));
     uxLogTable(this, exportConfigHuman);
+
+    // Check for existing files and prompt user if needed
+    let finalResumeExport = resumeExport;
+    if (!isCI && !resumeExport) {
+      // User didn't explicitly set --resume and we're not in CI
+      const exportFolder = path.join(filesPath || '', 'export');
+      if (fs.existsSync(exportFolder)) {
+        try {
+          const files = await fs.readdir(exportFolder);
+          const hasFiles = files.length > 0;
+
+          if (hasFiles) {
+            uxLog("action", this, c.yellow(`Found existing files in output folder: ${exportFolder}`));
+            const resumePrompt = await prompts({
+              type: 'confirm',
+              message: c.cyanBright('Do you want to resume the previous export (validate and skip existing valid files)?'),
+              description: 'Choose "Yes" to resume (skip valid existing files) or "No" to restart (clear folder and download all files)',
+            });
+            finalResumeExport = resumePrompt.value === true;
+
+            if (finalResumeExport) {
+              uxLog("log", this, c.cyan('Resume mode selected: existing files will be validated and skipped if valid'));
+            } else {
+              uxLog("log", this, c.yellow('Restart mode selected: output folder will be cleared'));
+            }
+          }
+        } catch (error) {
+          uxLog("warning", this, c.yellow(`Could not check existing files in ${exportFolder}: ${(error as Error).message}`));
+        }
+      }
+    }
+
+    // Update export options with final resume decision
+    exportOptions.resumeExport = finalResumeExport;
 
     // Export files from org
     const exportResult = await new FilesExporter(

--- a/src/commands/hardis/org/files/export.ts
+++ b/src/commands/hardis/org/files/export.ts
@@ -117,7 +117,7 @@ The command's technical implementation involves:
     const recordsChunkSize = flags.chunksize;
     const pollTimeout = flags.polltimeout;
     const startChunkNumber = flags.startchunknumber || 0;
-    const resumeExport = flags.resume || isCI; // Default to resume in CI environments
+    const resumeExport = flags.resume;
     //const debugMode = flags.debug || false;
 
     const exportOptions: any = {

--- a/src/common/utils/filesUtils.ts
+++ b/src/common/utils/filesUtils.ts
@@ -44,6 +44,7 @@ export class FilesExporter {
 
   private recordChunksNumber = 0;
   private logFile: string;
+  private hasExistingFiles: boolean;
   private resumeExport: boolean;
 
   private totalRestApiCalls = 0;
@@ -75,6 +76,7 @@ export class FilesExporter {
     this.parentRecordsChunkSize = 100000;
     this.startChunkNumber = options?.startChunkNumber || 0;
     this.resumeExport = options?.resumeExport || false;
+    this.hasExistingFiles = fs.existsSync(path.join(this.filesPath, 'export'));
     this.commandThis = commandThis;
     if (options.exportConfig) {
       this.dtl = options.exportConfig;
@@ -98,9 +100,11 @@ export class FilesExporter {
 
     // Handle resume/restart mode
     if (!this.resumeExport) {
-      // Restart mode: clear the output folder
-      uxLog("action", this.commandThis, c.yellow(`Restart mode: clearing output folder ${this.exportedFilesFolder}`));
-      await fs.emptyDir(this.exportedFilesFolder);
+      if (this.hasExistingFiles) {
+        // Restart mode: clear the output folder
+        uxLog("action", this.commandThis, c.yellow(`Restart mode: clearing output folder ${this.exportedFilesFolder}`));
+        await fs.emptyDir(this.exportedFilesFolder);
+      }
     } else {
       uxLog("action", this.commandThis, c.cyan(`Resume mode: existing files will be validated and skipped if valid`));
     }

--- a/src/common/utils/filesUtils.ts
+++ b/src/common/utils/filesUtils.ts
@@ -57,6 +57,7 @@ export class FilesExporter {
   private filesIgnoredExisting = 0;
   private filesIgnoredSize = 0;
   private filesValidationErrors = 0;
+  private filesValidated = 0; // Count of files that went through validation (downloaded or existing)
 
   // Optimized API Limits Management System
   private apiLimitsManager: ApiLimitsManager;
@@ -692,6 +693,7 @@ export class FilesExporter {
         const validation = await this.validateDownloadedFile(outputFile, expectedSize, expectedChecksum);
 
         if (validation.valid) {
+          this.filesValidated++; // Count only valid files
           // File exists and is valid - skip download
           const fileDisplay = path.join(folderPath, fileName).replace(/\\/g, '/');
           uxLog("success", this, c.grey(`Skipped (valid existing file) ${fileDisplay}`));
@@ -730,6 +732,7 @@ export class FilesExporter {
         const validation = await this.validateDownloadedFile(outputFile, expectedSize, expectedChecksum);
 
         if (validation.valid) {
+          this.filesValidated++; // Count only valid files
           validationStatus = 'Valid';
           isValidFile = true;
           uxLog("success", this, c.green(`✓ Validation passed for ${fileName}`));
@@ -903,6 +906,7 @@ export class FilesExporter {
 
     const result = {
       stats: {
+        filesValidated: this.filesValidated,
         filesDownloaded: this.filesDownloaded,
         filesErrors: this.filesErrors,
         filesIgnoredType: this.filesIgnoredType,

--- a/src/common/utils/filesUtils.ts
+++ b/src/common/utils/filesUtils.ts
@@ -916,7 +916,7 @@ export class FilesExporter {
       const finalApiUsage = await this.getApiUsageStatus();
       uxLog("success", this, c.green(`Export completed! Final API usage: ${finalApiUsage.message}`));
     } catch (error) {
-      // Ignore API usage display errors
+      uxLog("warning", this, c.yellow(`Could not retrieve final API usage: ${(error as Error).message}`));
     }
 
     const result = {

--- a/src/common/utils/filesUtils.ts
+++ b/src/common/utils/filesUtils.ts
@@ -457,7 +457,7 @@ export class FilesExporter {
             }
           });
       } else {
-        uxLog("log", this, c.grey('No Attachments found for the parent records in this batch'));
+        uxLog("log", this, c.grey(`No Attachments found for the ${batch.length} parent records in this batch`));
       }
     }
     for (let i = 0; i < records.length; i += contentVersionBatchSize) {
@@ -467,6 +467,7 @@ export class FilesExporter {
       const linkedEntityInQuery = `SELECT ContentDocumentId,LinkedEntityId FROM ContentDocumentLink WHERE LinkedEntityId IN (${linkedEntityIdIn})`;
       await this.waitIfApiLimitApproached('BULK');
       this.totalBulkApiCalls++;
+      uxLog("log", this, c.grey(`Querying ContentDocumentLinks for ${linkedEntityInQuery.length} parent records in this batch...`));
       const contentDocumentLinks = await bulkQueryByChunks(linkedEntityInQuery, this.conn, this.parentRecordsChunkSize);
       if (contentDocumentLinks.records.length > 0) {
         // Retrieve all ContentVersion related to ContentDocumentLink

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -228,7 +228,7 @@ export async function promptInstanceUrl(
   const orgTypeResponse = await prompts({
     type: 'select',
     name: 'value',
-    message: c.cyanBright(`What is the base URL or the org you want to connect to, as ${alias} ?`),
+    message: c.cyanBright(`What is the base URL or domain or the org you want to connect to, as ${alias} ?`),
     description: 'Select the Salesforce environment type or specify a custom URL for authentication',
     choices: choices,
     initial: 1,
@@ -244,7 +244,7 @@ export async function promptInstanceUrl(
     name: 'value',
     message: c.cyanBright('Please input the base URL of the salesforce org'),
     description: 'Copy paste the full URL of your currently open Salesforce org :)',
-    placeholder: 'Ex: https://myclient.my.salesforce.com',
+    placeholder: 'Ex: https://myclient.my.salesforce.com , or myclient',
   });
   let urlCustom = (customUrlResponse?.value || "")
     .replace('.lightning.force.com', '.my.salesforce.com')
@@ -252,6 +252,12 @@ export async function promptInstanceUrl(
   // Remove everything after '.my.salesforce.com' if existing
   if (urlCustom.includes('.my.salesforce.com')) {
     urlCustom = urlCustom.substring(0, urlCustom.indexOf('.my.salesforce.com') + '.my.salesforce.com'.length);
+  }
+  if (!urlCustom.startsWith('https://')) {
+    urlCustom = 'https://' + urlCustom;
+  }
+  if (!urlCustom.endsWith('.my.salesforce.com')) {
+    urlCustom = urlCustom + '.my.salesforce.com';
   }
   return urlCustom;
 }

--- a/src/common/utils/limitUtils.ts
+++ b/src/common/utils/limitUtils.ts
@@ -1,0 +1,251 @@
+// External Libraries and Node.js Modules
+import c from 'chalk';
+
+// Salesforce Specific Libraries
+import { Connection, SfError } from '@salesforce/core';
+
+// Project Specific Utilities
+import { uxLog } from './index.js';
+
+// Optimized API Limits Management System
+export class ApiLimitsManager {
+  private conn: Connection;
+  private commandThis: any;
+
+  // Caching system
+  private cachedLimits: any = null;
+  private lastRefreshTime: number = 0;
+  private cacheDuration: number = 5 * 60 * 1000; // 5 minutes
+
+  // Local tracking counters
+  private localRestApiCalls: number = 0;
+  private localBulkApiCalls: number = 0;
+
+  // Base limits from Salesforce
+  private baseRestApiUsed: number = 0;
+  private baseRestApiLimit: number = 0;
+  private baseBulkApiUsed: number = 0;
+  private baseBulkApiLimit: number = 0;
+
+  // Thresholds for API management
+  private readonly WARNING_THRESHOLD = 70; // Force refresh at 70%
+  private readonly DANGER_THRESHOLD = 80;  // Stop operations at 80%
+
+  constructor(conn: Connection, commandThis: any) {
+    this.conn = conn;
+    this.commandThis = commandThis;
+  }
+
+  // Initialize the limits manager with initial API limits data
+  async initialize(): Promise<void> {
+    await this.refreshLimits(true); // Force initial refresh
+  }
+
+  // Intelligent refresh logic - only refresh when needed
+  private async refreshLimits(forceRefresh: boolean = false): Promise<void> {
+    const now = Date.now();
+    const cacheAge = now - this.lastRefreshTime;
+
+    // Use cache if it's fresh and not forced refresh
+    if (!forceRefresh && this.cachedLimits && cacheAge < this.cacheDuration) {
+      uxLog("log", this.commandThis, c.grey(`Using cached API limits (${Math.round(cacheAge / 1000)}s old)`));
+      return;
+    }
+
+    try {
+      uxLog("log", this.commandThis, c.grey(`Refreshing API limits from Salesforce...`));
+
+      // Fetch fresh limits from Salesforce
+      this.cachedLimits = await this.conn.limits();
+
+      if (!this.cachedLimits) {
+        throw new SfError("Unable to retrieve API limit information from Salesforce org.");
+      }
+
+      // Extract REST API limits
+      if (!this.cachedLimits.DailyApiRequests) {
+        throw new SfError("DailyApiRequests limit not available from Salesforce org.");
+      }
+
+      this.baseRestApiUsed = this.cachedLimits.DailyApiRequests.Max - this.cachedLimits.DailyApiRequests.Remaining;
+      this.baseRestApiLimit = this.cachedLimits.DailyApiRequests.Max;
+
+      // Extract Bulk API v2 limits
+      if (!this.cachedLimits.DailyBulkV2QueryJobs) {
+        throw new SfError("DailyBulkV2QueryJobs limit not available from Salesforce org.");
+      }
+
+      this.baseBulkApiUsed = this.cachedLimits.DailyBulkV2QueryJobs.Max - this.cachedLimits.DailyBulkV2QueryJobs.Remaining;
+      this.baseBulkApiLimit = this.cachedLimits.DailyBulkV2QueryJobs.Max;
+
+      // Reset local counters on fresh data
+      this.localRestApiCalls = 0;
+      this.localBulkApiCalls = 0;
+      this.lastRefreshTime = now;
+
+      uxLog("success", this.commandThis,
+        `API Limits refreshed - REST: ${this.baseRestApiUsed}/${this.baseRestApiLimit}, Bulk: ${this.baseBulkApiUsed}/${this.baseBulkApiLimit}`
+      );
+
+    } catch (error: any) {
+      if (error instanceof SfError) throw error;
+      throw new SfError(`Failed to refresh API limits: ${error?.message || 'Unknown error'}`);
+    }
+  }
+
+  // Track API call and check if we need to wait or refresh
+  async trackApiCall(apiType: 'REST' | 'BULK'): Promise<void> {
+    // Increment local counter
+    if (apiType === 'REST') {
+      this.localRestApiCalls++;
+    } else {
+      this.localBulkApiCalls++;
+    }
+
+    // Calculate current usage
+    const currentRestUsage = this.baseRestApiUsed + this.localRestApiCalls;
+    const currentBulkUsage = this.baseBulkApiUsed + this.localBulkApiCalls;
+
+    const restPercent = (currentRestUsage / this.baseRestApiLimit) * 100;
+    const bulkPercent = (currentBulkUsage / this.baseBulkApiLimit) * 100;
+
+    // Check if we need to refresh limits due to approaching thresholds
+    const needsRefresh = (
+      (apiType === 'REST' && restPercent >= this.WARNING_THRESHOLD) ||
+      (apiType === 'BULK' && bulkPercent >= this.WARNING_THRESHOLD)
+    );
+
+    if (needsRefresh) {
+      await this.refreshLimits(true); // Force refresh for accurate counts
+
+      // Recalculate with fresh data
+      const freshRestUsage = this.baseRestApiUsed + this.localRestApiCalls;
+      const freshBulkUsage = this.baseBulkApiUsed + this.localBulkApiCalls;
+      const freshRestPercent = (freshRestUsage / this.baseRestApiLimit) * 100;
+      const freshBulkPercent = (freshBulkUsage / this.baseBulkApiLimit) * 100;
+
+      // Check if we need to wait
+      if (apiType === 'REST' && freshRestPercent >= this.DANGER_THRESHOLD) {
+        await this.waitForLimitReset('REST', freshRestPercent);
+      }
+
+      if (apiType === 'BULK' && freshBulkPercent >= this.DANGER_THRESHOLD) {
+        await this.waitForLimitReset('BULK', freshBulkPercent);
+      }
+    }
+  }
+
+  // Wait for API limits to reset
+  private async waitForLimitReset(apiType: 'REST' | 'BULK', currentPercent: number): Promise<void> {
+    const WAIT_INTERVAL = 300; // 5 minutes
+    const MAX_CYCLES = 12; // 1 hour max
+
+    uxLog("warning", this.commandThis,
+      c.yellow(`${apiType} API at ${currentPercent.toFixed(1)}%. Waiting for limits to reset...`)
+    );
+
+    for (let cycle = 0; cycle < MAX_CYCLES; cycle++) {
+      uxLog("action", this.commandThis,
+        c.cyan(`Waiting ${WAIT_INTERVAL}s for ${apiType} API reset (${cycle + 1}/${MAX_CYCLES})...`)
+      );
+
+      // Wait in 1-second intervals
+      for (let i = 0; i < WAIT_INTERVAL; i++) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+
+      // Check if limits have reset
+      await this.refreshLimits(true);
+
+      const currentUsage = apiType === 'REST'
+        ? this.baseRestApiUsed + this.localRestApiCalls
+        : this.baseBulkApiUsed + this.localBulkApiCalls;
+      const limit = apiType === 'REST' ? this.baseRestApiLimit : this.baseBulkApiLimit;
+      const percent = (currentUsage / limit) * 100;
+
+      if (percent < this.WARNING_THRESHOLD) {
+        uxLog("success", this.commandThis,
+          c.green(`${apiType} API usage dropped to ${percent.toFixed(1)}%. Resuming operations.`)
+        );
+        return;
+      }
+    }
+
+    throw new SfError(`${apiType} API limits did not reset after ${MAX_CYCLES * WAIT_INTERVAL / 60} minutes.`);
+  }
+
+  // Get current API usage status for display
+  getUsageStatus(): { rest: number; bulk: number; message: string } {
+    const currentRestUsage = this.baseRestApiUsed + this.localRestApiCalls;
+    const currentBulkUsage = this.baseBulkApiUsed + this.localBulkApiCalls;
+
+    const restPercent = (currentRestUsage / this.baseRestApiLimit) * 100;
+    const bulkPercent = (currentBulkUsage / this.baseBulkApiLimit) * 100;
+
+    return {
+      rest: restPercent,
+      bulk: bulkPercent,
+      message: `[REST: ${restPercent.toFixed(1)}% | Bulk: ${bulkPercent.toFixed(1)}%]`
+    };
+  }
+
+  // Get current usage for API consumption estimation
+  getCurrentUsage(): {
+    restUsed: number;
+    restLimit: number;
+    bulkUsed: number;
+    bulkLimit: number;
+    restRemaining: number;
+    bulkRemaining: number;
+  } {
+    const currentRestUsage = this.baseRestApiUsed + this.localRestApiCalls;
+    const currentBulkUsage = this.baseBulkApiUsed + this.localBulkApiCalls;
+
+    return {
+      restUsed: currentRestUsage,
+      restLimit: this.baseRestApiLimit,
+      bulkUsed: currentBulkUsage,
+      bulkLimit: this.baseBulkApiLimit,
+      restRemaining: this.baseRestApiLimit - currentRestUsage,
+      bulkRemaining: this.baseBulkApiLimit - currentBulkUsage
+    };
+  }
+
+  // Get final usage for reporting (forces a fresh refresh)
+  async getFinalUsage(): Promise<{
+    restUsed: number;
+    restLimit: number;
+    restRemaining: number;
+    bulkUsed: number;
+    bulkLimit: number;
+    bulkRemaining: number;
+  }> {
+    try {
+      const currentLimits = await this.conn.limits();
+      if (currentLimits && currentLimits.DailyApiRequests && currentLimits.DailyBulkV2QueryJobs) {
+        const restUsed = currentLimits.DailyApiRequests.Max - currentLimits.DailyApiRequests.Remaining;
+        const bulkUsed = currentLimits.DailyBulkV2QueryJobs.Max - currentLimits.DailyBulkV2QueryJobs.Remaining;
+
+        return {
+          restUsed: restUsed,
+          restLimit: currentLimits.DailyApiRequests.Max,
+          restRemaining: currentLimits.DailyApiRequests.Remaining,
+          bulkUsed: bulkUsed,
+          bulkLimit: currentLimits.DailyBulkV2QueryJobs.Max,
+          bulkRemaining: currentLimits.DailyBulkV2QueryJobs.Remaining
+        };
+      }
+    } catch (error) {
+      // Fallback to cached values if fresh fetch fails
+    }
+
+    return {
+      restUsed: this.baseRestApiUsed + this.localRestApiCalls,
+      restLimit: this.baseRestApiLimit,
+      restRemaining: this.baseRestApiLimit - (this.baseRestApiUsed + this.localRestApiCalls),
+      bulkUsed: this.baseBulkApiUsed + this.localBulkApiCalls,
+      bulkLimit: this.baseBulkApiLimit,
+      bulkRemaining: this.baseBulkApiLimit - (this.baseBulkApiUsed + this.localBulkApiCalls)
+    };
+  }
+}


### PR DESCRIPTION
Implements the `files:export` command to export file attachments from a Salesforce org based on a predefined configuration.

It introduces a resume/restart capability to handle interrupted exports.
When the `--resume` flag is used (default in CI environments), the command checks existing downloaded files for validity. Valid files are skipped, and invalid files are re-downloaded.
When resume is disabled, the output folder is cleared, and a fresh export starts.

The command also supports interactive project selection and configurable export options.
It handles both ContentVersion and Attachment files, validating file integrity by comparing checksums (ContentVersion) and file sizes (both ContentVersion and Attachment) against Salesforce metadata.

Better handling of API limits

Co-authored-by: @piotrekkr <503782+piotrekkr@users.noreply.github.com>
