### PR TITLE
Ensure that target username is not lost to devhub

### DIFF
--- a/src/common/utils/authUtils.ts
+++ b/src/common/utils/authUtils.ts
@@ -170,9 +170,11 @@ export async function authOrg(orgAlias: string, options: AuthOrgOptions): Promis
         options.forceUsername :
         typeof cmdFlags.targetusername === 'string'
           ? cmdFlags.targetusername
-          : process.env.TARGET_USERNAME || isDevHub
+          : isDevHub
             ? config.devHubUsername
-            : config.targetUsername || null;
+            : process.env.TARGET_USERNAME
+              ? process.env.TARGET_USERNAME
+              : config.targetUsername || null;
     if (username == null && isCI) {
       const gitBranchFormatted = await getCurrentGitBranch({ formatted: true });
       console.error(


### PR DESCRIPTION
Small proposed fix for https://github.com/hardisgroupcom/sfdx-hardis/issues/1772 where the targetUsername is not overwritten by devHubUsername on non-branch config