### PR TITLE
Removed invalid Env Var already handled in getPullRequestInfo()

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -271,7 +271,9 @@ export async function getReportDirectory() {
 export function getEnvVar(envVarName: string): string | null {
   const varValue = process.env[envVarName] || null;
   // Avoid Azure cases that sends the expression as string if variable not defined
-  if (varValue && varValue.includes(`(${envVarName}`)) {
+  // RegEx will match on strings beginning with '$(' some text, then ')' 
+  // It will match unresolved environment vars e.g. $(System.PullRequest.PullRequestId) or $(JIRA_TICKET_REGEX)
+  if (varValue && /^\$\([^)]+\)$/.test(varValue)) {
     return null;
   }
   return varValue;


### PR DESCRIPTION
In a deployment scenario the getEnvVar("SYSTEM_PULLREQUEST_PULLREQUESTID") resolves to $(System.PullRequest.PullRequestId) which in line [#540](https://github.com/hardisgroupcom/sfdx-hardis/blob/cb5333cdea1d97c95cd6ff14f59ef13943ab52d4/src/common/gitProvider/azureDevops.ts#L540) gives NaN when trying to interpret as number.

There is already a more solid check in getPullRequestInfo() so this env just overwrites that and cause the message post to fail.