### PR TITLE
Normalizes hyphens in generated branch names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- [hardis:work:new](https://sfdx-hardis.cloudity.com/hardis/work/new/): If there are multiple `-` in a generated branch name , replace by single `-`, otherwise it messes with mermaid diagrams
+
 ## [6.11.5] 2025-11-09
 
 - Excludes training branches from merge target suggestions

--- a/src/commands/hardis/work/new.ts
+++ b/src/commands/hardis/work/new.ts
@@ -272,7 +272,9 @@ The command's logic orchestrates various underlying processes:
       description: 'Enter a descriptive name for your User Story that will be used in the git branch name',
       placeholder: `Ex: ${taskNameExample}`,
     });
-    const taskName = taskResponse.taskName.replace(/[^a-zA-Z0-9 -]|\s/g, '-');
+    let taskName = taskResponse.taskName.replace(/[^a-zA-Z0-9 -]|\s/g, '-');
+    // If there are multiple "-" , replace by single "-", otherwise it messes with mermaid diagrams
+    taskName = taskName.replace(/-+/g, '-');
     if (validationRegex != null && !new RegExp(validationRegex).test(taskName)) {
       uxLog(
         "warning",


### PR DESCRIPTION
Ensures that multiple consecutive hyphens in the generated task name for the branch are replaced with a single hyphen.

This prevents issues with Mermaid diagrams where multiple hyphens can cause rendering problems.
