### PR TITLE
fix: handle directories in hiddenitems clean

### DIFF
--- a/src/commands/hardis/project/clean/hiddenitems.ts
+++ b/src/commands/hardis/project/clean/hiddenitems.ts
@@ -126,11 +126,15 @@ In agent mode, all interactive prompts are skipped and default values are used.
     /* jscpd:ignore-end */
     const rootFolder = path.resolve(this.folder);
     const findManagedPattern = `**/*.{${HIDDEN_SOURCE_FILE_EXTENSIONS}}`;
-    const matchingCustomFiles = await glob(findManagedPattern, { cwd: rootFolder, ignore: GLOB_IGNORE_PATTERNS });
+    const matchingCustomFiles = await glob(findManagedPattern, { cwd: rootFolder, ignore: GLOB_IGNORE_PATTERNS, nodir: true });
     let counter = 0;
     for (const matchingCustomFile of matchingCustomFiles) {
       const matchingCustomFilePath = path.join(rootFolder, matchingCustomFile);
       if (!fs.existsSync(matchingCustomFilePath)) {
+        continue;
+      }
+      const fileStats = await fs.stat(matchingCustomFilePath);
+      if (!fileStats.isFile()) {
         continue;
       }
       const fileContent = await fs.readFile(matchingCustomFilePath, 'utf8');

--- a/test/commands/hardis/project/clean/hiddenitems.test.ts
+++ b/test/commands/hardis/project/clean/hiddenitems.test.ts
@@ -82,4 +82,21 @@ describe('hardis:project:clean:hiddenitems', () => {
     expect(fs.existsSync(visibleClass), 'visible Apex class should be kept').to.be.true;
     expect(fs.existsSync(visibleClassMeta), 'visible Apex class metadata should be kept').to.be.true;
   });
+
+  it('ignores matching directories and removes hidden files', async () => {
+    const root = ctx.getForceApp();
+    const matchingDirectory = path.join(root, 'objects', 'FolderWithXmlExtension.xml');
+    const hiddenFile = path.join(root, 'classes', 'HiddenClass.xml');
+    const normalFile = path.join(root, 'classes', 'VisibleClass.xml');
+
+    await fs.ensureDir(matchingDirectory);
+    await writeFile(hiddenFile, '(hidden)');
+    await writeFile(normalFile, '<xml/>');
+
+    await CleanHiddenItems.run(['-f', root]);
+
+    expect(fs.existsSync(matchingDirectory), 'matching directory should be ignored').to.be.true;
+    expect(fs.existsSync(hiddenFile), 'hidden file should be removed').to.be.false;
+    expect(fs.existsSync(normalFile), 'normal file should be kept').to.be.true;
+  });
 });


### PR DESCRIPTION
## Summary

- make `hardis:project:clean:hiddenitems` ignore glob matches that are directories
- add a regression test for directories whose names end with scanned extensions

## Root cause

`hardis:project:clean:hiddenitems` scans `**/*.{app,cmp,evt,tokens,html,css,js,xml}` and then calls `fs.readFile(...)` on every match. Static resource dependencies can contain directories such as `bower_components/history.js`, which match the `.js` suffix but are not files. Reading that path throws `EISDIR: illegal operation on a directory, read`.

## Fix

The command now asks `glob` to return files only with `nodir: true`, and also keeps a defensive `stat.isFile()` guard before reading each match.

Fixes #1943

## Validation

- `yarn mocha "test/commands/hardis/project/clean/hiddenitems.test.ts"`
- `yarn eslint "src/commands/hardis/project/clean/hiddenitems.ts" "test/commands/hardis/project/clean/hiddenitems.test.ts"`
- `yarn tsc -p . --pretty false --incremental false`
- `yarn tsc -p ./test --pretty false --noEmit`