### PR TITLE
Migrated to OpenAI ResponsesAPI 

### DIFF
--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -180,6 +180,28 @@
       "type": "string",
       "default": "gpt-4o-mini"
     },
+    "openaiServiceTier": {
+      "$id": "#/properties/openaiServiceTier",
+      "description": "Service tier used for direct OpenAI prompts. Equivalent to OPENAI_SERVICE_TIER env var.",
+      "title": "OpenAI service tier",
+      "type": "string",
+      "enum": [
+        "auto",
+        "default",
+        "flex"
+      ]
+    },
+    "openaiReasoningEffort": {
+      "$id": "#/properties/openaiReasoningEffort",
+      "description": "Reasoning effort used for direct OpenAI prompts on supported models. Equivalent to OPENAI_REASONING_EFFORT env var.",
+      "title": "OpenAI reasoning effort",
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
     "useAgentforce": {
       "$id": "#/properties/useAgentforce",
       "description": "Set to true to enable Agentforce integration (mirrors USE_AGENTFORCE env var).",

--- a/docs/all-env-variables.md
+++ b/docs/all-env-variables.md
@@ -242,12 +242,14 @@ When `CODEX_API_KEY` is not defined, sfdx-hardis will also accept existing local
 
 ### OpenAI (direct) variables
 
-| Variable Name      | Description                      | Default       | Possible Values                                                      | Usage Location                                                                                                             |
-|--------------------|----------------------------------|---------------|----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| **OPENAI_API_KEY** | OpenAI API key for AI operations | `undefined`   | Valid OpenAI API keys                                                | [`src/common/aiProvider/index.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/aiProvider/index.ts) |
-| **OPENAI_MODEL**   | OpenAI model to use for prompts  | `gpt-4o-mini` | OpenAI model names (e.g., `gpt-4o-mini`, `gpt-4o`, `gpt-4o-mini-3b`) | OpenAI-specific configuration                                                                                              |
+| Variable Name                    | Description                                            | Default       | Possible Values                                                      | Usage Location                                                                                                                      |
+|----------------------------------|--------------------------------------------------------|---------------|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| **OPENAI_API_KEY**               | OpenAI API key for AI operations                       | `undefined`   | Valid OpenAI API keys                                                | [`src/common/aiProvider/index.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/aiProvider/index.ts)        |
+| **OPENAI_MODEL**                 | OpenAI model to use for prompts                        | `gpt-4o-mini` | OpenAI model names (e.g., `gpt-4o-mini`, `gpt-4o`, `gpt-4o-mini-3b`) | OpenAI-specific configuration                                                                                                       |
+| **OPENAI_SERVICE_TIER**          | Optional OpenAI service tier for direct prompts        | `undefined`   | `auto`, `default`, `flex`                                            | [`src/common/aiProvider/openaiProvider.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/aiProvider/openaiProvider.ts) |
+| **OPENAI_REASONING_EFFORT**      | Optional reasoning effort for supported OpenAI models  | `undefined`   | `low`, `medium`, `high`                                              | [`src/common/aiProvider/openaiProvider.ts`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/src/common/aiProvider/openaiProvider.ts) |
 
-Project-wide defaults (e.g., preferred model) can be stored directly at the root of `.sfdx-hardis.yml` using camelCase keys (for example `openaiModel`), but the `OPENAI_API_KEY` must remain in a secured environment variable.
+Project-wide defaults (e.g., preferred model) can be stored directly at the root of `.sfdx-hardis.yml` using camelCase keys (for example `openaiModel`, `openaiServiceTier`, `openaiReasoningEffort`), but the `OPENAI_API_KEY` must remain in a secured environment variable.
 
 ### Email Notifications
 

--- a/docs/salesforce-ai-setup.md
+++ b/docs/salesforce-ai-setup.md
@@ -156,16 +156,20 @@ You need to define env variable OPENAI_API_KEY and make it available to your CI/
 
 To get an OpenAi API key , register on [OpenAi Platform](https://platform.openai.com/).
 
-| Variable       | Description                                                                               | Default       |
-|----------------|-------------------------------------------------------------------------------------------|---------------|
-| OPENAI_API_KEY | Your openai account API key                                                               |               |
-| OPENAI_MODEL   | OpenAi model used to perform prompts (see [models list](https://openai.com/api/pricing/)) | `gpt-4o-mini` |
+| Variable                 | Description                                                                                           | Default       |
+|--------------------------|-------------------------------------------------------------------------------------------------------|---------------|
+| OPENAI_API_KEY           | Your openai account API key                                                                           |               |
+| OPENAI_MODEL             | OpenAi model used to perform prompts (see [models list](https://openai.com/api/pricing/))            | `gpt-4o-mini` |
+| OPENAI_SERVICE_TIER      | Optional OpenAI service tier for supported projects (`auto`, `default`, `flex`)                      |               |
+| OPENAI_REASONING_EFFORT  | Optional reasoning effort for supported OpenAI reasoning models (`low`, `medium`, `high`)            |               |
 
 #### Configure OpenAI via .sfdx-hardis.yml
 
 ```yaml
 useOpenaiDirect: true
 openaiModel: gpt-4o-mini
+openaiServiceTier: auto
+openaiReasoningEffort: medium
 ```
 
 Store only model and provider preferences in the config file; keep `OPENAI_API_KEY` in a secure environment variable.

--- a/src/common/aiProvider/openaiProvider.ts
+++ b/src/common/aiProvider/openaiProvider.ts
@@ -9,12 +9,20 @@ import { resolveBooleanFlag } from "./providerConfigUtils.js";
 import { t } from '../utils/i18n.js';
 
 export class OpenAiProvider extends AiProviderRoot {
-  protected openai: OpenAI;
-  private modelName: string;
+  private static readonly DEFAULT_MODEL = "gpt-4o-mini";
+  private static readonly SUPPORTED_SERVICE_TIERS: OpenAiServiceTier[] = ["auto", "default", "flex"];
+  private static readonly SUPPORTED_REASONING_EFFORTS: OpenAiReasoningEffort[] = ["low", "medium", "high"];
 
-  private constructor(modelName: string) {
+  protected openai: OpenAI;
+  private readonly modelName: string;
+  private readonly serviceTier?: OpenAiServiceTier;
+  private readonly reasoningEffort?: OpenAiReasoningEffort;
+
+  private constructor(config: OpenAiResolvedConfig) {
     super();
-    this.modelName = modelName || "gpt-4o-mini";
+    this.modelName = config.modelName || OpenAiProvider.DEFAULT_MODEL;
+    this.serviceTier = config.serviceTier;
+    this.reasoningEffort = config.reasoningEffort;
     this.openai = new OpenAI();
   }
 
@@ -32,7 +40,7 @@ export class OpenAiProvider extends AiProviderRoot {
     if (!config) {
       throw new Error("OpenAI provider is not properly configured");
     }
-    return new OpenAiProvider(config.modelName);
+    return new OpenAiProvider(config);
   }
 
   private static async resolveConfig(): Promise<OpenAiResolvedConfig | null> {
@@ -50,8 +58,37 @@ export class OpenAiProvider extends AiProviderRoot {
     const modelName = getEnvVar("OPENAI_MODEL")
       || rootConfig.openaiModel
       || rootConfig.OPENAI_MODEL
-      || "gpt-4o-mini";
-    return { modelName };
+      || OpenAiProvider.DEFAULT_MODEL;
+    const serviceTier = this.resolveOptionalServiceTier(
+      getEnvVar("OPENAI_SERVICE_TIER")
+      || rootConfig.openaiServiceTier
+      || rootConfig.OPENAI_SERVICE_TIER
+    );
+    const reasoningEffort = this.resolveOptionalReasoningEffort(
+      getEnvVar("OPENAI_REASONING_EFFORT")
+      || rootConfig.openaiReasoningEffort
+      || rootConfig.OPENAI_REASONING_EFFORT
+    );
+    return { modelName, serviceTier, reasoningEffort };
+  }
+
+  private static resolveOptionalServiceTier(rawValue: string | null | undefined): OpenAiServiceTier | undefined {
+    return this.resolveOptionalEnumValue(rawValue, OpenAiProvider.SUPPORTED_SERVICE_TIERS);
+  }
+
+  private static resolveOptionalReasoningEffort(rawValue: string | null | undefined): OpenAiReasoningEffort | undefined {
+    return this.resolveOptionalEnumValue(rawValue, OpenAiProvider.SUPPORTED_REASONING_EFFORTS);
+  }
+
+  private static resolveOptionalEnumValue<T extends string>(rawValue: string | null | undefined, supportedValues: T[]): T | undefined {
+    if (!rawValue) {
+      return undefined;
+    }
+    const normalizedValue = rawValue.toLowerCase();
+    if (supportedValues.includes(normalizedValue as T)) {
+      return normalizedValue as T;
+    }
+    return undefined;
   }
 
   public async promptAi(promptText: string, template: PromptTemplate | null = null): Promise<AiResponse | null> {
@@ -66,23 +103,30 @@ export class OpenAiProvider extends AiProviderRoot {
       uxLog("log", this, c.grey('[OpenAI] ' + t('openaiRequestingPrompt', { modelName: gptModel, template: template ? ' using template ' + template : '' })));
     }
     this.incrementAiCallsNumber();
-    const completion = await this.openai.chat.completions.create({
-      messages: [{ role: "system", content: promptText }],
+    const request: OpenAI.Responses.ResponseCreateParamsNonStreaming = {
       model: gptModel,
-    });
+      input: [{ role: "system", content: promptText }],
+    };
+    if (this.serviceTier) {
+      request.service_tier = this.serviceTier;
+    }
+    if (this.reasoningEffort) {
+      request.reasoning = { effort: this.reasoningEffort };
+    }
+    const response = await this.openai.responses.create(request);
     if (process.env?.DEBUG_PROMPTS === "true") {
-      uxLog("log", this, c.grey('[OpenAI] ' + t('openaiReceivedResponseDebug', { modelName: gptModel, response: JSON.stringify(completion, null, 2) })));
+      uxLog("log", this, c.grey('[OpenAI] ' + t('openaiReceivedResponseDebug', { modelName: gptModel, response: JSON.stringify(response, null, 2) })));
     }
     else {
       uxLog("log", this, c.grey('[OpenAI] ' + t('openaiReceivedResponse', { modelName: gptModel })));
     }
     const aiResponse: AiResponse = {
       success: false,
-      model: completion.model,
+      model: response.model,
     };
-    if (completion?.choices?.length > 0) {
+    if (response.output.length > 0) {
       aiResponse.success = true;
-      aiResponse.promptResponse = completion.choices[0].message.content ?? undefined;
+      aiResponse.promptResponse = response.output_text || undefined;
     }
     return aiResponse;
   }
@@ -90,4 +134,9 @@ export class OpenAiProvider extends AiProviderRoot {
 
 interface OpenAiResolvedConfig {
   modelName: string;
+  serviceTier?: OpenAiServiceTier;
+  reasoningEffort?: OpenAiReasoningEffort;
 }
+
+type OpenAiServiceTier = "auto" | "default" | "flex";
+type OpenAiReasoningEffort = "low" | "medium" | "high";


### PR DESCRIPTION
## Summary

Migrate the direct OpenAI provider from Chat Completions to the Responses API and add support for configurable `service_tier` and `reasoning` options.

## What Changed

- Switched `OpenAiProvider` to use `openai.responses.create(...)` instead of `chat.completions.create(...)`
- Kept the default OpenAI model as `gpt-4o-mini`
- Added optional support for:
  - `OPENAI_SERVICE_TIER` / `openaiServiceTier`
  - `OPENAI_REASONING_EFFORT` / `openaiReasoningEffort`
- Added schema support for the new config keys in `sfdx-hardis.jsonschema.json`
- Updated OpenAI setup and environment variable documentation to describe the new options

## Implementation Notes

- Supported service tiers: `auto`, `default`, `flex`
- Supported reasoning efforts: `low`, `medium`, `high`
- Invalid or unsupported optional values are ignored rather than breaking provider initialization
- Response parsing now reads from the Responses API output (`output_text`)

## Why

This aligns the OpenAI integration with the current API surface and exposes newer request controls for latency/cost/performance tuning on supported models and projects.
e.g. This allows using the flex tier which is half the cost (but slower)

## Docs

Documentation was updated to cover both environment-variable and `.sfdx-hardis.yml` configuration for the new OpenAI options.


