### PR TITLE
Fixes Jira server label in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
 - [hardis:doc:project2markdown](https://sfdx-hardis.cloudity.com/hardis/doc/project2markdown/): Fix crash when generating documentation when a formula is just `true`
+- Jira Provider: Fix label of jira server in output message when coming from config file.
 
 ## [6.15.0] 2025-12-08
 

--- a/src/common/ticketProvider/jiraProvider.ts
+++ b/src/common/ticketProvider/jiraProvider.ts
@@ -11,13 +11,15 @@ import { CommonPullRequestInfo } from "../gitProvider/index.js";
 
 export class JiraProvider extends TicketProviderRoot {
   private jiraClient: Version3Client | null = null;
+  private jiraHost: string | null = null;
 
   constructor(config: any) {
     super();
     const rawHost = getEnvVar("JIRA_HOST") || config.jiraHost || "";
     const sanitizedHost = rawHost.startsWith("http") ? rawHost : `https://${rawHost}`;
+    this.jiraHost = sanitizedHost.replace(/\/$/, "");
     const jiraOptions: ConstructorParameters<typeof Version3Client>[0] = {
-      host: sanitizedHost.replace(/\/$/, ""),
+      host: this.jiraHost || '',
     };
     // Basic Auth
     if (getEnvVar("JIRA_EMAIL") && getEnvVar("JIRA_TOKEN")) {
@@ -119,7 +121,7 @@ export class JiraProvider extends TicketProviderRoot {
       uxLog(
         "action",
         this,
-        c.cyan(`[JiraProvider] Now trying to collect ${jiraTicketsNumber} tickets infos from JIRA server ` + process.env.JIRA_HOST + " ..."),
+        c.cyan(`[JiraProvider] Now trying to collect ${jiraTicketsNumber} tickets infos from JIRA server ` + this.jiraHost + " ..."),
       );
     }
     for (const ticket of tickets) {


### PR DESCRIPTION
Corrects the Jira server label in the output message to display the host retrieved from the configuration or environment variables, resolving an issue where the wrong host was being displayed.

The Jira host is now stored in the `jiraHost` property and used in the output message.

Relates to fixes/jira4
