### PR TITLE
docs: add agent guidance for sfdx-hardis command usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# sfdx-hardis Agent Guidance
+
+This repository already documents how coding agents should use `sfdx-hardis`.
+Do not add runtime AI behavior, generated command catalogs, or MCP-specific command
+knowledge here.
+
+## Command Usage
+
+When selecting, explaining, or preparing a `sfdx-hardis` CLI command:
+
+1. First read `docs/salesforce-agentic-automation.md`.
+2. Then read the selected command page under `docs/hardis/**`.
+3. Use `--agent` for non-interactive execution only when the selected command
+   documents agent mode support.
+4. Prefer `--json` when the selected command supports it and structured output
+   is useful.
+
+Do not invent commands, aliases, flags, defaults, examples, or behavior. If the
+existing documentation does not prove a command or flag, say that it is
+unverified and ask for confirmation before using it.
+
+## Safety
+
+Ask for explicit confirmation before recommending or running commands that can:
+
+- deploy or mutate Salesforce metadata;
+- delete data, metadata, files, scratch orgs, or org resources;
+- create, refresh, connect, select, or otherwise mutate org state;
+- mutate git state or publish externally;
+- handle secrets, credentials, tokens, or authentication material.
+
+For local repository work, follow the existing project conventions in
+`CLAUDE.md` and `.claude/skills/**` where relevant. Use Yarn for package
+scripts.


### PR DESCRIPTION
## Summary

This PR adds a small repository guidance file for coding agents that need to select and use `sfdx-hardis` commands safely.

It points agents to the existing canonical documentation:

- `docs/salesforce-agentic-automation.md`
- the selected command page under `docs/hardis/**`
- documented `--agent` behavior for non-interactive execution

## Scope

This PR does not add runtime AI behavior to `sfdx-hardis`.

It does not add a generated command catalog, MCP server, generated command packs, or vendor-specific skills. Command knowledge remains in the existing documentation and command descriptions.

## Validation

- `git diff --name-status origin/main...HEAD`
- `git diff --check origin/main...HEAD`
