### PR TITLE
Fix Validation Rules formula field in doc generation

### DIFF
--- a/src/common/docBuilder/docBuilderObject.ts
+++ b/src/common/docBuilder/docBuilderObject.ts
@@ -67,7 +67,7 @@ export class DocBuilderObject extends DocBuilderRoot {
     ]);
     for (const rule of validationRules) {
       lines.push(...[
-        `| ${rule.fullName} | ${rule.active ? "Yes" : "No ⚠️"} | ${rule.description || ""} | \`${rule.errorConditionFormula}\` |`
+        `| ${rule.fullName} | ${rule.active ? "Yes" : "No ⚠️"} | ${rule.description || ""} | ${mdTableCell(rule.errorConditionFormula)} |`
       ]);
     }
     lines.push("");


### PR DESCRIPTION
Hey! This is a minor fix to the Validation Rules doc generation to prevent it from breaking when a formula contains line breaks.

**Original VR**

<img width="750" height="238" alt="image" src="https://github.com/user-attachments/assets/b2dcbb22-0c16-46c1-aaf7-4f0d98d1dcc8" />

**Before**

<img width="836" height="332" alt="image" src="https://github.com/user-attachments/assets/8a5369f4-ee6a-4e9d-b5df-c5d6e582edf4" />

**After**

<img width="793" height="289" alt="image" src="https://github.com/user-attachments/assets/9c6a0b03-6796-4d30-9ad0-c69130bd246a" />