### PR TITLE
Fix: Resolve duplicate WHERE clause in bulkQueryByChunks pagination

### DIFF
--- a/src/common/utils/apiUtils.ts
+++ b/src/common/utils/apiUtils.ts
@@ -148,7 +148,7 @@ export async function bulkQueryByChunks(
     let soqlQueryWithLimit = `${soqlQuery} ORDER BY Id`;
     if (lastRecordId) {
       // Check if query already has a WHERE clause to use AND instead of WHERE
-      const hasWhere = soqlQuery.toUpperCase().includes('WHERE');
+      const hasWhere = soqlQuery.toUpperCase().includes(' WHERE ');
       const connector = hasWhere ? 'AND' : 'WHERE';
       soqlQueryWithLimit = `${soqlQuery} ${connector} Id > '${lastRecordId}' ORDER BY Id`;
     }


### PR DESCRIPTION
## Summary

Fixes issue #1538 - Resolves duplicate WHERE clause problem in `bulkQueryByChunks` function

## Changes

- Check if SOQL query already contains WHERE clause before pagination
- Use AND connector for pagination when WHERE exists
- Use WHERE connector when query has no WHERE clause

## Problem

The `bulkQueryByChunks` function in `src/common/utils/apiUtils.ts` was always appending `WHERE Id > '...'` for pagination, causing invalid SOQL syntax when the original query already contained a WHERE clause.

**Before:**
```typescript
if (lastRecordId) {
  soqlQueryWithLimit = `${soqlQuery} WHERE Id > '${lastRecordId}' ORDER BY Id`;
}
```

**After:**
```typescript
if (lastRecordId) {
  // Check if query already has a WHERE clause to use AND instead of WHERE
  const hasWhere = soqlQuery.toUpperCase().includes('WHERE');
  const connector = hasWhere ? 'AND' : 'WHERE';
  soqlQueryWithLimit = `${soqlQuery} ${connector} Id > '${lastRecordId}' ORDER BY Id`;
}
```

## Impact

- Fixes invalid SOQL syntax when paginating filtered queries
- Resolves issue with file exports exceeding 100k records with filters
- Maintains backward compatibility for queries without WHERE clauses

## Related Issue

https://github.com/hardisgroupcom/sfdx-hardis/issues/1538