### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,9 +27,9 @@ coverage
 # Ignore development configuration
 .vscode
 .idea
-*.swp
-*.swo
-*~
+**/*.swp
+**/*.swo
+**/*~
 
 # Ignore build artifacts
 lib
@@ -48,13 +48,13 @@ logs
 *.log
 
 # Ignore OS generated files
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-ehthumbs.db
-Thumbs.db
+**/.DS_Store
+**/.DS_Store?
+**/._*
+**/.Spotlight-V100
+**/.Trashes
+**/ehthumbs.db
+**/Thumbs.db
 
 # Ignore environment files
 .env


### PR DESCRIPTION
This PR fixes minor .dockerignore misconfigurations (#1440).

- I added `**/` at the beginning of the patterns I thought should match recursively
- Please let me know (or directly update my PR) if any other lines should include `**/` as well.