### PR TITLE
[fix/flow-diff-error-stacktrace] Include stack trace in warning log for Flow diff generation errors.

### DIFF
--- a/src/common/gitProvider/utilsMarkdown.ts
+++ b/src/common/gitProvider/utilsMarkdown.ts
@@ -109,7 +109,7 @@ export async function flowDiffToMarkdownForPullRequest(flowNames: string[], from
         await generateDiffMarkdownWithPng(fileMetadata, fromCommit, toCommit, flowDiffMarkdownList, flowName);
       }
     } catch (e: any) {
-      uxLog("warning", this, c.yellow(`[FlowGitDiff] Unable to generate Flow diff for ${flowName}: ${e.message}`));
+      uxLog("warning", this, c.yellow(`[FlowGitDiff] Unable to generate Flow diff for ${flowName}: ${e.message}`) + "\n" + c.grey(e.stack));
     }
   }
   if (truncatedNb > 0) {


### PR DESCRIPTION
Add stack trace output to error logging in flowDiffToMarkdownForPullRequest to help debug.