### PR TITLE
Added "secrets" variable before the SFDX_AUTH_URL_TECHNICAL_ORG

### DIFF
--- a/defaults/ci/.github/workflows/check-deploy.yml
+++ b/defaults/ci/.github/workflows/check-deploy.yml
@@ -59,7 +59,7 @@ jobs:
           SFDX_CLIENT_KEY_PREPROD: ${{ secrets.SFDX_CLIENT_KEY_PREPROD}}
           SFDX_CLIENT_ID_MAIN: ${{ secrets.SFDX_CLIENT_ID_MAIN}}
           SFDX_CLIENT_KEY_MAIN: ${{ secrets.SFDX_CLIENT_KEY_MAIN}}
-          SFDX_AUTH_URL_TECHNICAL_ORG: ${{ SFDX_AUTH_URL_TECHNICAL_ORG }}
+          SFDX_AUTH_URL_TECHNICAL_ORG: ${{ secrets.SFDX_AUTH_URL_TECHNICAL_ORG }}
           SFDX_DEPLOY_WAIT_MINUTES: ${{ vars.SFDX_DEPLOY_WAIT_MINUTES || '120' }}
           SFDX_TEST_WAIT_MINUTES: ${{ vars.SFDX_TEST_WAIT_MINUTES || '120' }}
           CI_COMMIT_REF_NAME: ${{ github.event.pull_request.base.ref }} # Defines the target branch of the PR


### PR DESCRIPTION
I noticed an issue when generating a project with the check-deploy Github action.

The automatically generated workflow file contains this line:
SFDX_AUTH_URL_TECHNICAL_ORG: ${{  SFDX_AUTH_URL_TECHNICAL_ORG }}

This throws an error for an invalid workflow file when Github actions tries to run it. It needs to be referencing the "secrets" variable like this:
SFDX_AUTH_URL_TECHNICAL_ORG: ${{ secrets.SFDX_AUTH_URL_TECHNICAL_ORG }}

I found where the file is kept in the repo and corrected the line.

Steps taken to test:
Made the change
Built the new version of the project, linked the plugin
Created a new sfdx project,
Ran the "Create a new SFDX Project" command from the VS Code extension inside the new project
The Github workflow file seems to generate correctly


This is my first contribution to this project, so please let me know if I need to do something differently!