### PR TITLE
Make # optional in PR message

### DIFF
--- a/src/common/gitProvider/azureDevops.ts
+++ b/src/common/gitProvider/azureDevops.ts
@@ -126,11 +126,15 @@ ${this.getPipelineVariablesConfig()}
       // - "Merged PR #123: Title"
       // - "Merge PR #123"
       // - "Merged pull request #123"
+      // - "Merge pull request 123 from branch-name"
+      // - "Merged PR 123: Title"
+      // - "Merge PR 123"
+      // - "Merged pull request 123"
       const prIdPatterns = [
-        /(?:Merge|Merged)\s+(?:pull\s+request|PR)\s+#(\d+)/i,
-        /(?:Merge|Merged)\s+PR\s+#(\d+)/i,
-        /pull\s+request\s+#(\d+)/i,
-        /PR\s+#(\d+)/i,
+        /(?:Merge|Merged)\s+(?:pull\s+request|PR)\s+#?(\d+)/i,
+        /(?:Merge|Merged)\s+PR\s+#?(\d+)/i,
+        /pull\s+request\s+#?(\d+)/i,
+        /PR\s+#?(\d+)/i,
       ];
       for (const pattern of prIdPatterns) {
         const match = commitMessage.match(pattern);


### PR DESCRIPTION
I get this error when running smart deploy: 

[sfdx-hardis] [Azure integration] Listing Threads of Pull Request #NaN ...
[sfdx-hardis] [GitProvider] Error while trying to post pull request message.
{"count":1,"value":{"Message":"The request is invalid."}}
Error: {"count":1,"value":{"Message":"The request is invalid."}}
    at RestClient.<anonymous> (/home/vsts/.local/share/sf/node_modules/typed-rest-client/RestClient.js:204:31)
    at Generator.next (<anonymous>)
    at fulfilled (/home/vsts/.local/share/sf/node_modules/typed-rest-client/RestClient.js:7:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)

It seems that the regex used expect a # to be present in the merge commit, but the merge strategy I have does not add that. Therefor I have made it optional.