### PR TITLE
feat: add configuration options to skip logs and metrics in API notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Note: Can be used with `sfdx plugins:install sfdx-hardis@beta` and docker image `hardisgroupcom/sfdx-hardis@beta`
 
+## [6.16.1] 2025-12-16
+
+- Notif Provider: Add NOTIF_API_SKIP_LOGS and NOTIF_API_SKIP_METRICS env variables to skip posting logs or metrics to API for all notification types or specific ones. (See details in [documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-integration-api/#skip-configuration))
+
 ## [6.16.0] 2025-12-14
 
 - [hardis:org:diagnose:legacyapi](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/legacyapi/) enhancements:

--- a/docs/salesforce-ci-cd-setup-integration-api.md
+++ b/docs/salesforce-ci-cd-setup-integration-api.md
@@ -86,6 +86,23 @@ ApexTestsFailingClasses,source=sfdx-hardis,type=APEX_TESTS,orgIdentifier=hardis-
 ApexTestsCodeCoverage,source=sfdx-hardis,type=APEX_TESTS,orgIdentifier=hardis-group,gitIdentifier=monitoring-hardis-org/monitoring_hardis_group metric=90.00
 ```
 
+## Skip Configuration
+
+You can skip sending logs or metrics to the API based on notification type by defining the following CI/CD variables:
+
+- **NOTIF_API_SKIP_LOGS** : Comma-separated list of notification types to skip for logs, or `all` to skip all logs
+- **NOTIF_API_SKIP_METRICS** : Comma-separated list of notification types to skip for metrics, or `all` to skip all metrics
+
+Examples of configuration:
+
+```sh
+NOTIF_API_SKIP_LOGS=all
+```
+
+```sh
+NOTIF_API_SKIP_METRICS=APEX_TESTS,DEPLOYMENT
+```
+
 ## Troubleshooting
 
 If you want to see the content of the API notifications in execution logs, you can define `NOTIF_API_DEBUG=true`

--- a/docs/salesforce-monitoring-config-home.md
+++ b/docs/salesforce-monitoring-config-home.md
@@ -81,6 +81,22 @@ Example in env var:
 NOTIFICATIONS_DISABLE=METADATA_STATUS,UNUSED_METADATAS
 ```
 
+You can also decide to skip posting logs or metrics to API for all notification types or specific ones by defining env variables **NOTIF_API_SKIP_LOGS** and **NOTIF_API_SKIP_METRICS**.
+
+Examples:
+
+```sh
+# Skip posting logs to API and JSON file for specific notification types
+NOTIF_API_SKIP_LOGS=UNUSED_USERS,METADATA_STATUS
+```
+
+```sh
+# Skip posting logs to API and JSON file for all notification types
+NOTIF_API_SKIP_LOGS=all
+# Skip posting metrics to API for specific notification types
+NOTIF_API_SKIP_METRICS=METADATA_STATUS,UNUSED_METADATAS
+```
+
 ## Monitoring commands
 
 You can decide to disable commands by defining either a **monitoringDisable** property in `.sfdx-hardis.yml`, or a comma separated list in env variable **MONITORING_DISABLE**


### PR DESCRIPTION
- Notif Provider: Add NOTIF_API_SKIP_LOGS and NOTIF_API_SKIP_METRICS env variables to skip posting logs or metrics to API for all notification types or specific ones. (See details in [documentation](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-integration-api/#skip-configuration))