### PR TITLE
JSON.Stringify() object to avoid textInit.startsWith error in uxLog

### DIFF
--- a/src/commands/hardis/project/clean/filter-xml-content.ts
+++ b/src/commands/hardis/project/clean/filter-xml-content.ts
@@ -175,7 +175,7 @@ The command's technical implementation involves:
             // Found matching type tag
             found = true;
             uxLog("other", this, '\nFound type: ' + eltKey);
-            uxLog("other", this, elementValue[eltKey]);
+            uxLog("other", this, JSON.stringify(elementValue[eltKey], null, 2));
             // Filter type values
             const typeValues = elementValue[eltKey];
             const newTypeValues: any[] = [];


### PR DESCRIPTION
The uxLog throws an textInit.startsWith error when trying to parse an object