### PR TITLE
Handles errors from pull request commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [6.11.3] 2025-11-04
+
+- Handles errors from pull request commands
+
 ## [6.11.2] 2025-11-03
 
 - Enhances storage stats with breakdown and filtering

--- a/src/common/utils/prePostCommandUtils.ts
+++ b/src/common/utils/prePostCommandUtils.ts
@@ -18,7 +18,11 @@ export async function executePrePostCommands(property: 'commandsPreDeploy' | 'co
   uxLog("action", this, c.cyan(`[DeploymentActions] Listing ${actionLabel}...`));
   const branchConfig = await getConfig('branch');
   const commands: PrePostCommand[] = [...(branchConfig[property] || []), ...(options.extraCommands || [])];
-  await completeWithCommandsFromPullRequests(property, commands, options.checkOnly);
+  try {
+    await completeWithCommandsFromPullRequests(property, commands, options.checkOnly);
+  } catch (e) {
+    uxLog("error", this, c.red(`[DeploymentActions] Error while retrieving commands from pull requests: ${(e as Error).message}\n ${(e as Error).stack}\n You might report the issue on sfdx-hardis GitHub repository.`));
+  }
   if (commands.length === 0) {
     uxLog("action", this, c.cyan(`[DeploymentActions] No ${actionLabel} defined in branch config or pull requests`));
     uxLog("log", this, c.grey(`No ${property} found to run`));


### PR DESCRIPTION
Adds a try/catch block to handle errors that may occur
when retrieving commands from pull requests.

Displays a user-friendly error message in case of failure,
instructing the user to report the issue.
