### PR TITLE
Fixes docgen crash with boolean formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+- [hardis:doc:project2markdown](https://sfdx-hardis.cloudity.com/hardis/doc/project2markdown/): Fix crash when generating documentation when a formula is just `true`
+
 ## [6.15.0] 2025-12-08
 
 - Ticketing: replace the deprecated `jira-client` dependency with the `jira.js` SDK to improve Atlassian Cloud API v3 compatibility and authentication handling.

--- a/src/common/gitProvider/utilsMarkdown.ts
+++ b/src/common/gitProvider/utilsMarkdown.ts
@@ -81,6 +81,9 @@ export function mdTableCell(str: string) {
   if (!str) {
     return "<!-- -->"
   }
+  if (typeof str !== "string") {
+    str = String(str);
+  }
   return str.replace(/\n/gm, "<br/>").replace(/\|/gm, "");
 }
 


### PR DESCRIPTION
Addresses a crash in the documentation generator that occurred when a formula evaluated to a boolean value.

Ensures that all values are converted to strings before processing to prevent unexpected errors during documentation generation.
