### PR TITLE
Downgrades parse5 to v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [6.12.9] 2025-11-25
+
+- Fixes compatibility issues caused by upgrading to parse5 v8.0.0.
+
 ## [6.12.8] 2025-11-25
 
 - Upgrade isomorphic-dompurify

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "form-data": "4.0.5",
     "tmp": "0.2.5",
     "prebuild-install/tar-fs": "2.1.4",
-    "@puppeteer/browsers/tar-fs": "3.1.1"
+    "@puppeteer/browsers/tar-fs": "3.1.1",
+    "parse5": "6.0.1"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10563,12 +10563,10 @@ parse-json@^8.0.0:
     index-to-position "^1.1.0"
     type-fest "^4.39.1"
 
-parse5@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-8.0.0.tgz#aceb267f6b15f9b6e6ba9e35bfdd481fc2167b12"
-  integrity sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==
-  dependencies:
-    entities "^6.0.0"
+parse5@6.0.1, parse5@^8.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 pascal-case@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
Fixes compatibility issues caused by upgrading to parse5 v8.0.0.
The downgrade restores expected functionality.
