### PR TITLE
Adds site/ to .gitignore only in monitoring repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- Adds site/ to .gitignore only in monitoring repositories
+
 ## [6.12.10] 2025-11-25
 
 - Temporary downgrade isomorphic-dompurify package (jsdom dep not compliant with NodeJS < 20.19.5 and CodeBuilder / Agentforce Vibes is below)
@@ -27,7 +29,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 ## [6.12.5] 2025-11-18
 
-- Improve JIRA authentication and display 
+- Improve JIRA authentication and display
 - [hardis:project:deploy:notify](https://sfdx-hardis.cloudity.com/hardis/project/deploy/notify/): Make default org optional
 - Improve pre/post deployment commands details display in PR comments
 
@@ -69,7 +71,7 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 
 - [hardis:org:test:apex](https://sfdx-hardis.cloudity.com/hardis/org/test/apex/): Fix bug when there are no Apex classes in the org
 - GitHub integration: Fix way to get Pull Request number
-- As SF Cli now requires NodeJs >= 24, set the same requirement to sfdx-hardis default  workflows
+- As SF Cli now requires NodeJs >= 24, set the same requirement to sfdx-hardis default workflows
 
 ## [6.11.3] 2025-11-04
 
@@ -97,7 +99,6 @@ Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image 
 - Add explicit message in case of error when authenticating to Git provider API
 - Allow to override SFDX_TEST_WAIT_MINUTES and SFDX_DEPLOY_WAIT_MINUTES using CI/CD variables, and set 120 minutes as default value everywhere
 - Fix Validation Rules formula field in doc generation
-
 
 ## [6.9.0] 2025-10-23
 

--- a/src/hooks/prerun/check-dependencies.ts
+++ b/src/hooks/prerun/check-dependencies.ts
@@ -108,7 +108,7 @@ async function manageGitIgnoreForceIgnore(commandId: string) {
         .map((line) => line.trim())
         .filter((line) => line !== '');
       let updated = false;
-      for (const gitIgnoreMandatoryLine of await getHardisGitRepoIgnoreContent()) {
+      for (const gitIgnoreMandatoryLine of await getHardisGitRepoIgnoreContent(isMon)) {
         if (!gitIgnoreLines.includes(gitIgnoreMandatoryLine)) {
           gitIgnoreLines.push(gitIgnoreMandatoryLine);
           updated = true;
@@ -188,12 +188,11 @@ async function manageGitIgnoreForceIgnore(commandId: string) {
   }
 }
 
-async function getHardisGitRepoIgnoreContent() {
+async function getHardisGitRepoIgnoreContent(isMonitoring: boolean) {
   const gitIgnoreContent = [
     '.cache/',
     'config/user/',
     'hardis-report/',
-    'site/',
     'tmp/',
     '**/__tests__/**',
     // Metadatas to be ignored
@@ -204,6 +203,9 @@ async function getHardisGitRepoIgnoreContent() {
     '**/data/**/target/**',
     'force-app/main/default/appMenus/AppSwitcher.appMenu-meta.xml',
   ];
+  if (isMonitoring) {
+    gitIgnoreContent.push('site/');
+  }
   return gitIgnoreContent;
 }
 


### PR DESCRIPTION
Conditionally adds the `site/` directory to the `.gitignore` file only when the application is running in monitoring mode.

This prevents unnecessary inclusion of the `site/` directory in the repository when not required, addressing potential issues related to file tracking and deployment.
