### PR TITLE
Added OpenAI Codex as AiProvider

### DIFF
--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -139,6 +139,33 @@
       "title": "LangChain base URL",
       "type": "string"
     },
+    "useCodexDirect": {
+      "$id": "#/properties/useCodexDirect",
+      "description": "Set to true to enable the direct Codex connector (mirrors USE_CODEX_DIRECT env var).",
+      "title": "Enable Codex",
+      "type": "boolean",
+      "default": false
+    },
+    "codexModel": {
+      "$id": "#/properties/codexModel",
+      "description": "Name of the Codex model to use by default (ex: gpt-5.1-codex). Equivalent to CODEX_MODEL env var.",
+      "title": "Codex model",
+      "type": "string",
+      "default": "gpt-5.1-codex"
+    },
+    "codexReasoningEffort": {
+      "$id": "#/properties/codexReasoningEffort",
+      "description": "Reasoning effort used for direct Codex prompts. Equivalent to CODEX_REASONING_EFFORT env var. Note: Not all values are supported by all models",
+      "title": "Codex reasoning effort",
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default": "high"
+    },
     "useOpenaiDirect": {
       "$id": "#/properties/useOpenaiDirect",
       "description": "Set to true to enable the direct OpenAI connector (mirrors USE_OPENAI_DIRECT env var).",

--- a/docs/all-env-variables.md
+++ b/docs/all-env-variables.md
@@ -34,6 +34,7 @@ This list has been generated with GitHub Copilot so if you see any incoherence p
    - [MegaLinter LLM Advisor](#megalinter-llm-advisor)
    - [Agentforce (Salesforce) integration](#agentforce-salesforce-integration)
    - [LangChain integration (OpenAI, Anthropic, Gemini...)](#langchain-integration-openai-anthropic-gemini)
+   - [Codex (direct) variables](#codex-direct-variables)
    - [OpenAI (direct) variables](#openai-direct-variables)
    - [Email Notifications](#email-notifications)
    - [Browser Automation](#browser-automation)
@@ -221,6 +222,17 @@ Non-sensitive defaults (prompt template, custom endpoint) can be placed directly
 | **LANGCHAIN_LLM_BASE_URL**      | Base URL for LangChain HTTP-based providers (e.g., Ollama)                        | `http://localhost:11434` | URL string                                                          | LangChain / Ollama examples                                                                                                                        |
 
 You can also define non-secret defaults (provider, model, temperature, etc.) in your project `.sfdx-hardis.yml` using camelCase versions of the LangChain environment variables (for example `langchainLlmProvider` and `langchainLlmModel`). API keys must still be provided via secure env vars.
+
+### Codex (direct) variables
+
+| Variable Name      | Description                                                                                     | Default         | Possible Values                                                | Usage Location                                                                                                             |
+|--------------------|-------------------------------------------------------------------------------------------------|-----------------|----------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| **USE_CODEX_DIRECT** | Enable direct Codex provider integration                                                        | `false`         | `'true'`, `'false'`                                            | [`src/common/aiProvider/codexProvider.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/aiProvider/codexProvider.ts) |
+| **CODEX_API_KEY**  | Codex API key for direct Codex operations (optional when local auth cache is available)        | `undefined`     | Valid Codex/OpenAI API keys                                    | [`src/common/aiProvider/codexProvider.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/aiProvider/codexProvider.ts) |
+| **CODEX_MODEL**    | Codex model to use for prompts                                                                  | `gpt-5.1-codex` | Codex model names (e.g., `gpt-5.1-codex`, `gpt-5.1-codex-max`) | Codex-specific configuration                                                                                              |
+| **CODEX_REASONING_EFFORT** | Reasoning effort used for direct Codex calls                                            | `high`          | `low`, `medium`, `high`, `xhigh`                                         | [`src/common/aiProvider/codexProvider.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/aiProvider/codexProvider.ts) |
+
+When `CODEX_API_KEY` is not defined, sfdx-hardis will also accept existing local Codex authentication cache at `CODEX_HOME/auth.json` (or `~/.codex/auth.json` when `CODEX_HOME` is not set).
 
 ### OpenAI (direct) variables
 

--- a/docs/salesforce-ai-setup.md
+++ b/docs/salesforce-ai-setup.md
@@ -170,6 +170,34 @@ openaiModel: gpt-4o-mini
 
 Store only model and provider preferences in the config file; keep `OPENAI_API_KEY` in a secure environment variable.
 
+### With Codex Directly
+
+To use Codex directly, set `USE_CODEX_DIRECT=true`.
+
+Authentication is resolved in this order:
+
+1. `CODEX_API_KEY` environment variable (recommended for CI/CD).
+2. Existing Codex local auth cache file at `$CODEX_HOME/auth.json` (or `~/.codex/auth.json` when `CODEX_HOME` is not set).
+
+| Variable         | Description                                                                                               | Default         |
+|------------------|-----------------------------------------------------------------------------------------------------------|-----------------|
+| USE_CODEX_DIRECT | Set to true to activate direct Codex integration                                                          | `false`         |
+| CODEX_API_KEY    | Codex API key used by `@openai/codex-sdk` (optional if auth cache file exists)                            |                 |
+| CODEX_MODEL      | Codex model used to perform prompts                                                                       | `gpt-5.1-codex` |
+| CODEX_REASONING_EFFORT | Reasoning effort used for Codex calls (`low`, `medium`, `high`, `xhigh`)                            | `high`          |
+
+If `CODEX_REASONING_EFFORT` is set to an unsupported value, sfdx-hardis falls back to `high`.
+
+#### Configure Codex via .sfdx-hardis.yml
+
+```yaml
+useCodexDirect: true
+codexModel: gpt-5.1-codex
+codexReasoningEffort: high
+```
+
+Store only model preferences in the config file; keep `CODEX_API_KEY` in a secure environment variable when running in CI/CD.
+
 ## Templates
 
 You can override default prompts by defining the following environment variables.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@langchain/ollama": "1.2.3",
     "@langchain/openai": "1.2.8",
     "@oclif/core": "4.8.0",
+    "@openai/codex-sdk": "0.105.0",
     "@salesforce/core": "8.25.1",
     "@salesforce/sf-plugins-core": "11.3.12",
     "@slack/types": "2.20.0",

--- a/src/common/aiProvider/codexProvider.ts
+++ b/src/common/aiProvider/codexProvider.ts
@@ -1,0 +1,160 @@
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import c from "chalk";
+import { Codex } from "@openai/codex-sdk";
+import { getEnvVar } from "../../config/index.js";
+import { PromptTemplate } from "./promptTemplates.js";
+import { resolveBooleanFlag } from "./providerConfigUtils.js";
+import { uxLog } from "../utils/index.js";
+import { AiProviderRoot } from "./aiProviderRoot.js";
+import { AiResponse } from "./index.js";
+
+export class CodexProvider extends AiProviderRoot {
+  private static readonly DEFAULT_MODEL = "gpt-5.1-codex";
+  private static readonly DEFAULT_REASONING_EFFORT: CodexReasoningEffort = "high";
+  private static readonly SUPPORTED_REASONING_EFFORTS: CodexReasoningEffort[] = ["low", "medium", "high", "xhigh"];
+
+  private codex: Codex | null = null;
+  private readonly modelName: string;
+  private readonly apiKey?: string;
+  private readonly reasoningEffort: CodexReasoningEffort;
+
+  private constructor(config: CodexResolvedConfig) {
+    super();
+    this.modelName = config.modelName;
+    this.apiKey = config.apiKey;
+    this.reasoningEffort = config.reasoningEffort;
+  }
+
+  public getLabel(): string {
+    return "Codex connector";
+  }
+
+  public static async isConfigured(): Promise<boolean> {
+    const config = await this.resolveConfig();
+    return config != null;
+  }
+
+  public static async shouldPromptForApiKey(): Promise<boolean> {
+    const { enabled } = await resolveBooleanFlag({
+      envVar: "USE_CODEX_DIRECT",
+      configKey: "useCodexDirect",
+      defaultValue: false,
+    });
+    if (!enabled) {
+      return false;
+    }
+    if (getEnvVar("CODEX_API_KEY")) {
+      return false;
+    }
+    return !existsSync(this.resolveAuthFilePath());
+  }
+
+  public static async create(): Promise<CodexProvider> {
+    const config = await this.resolveConfig();
+    if (!config) {
+      throw new Error("Codex provider is not properly configured");
+    }
+    return new CodexProvider(config);
+  }
+
+  private static async resolveConfig(): Promise<CodexResolvedConfig | null> {
+    const { enabled, rootConfig } = await resolveBooleanFlag({
+      envVar: "USE_CODEX_DIRECT",
+      configKey: "useCodexDirect",
+      defaultValue: false,
+    });
+    if (!enabled) {
+      return null;
+    }
+
+    const apiKey = getEnvVar("CODEX_API_KEY") || undefined;
+    if (!apiKey && !existsSync(this.resolveAuthFilePath())) {
+      return null;
+    }
+
+    const modelName = getEnvVar("CODEX_MODEL")
+      || rootConfig.codexModel
+      || rootConfig.CODEX_MODEL
+      || CodexProvider.DEFAULT_MODEL;
+    const reasoningEffort = this.resolveReasoningEffort(
+      getEnvVar("CODEX_REASONING_EFFORT")
+      || rootConfig.codexReasoningEffort
+      || rootConfig.CODEX_REASONING_EFFORT
+      || CodexProvider.DEFAULT_REASONING_EFFORT
+    );
+
+    return { apiKey, modelName, reasoningEffort };
+  }
+
+  private static resolveAuthFilePath(): string {
+    const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+    return path.join(codexHome, "auth.json");
+  }
+
+  private static resolveReasoningEffort(rawValue: string): CodexReasoningEffort {
+    const normalizedValue = rawValue.toLowerCase();
+    if (CodexProvider.SUPPORTED_REASONING_EFFORTS.includes(normalizedValue as CodexReasoningEffort)) {
+      return normalizedValue as CodexReasoningEffort;
+    }
+
+    uxLog("warning", this, c.yellow(`[Codex] Unsupported reasoning effort "${rawValue}". Falling back to "${CodexProvider.DEFAULT_REASONING_EFFORT}".`));
+    return CodexProvider.DEFAULT_REASONING_EFFORT;
+  }
+
+  private getCodexClient(): Codex {
+    if (!this.codex) {
+      this.codex = this.apiKey ? new Codex({ apiKey: this.apiKey }) : new Codex();
+    }
+    return this.codex;
+  }
+
+  public async promptAi(promptText: string, template: PromptTemplate | null = null): Promise<AiResponse | null> {
+    if (!this.checkMaxAiCallsNumber()) {
+      const maxCalls = this.getAiMaxCallsNumber();
+      uxLog("warning", this, c.yellow(`[Codex] Already performed maximum ${maxCalls} calls. Increase it by defining AI_MAXIMUM_CALL_NUMBER env variable`));
+      return null;
+    }
+
+    if (process.env?.DEBUG_PROMPTS === "true") {
+      uxLog("log", this, c.grey(`[Codex] Requesting the following prompt to ${this.modelName}${template ? " using template " + template : ""}:\n${promptText}`));
+    } else {
+      uxLog("log", this, c.grey(`[Codex] Requesting prompt to ${this.modelName}${template ? " using template " + template : ""} (define DEBUG_PROMPTS=true to see details)`));
+    }
+
+    this.incrementAiCallsNumber();
+
+    const thread = this.getCodexClient().startThread({
+      model: this.modelName,
+      modelReasoningEffort: this.reasoningEffort,
+      sandboxMode: "read-only",
+      approvalPolicy: "never",
+    });
+    const turn = await thread.run(promptText);
+
+    if (process.env?.DEBUG_PROMPTS === "true") {
+      uxLog("log", this, c.grey("[Codex] Received prompt response from " + this.modelName + "\n" + JSON.stringify(turn, null, 2)));
+    } else {
+      uxLog("log", this, c.grey("[Codex] Received prompt response from " + this.modelName));
+    }
+
+    const aiResponse: AiResponse = {
+      success: false,
+      model: this.modelName,
+    };
+    if (turn.finalResponse) {
+      aiResponse.success = true;
+      aiResponse.promptResponse = turn.finalResponse;
+    }
+    return aiResponse;
+  }
+}
+
+interface CodexResolvedConfig {
+  apiKey?: string;
+  modelName: string;
+  reasoningEffort: CodexReasoningEffort;
+}
+
+type CodexReasoningEffort = "low" | "medium" | "high" | "xhigh";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,6 +2194,55 @@
   dependencies:
     "@octokit/openapi-types" "^25.1.0"
 
+"@openai/codex-darwin-arm64@npm:@openai/codex@0.105.0-darwin-arm64":
+  version "0.105.0-darwin-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.105.0-darwin-arm64.tgz#cc75f2f64346fb602d9d7e99daa9a0400b5cad8f"
+  integrity sha512-9TD7pDIg8o7itmOhyEPcC2HeVnVIOxxrrbwTvnTibMj2rHPLnY8E0JaK8QOBRNiIUlqI4WKspTMUZQg5Fegndw==
+
+"@openai/codex-darwin-x64@npm:@openai/codex@0.105.0-darwin-x64":
+  version "0.105.0-darwin-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.105.0-darwin-x64.tgz#d48df9018a5e3079dbb65a50ac1b4bfb1fe474b8"
+  integrity sha512-00xRV2X7RwKFRY8LB99/WmVSWqhHnMV6BB4gc5x4MMuDPDslaNrGTYWdp6KBukok1ayrg0JfwazUeAawNWU5Zw==
+
+"@openai/codex-linux-arm64@npm:@openai/codex@0.105.0-linux-arm64":
+  version "0.105.0-linux-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.105.0-linux-arm64.tgz#9f820f14479b3817280d9ac28a3d54b9591115bd"
+  integrity sha512-UFGyZhRB0Gtr31wFf0WDd//W3XGbZZ7mxYwf528i6rhlwabb3FIJKWrgv4DVXKQZCGiBujqAk0pr32PziElouA==
+
+"@openai/codex-linux-x64@npm:@openai/codex@0.105.0-linux-x64":
+  version "0.105.0-linux-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.105.0-linux-x64.tgz#e0e1a51ce8540b121a40423c42af740a281c414e"
+  integrity sha512-cZgNzNjspqHmXNf/CraqqQrfotw5cXO7wvkSSYs2NZjZR7Ud10u5hFeumUW1sEvb5/F9tEKsjO+WCj+bVxdrYQ==
+
+"@openai/codex-sdk@0.105.0":
+  version "0.105.0"
+  resolved "https://registry.yarnpkg.com/@openai/codex-sdk/-/codex-sdk-0.105.0.tgz#2fe4bc6bdeb72a43cd65905ec94699f8412e27a8"
+  integrity sha512-sHq9JdcZftlybuWH5846h2bezKcMpTBX7m2AH8vpqV1+1ex7Q/Prwy64b81oMjrlWooiK+sVelZFED6ZPeLCZg==
+  dependencies:
+    "@openai/codex" "0.105.0"
+
+"@openai/codex-win32-arm64@npm:@openai/codex@0.105.0-win32-arm64":
+  version "0.105.0-win32-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.105.0-win32-arm64.tgz#c5333c8ea7734aa6b1496912469dd046dc13e123"
+  integrity sha512-OGvHTn/XAyY8889n0ZEcvUgiaPeT/rLFEFUEOzWgt5yhKiODV+zEzfruYmcvZUpzgFJ1kRQlDgKPMbW7u2r01Q==
+
+"@openai/codex-win32-x64@npm:@openai/codex@0.105.0-win32-x64":
+  version "0.105.0-win32-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.105.0-win32-x64.tgz#874816e5a693d856db970609cbdb0ec9fc7ed354"
+  integrity sha512-8V26RjFeg06i4mrrhQTKLY6lcRXsm0s1cxT3lamApLccvBBAhhAOE0je6jHb5nkrncvf9x/lee+WmY0louvvGQ==
+
+"@openai/codex@0.105.0":
+  version "0.105.0"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.105.0.tgz#a9d7319a2cbbf22cbec4ad41aed6cbd0a33ef76d"
+  integrity sha512-enoNmQs3aOgUhsKYC6kfuKEG0AogS4q01pqcySPwf9zl2r8OcKuMUoLw1v5n4Y7sd3B6qGS7UtTABqbcT5FaMA==
+  optionalDependencies:
+    "@openai/codex-darwin-arm64" "npm:@openai/codex@0.105.0-darwin-arm64"
+    "@openai/codex-darwin-x64" "npm:@openai/codex@0.105.0-darwin-x64"
+    "@openai/codex-linux-arm64" "npm:@openai/codex@0.105.0-linux-arm64"
+    "@openai/codex-linux-x64" "npm:@openai/codex@0.105.0-linux-x64"
+    "@openai/codex-win32-arm64" "npm:@openai/codex@0.105.0-win32-arm64"
+    "@openai/codex-win32-x64" "npm:@openai/codex@0.105.0-win32-x64"
+
 "@pinojs/redact@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@pinojs/redact/-/redact-0.4.0.tgz#c3de060dd12640dcc838516aa2a6803cc7b2e9d6"


### PR DESCRIPTION
We are already paying for ChatGPT with Codex in my company so I thought why not use that 🙂 

This PR adds a minimal CodexProvider integration in the same way ass the existing AI Providers.

What’s included
Add Codex SDK dependency.
Add new CodexProvider extending AiProviderRoot.
Register Codex in AI provider selection flow.
Added relevant config/env variables.
Supports both local authentication (codex is already installed and you are logged in via ChatGPT subscription) and API key.
