### PR TITLE
feat: Enhance release notes command for go-live accuracy, PDF, and actions

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -17,13 +17,24 @@ CHANGELOG.md entries are read by **end users** (Salesforce admins, devs, ops) de
   - NO: "Translated to all 9 locales (de, en, es, fr, it, ja, nl, pl, pt-BR)." (mention only if it is the change itself, e.g. "Added German translations")
 - **Skip implementation details** unless they directly affect the user: file paths, function names, i18n keys, internal flags, refactor mechanics.
 - **Link the command** when the entry applies to a specific command, using the standard format `[hardis:topic:action](https://sfdx-hardis.cloudity.com/hardis/topic/action/)`.
+- **Always group updates by command.** A command must appear at most once in a section. If it already has an entry (or you are adding several changes to the same command), write the command link once and put each change as a nested bullet under it - never repeat the same command link on multiple top-level lines. A single change stays on one line: `[command](url): <change>.`
 - **Add entries under `## [beta] (main)`** at the top of the file. Do not create version sections - releases set those.
 
 ## Pattern
+
+Single change for a command:
 
 ```markdown
 - [hardis:topic:action](https://sfdx-hardis.cloudity.com/hardis/topic/action/): <one short sentence about user-visible change>.
 - <Site / generic change>: <one short sentence>.
 ```
 
-If a single change has genuinely independent user-facing facets, use nested bullets - but only when each sub-bullet is itself end-user relevant (a new flag, a new channel, a new default). Never use sub-bullets to list affected files or locales.
+Multiple changes for the same command - group them under one command link:
+
+```markdown
+- [hardis:topic:action](https://sfdx-hardis.cloudity.com/hardis/topic/action/):
+  - <one short sentence about the first user-visible change>.
+  - <one short sentence about the second user-visible change>.
+```
+
+Each nested bullet must be end-user relevant (a new flag, a new channel, a new default, a fixed behavior). Never use sub-bullets to list affected files or locales.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - [hardis:org:user:unlink-security-key](https://sfdx-hardis.cloudity.com/hardis/org/user/unlink-security-key/): Send Slack, Teams, email and API notifications summarising which users had their security key / passkey (MFA) unlinked.
 - Bitbucket: support both a repository/workspace Access Token and an Atlassian account API token for authentication.
 - Fix Bitbucket merged Pull Request detection on busy branches by matching abbreviated commit hashes and paginating Pull Request and commit lookups.
+- [hardis:doc:release-notes](https://sfdx-hardis.cloudity.com/hardis/doc/release-notes/):
+  - Match the Pull Request and ticket list shown in the VS Code pipeline view when generating from a merge commit: scope to the Pull Requests of that release (excluding unrelated hotfixes merged at other times) and read ticket keys from source branch names and the release Pull Request description. Works across GitHub, GitLab, Azure DevOps and Bitbucket.
+  - Populate the Pull Request merge dates (previously blank) in the generated release notes for all git providers.
+  - Generate the PDF in landscape orientation by default so the wide Pull Request and ticket tables fit, with `--portrait` to switch back.
+  - List only the deployment actions that were processed (skipped ones are excluded) and remove duplicate rows.
 
 ## [7.16.3] 2026-06-15
 

--- a/src/commands/hardis/doc/release-notes.ts
+++ b/src/commands/hardis/doc/release-notes.ts
@@ -142,6 +142,10 @@ In agent mode:
       allowNo: true,
       description: "Generate the documentation in PDF format (enabled by default, use --no-pdf to skip)",
     }),
+    portrait: Flags.boolean({
+      default: false,
+      description: "Generate the PDF in portrait orientation (default is landscape, which fits the wide Pull Request and ticket tables better)",
+    }),
     /* jscpd:ignore-start */
     debug: Flags.boolean({
       char: "d",
@@ -297,7 +301,12 @@ In agent mode:
       const pdfMarkdown = markdown.replace(/<details[^>]*>/g, "").replace(/<\/details>/g, "").replace(/<summary>(.*?)<\/summary>/g, "### $1");
       const pdfSourceFile = mdOutputFile.replace(/\.md$/i, `.pdf-source-${Date.now()}.md`);
       await fs.writeFile(pdfSourceFile, pdfMarkdown, "utf8");
-      const pdfResult = await generatePdfFileFromMarkdown(pdfSourceFile);
+      // Landscape by default: the PR and ticket tables are wide and read better in landscape.
+      // Keep the first column (ticket ID / PR number) on a single line so IDs like CLIENT-61034 don't wrap.
+      const pdfResult = await generatePdfFileFromMarkdown(pdfSourceFile, {
+        landscape: flags.portrait !== true,
+        extraCss: "td:first-child, th:first-child { white-space: nowrap; }",
+      });
       if (pdfResult) {
         const defaultPdfFile = mdOutputFile.replace(/\.md$/i, ".pdf");
         try {

--- a/src/common/gitProvider/azureDevops.ts
+++ b/src/common/gitProvider/azureDevops.ts
@@ -549,69 +549,12 @@ ${this.getPipelineVariablesConfig()}
 
       // Create a Set of commit IDs for fast lookup
       const commitIds = new Set(
-        commits.map((c) => c.commitId).filter((id) => id),
+        commits.map((c) => c.commitId).filter((id) => id) as string[],
       );
 
-      // Step 3: Get all completed PRs targeting currentBranch and child branches (parallelized)
+      // Step 3-6: Match completed PRs targeting currentBranch and child branches against those commits
       const allBranches = [currentBranchName, ...childBranchesNames];
-
-      const prPromises = allBranches.map(async (branchName) => {
-        try {
-          const prs = await gitApi.getPullRequests(
-            process.env.BUILD_REPOSITORY_ID!,
-            {
-              targetRefName: `refs/heads/${branchName}`,
-              status: PullRequestStatus.Completed,
-            },
-            process.env.SYSTEM_TEAMPROJECT,
-          );
-          uxLog("log", this, c.grey(`[Azure Integration][listPullRequestsInBranchSinceLastMerge] Found ${prs?.length || 0} completed PRs for branch ${branchName}`));
-          return prs || [];
-        } catch (err) {
-          uxLog(
-            "warning",
-            this,
-            c.yellow(`Error fetching completed PRs for branch ${branchName}: ${String(err)}`),
-          );
-          return [];
-        }
-      });
-
-      const prResults = await Promise.all(prPromises);
-      const allMergedPRs: any[] = prResults.flat();
-
-      // Step 4: Filter PRs whose merge commit is in our commit list
-      const relevantPRs = allMergedPRs.filter((pr) => {
-        // Check if the merge commit ID is in our commits
-        const mergeCommitId = pr.lastMergeCommit?.commitId;
-        if (mergeCommitId && commitIds.has(mergeCommitId)) {
-          return true;
-        }
-
-        // Also check the source commit (last commit from the PR branch before merge)
-        const sourceCommitId = pr.lastMergeSourceCommit?.commitId;
-        if (sourceCommitId && commitIds.has(sourceCommitId)) {
-          return true;
-        }
-
-        return false;
-      });
-
-      // Step 5: Remove duplicates
-      const uniquePRsMap = new Map();
-      for (const pr of relevantPRs) {
-        if (!uniquePRsMap.has(pr.pullRequestId)) {
-          uniquePRsMap.set(pr.pullRequestId, pr);
-        }
-      }
-
-      const uniquePRs = Array.from(uniquePRsMap.values());
-      uxLog("log", this, c.grey(`[Azure Integration][listPullRequestsInBranchSinceLastMerge] Returning ${uniquePRs.length} unique PRs`));
-
-      // Step 6: Convert to CommonPullRequestInfo
-      return uniquePRs.map((pr) =>
-        this.completePullRequestInfo(pr)
-      );
+      return await this.collectMergedPrsForCommits(gitApi, allBranches, commitIds);
     } catch (err) {
       uxLog(
         "warning",
@@ -620,6 +563,107 @@ ${this.getPipelineVariablesConfig()}
       );
       return [];
     }
+  }
+
+  // List the Pull Requests included in a specific "go live" merge commit (e.g. the merge
+  // of preprod into main). Bounds the range by the merge commit's first parent so hotfixes
+  // merged to the target branch at other times are excluded.
+  public async listPullRequestsInGoLive(
+    branchName: string,
+    childBranchesNames: string[],
+    mergeCommitId: string,
+  ): Promise<CommonPullRequestInfo[]> {
+    if (!this.azureApi || !process.env.SYSTEM_TEAMPROJECT || !process.env.BUILD_REPOSITORY_ID || !mergeCommitId) {
+      return [];
+    }
+    try {
+      const gitApi = await this.azureApi.getGitApi();
+
+      // Step 1: Resolve the merge commit's first parent (the mainline before the go live)
+      const mergeCommit = await gitApi.getCommit(mergeCommitId, process.env.BUILD_REPOSITORY_ID, process.env.SYSTEM_TEAMPROJECT);
+      const firstParent = mergeCommit?.parents?.[0];
+      if (!firstParent) {
+        return [];
+      }
+
+      // Step 2: Commits introduced by the go live (firstParent..mergeCommit)
+      const commits = await gitApi.getCommitsBatch(
+        {
+          itemVersion: { version: firstParent, versionType: 2 }, // GitVersionType.Commit
+          compareVersion: { version: mergeCommitId, versionType: 2 }, // GitVersionType.Commit
+        } as any,
+        process.env.BUILD_REPOSITORY_ID,
+        process.env.SYSTEM_TEAMPROJECT,
+      );
+      const commitIds = new Set((commits || []).map((c) => c.commitId).filter((id) => id) as string[]);
+      commitIds.add(mergeCommitId);
+
+      // Step 3-6: Match completed PRs targeting branchName and child branches against those commits
+      const allBranches = [branchName, ...childBranchesNames];
+      return await this.collectMergedPrsForCommits(gitApi, allBranches, commitIds);
+    } catch (err) {
+      uxLog(
+        "warning",
+        this,
+        c.yellow(`Error in listPullRequestsInGoLive: ${String(err)}`),
+      );
+      return [];
+    }
+  }
+
+  // Shared tail: fetch completed PRs targeting each branch, keep those whose merge commit
+  // (or source commit) is part of commitIds, dedupe by PR id and convert to the common shape.
+  private async collectMergedPrsForCommits(
+    gitApi: any,
+    allBranches: string[],
+    commitIds: Set<string>,
+  ): Promise<CommonPullRequestInfo[]> {
+    const prPromises = allBranches.map(async (branchName) => {
+      try {
+        const prs = await gitApi.getPullRequests(
+          process.env.BUILD_REPOSITORY_ID!,
+          {
+            targetRefName: `refs/heads/${branchName}`,
+            status: PullRequestStatus.Completed,
+          },
+          process.env.SYSTEM_TEAMPROJECT,
+        );
+        uxLog("log", this, c.grey(`[Azure Integration] Found ${prs?.length || 0} completed PRs for branch ${branchName}`));
+        return prs || [];
+      } catch (err) {
+        uxLog(
+          "warning",
+          this,
+          c.yellow(`Error fetching completed PRs for branch ${branchName}: ${String(err)}`),
+        );
+        return [];
+      }
+    });
+
+    const prResults = await Promise.all(prPromises);
+    const allMergedPRs: any[] = prResults.flat();
+
+    // Keep PRs whose merge commit (or source commit) is in our commit list
+    const relevantPRs = allMergedPRs.filter((pr) => {
+      const mergeCommitId = pr.lastMergeCommit?.commitId;
+      if (mergeCommitId && commitIds.has(mergeCommitId)) {
+        return true;
+      }
+      const sourceCommitId = pr.lastMergeSourceCommit?.commitId;
+      if (sourceCommitId && commitIds.has(sourceCommitId)) {
+        return true;
+      }
+      return false;
+    });
+
+    // Remove duplicates by PR id
+    const uniquePRsMap = new Map();
+    for (const pr of relevantPRs) {
+      if (!uniquePRsMap.has(pr.pullRequestId)) {
+        uniquePRsMap.set(pr.pullRequestId, pr);
+      }
+    }
+    return Array.from(uniquePRsMap.values()).map((pr) => this.completePullRequestInfo(pr));
   }
 
   // Posts a note on the merge request
@@ -742,6 +786,9 @@ ${getBannerMarkdownAndLink()}
         process.env.BUILD_REPOSITORYNAME || "",
       )}/pullrequest/${prData.pullRequestId}`,
       authorName: prData?.createdBy?.displayName || "",
+      createdDate: prData?.creationDate ? new Date(prData.creationDate).toISOString() : undefined,
+      // Azure has no dedicated merge date: closedDate of a completed PR is its merge time
+      mergedDate: prData?.closedDate ? new Date(prData.closedDate).toISOString() : undefined,
       mergeCommitSha: prData?.lastMergeCommit?.commitId || undefined,
       providerInfo: prData,
       customBehaviors: {}

--- a/src/common/gitProvider/bitbucket.ts
+++ b/src/common/gitProvider/bitbucket.ts
@@ -530,69 +530,131 @@ export class BitbucketProvider extends GitProviderRoot {
 
       const commitHashes: string[] = commits.map((c: any) => c.hash);
 
-      // Step 3: Get all merged PRs targeting currentBranch and child branches (parallelized)
+      // Step 3-6: Match merged PRs targeting currentBranch and child branches against those commits
       const allBranches = [currentBranchName, ...childBranchesNames];
-
-      uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketFetchingMergedPrs', { branches: allBranches.join(', ') })));
-
-      const prPromises = allBranches.map(async (branchName) => {
-        try {
-          const branchQuery = `destination.branch.name = "${branchName}" AND state = "MERGED"`;
-          // Paginated: a branch can have more merged PRs than fit on one page
-          const values = await this.fetchAllPages(
-            (params) => this.bitbucket.pullrequests.list(params),
-            {
-              workspace,
-              repo_slug: repoSlug,
-              q: branchQuery,
-              pagelen: 50,
-            },
-          );
-
-          uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketFoundMergedPrs', { count: values.length, branchName })));
-
-          return values;
-        } catch (err) {
-          uxLog("warning", this, c.yellow('[Bitbucket Integration] ' + t('bitbucketErrorFetchingMergedPrs', { branchName, message: String(err) })));
-          return [];
-        }
-      });
-
-      const prResults = await Promise.all(prPromises);
-      const allMergedPRs: any[] = prResults.flat();
-
-      uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketTotalMergedPrs', { count: allMergedPRs.length })));
-
-      // Step 4: Filter PRs whose merge commit is in our commit list.
-      // The PR merge_commit hash (12 chars) is a prefix of the full commit hash
-      // (40 chars), so match with prefix awareness instead of exact equality.
-      const relevantPRs = allMergedPRs.filter((pr) => {
-        const mergeCommitHash = pr.merge_commit?.hash;
-        return commitHashes.some((hash) => this.hashesMatch(hash, mergeCommitHash));
-      });
-
-      uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketRelevantPrs', { count: relevantPRs.length })));
-
-      // Step 5: Remove duplicates
-      const uniquePRsMap = new Map();
-      for (const pr of relevantPRs) {
-        if (!uniquePRsMap.has(pr.id)) {
-          uniquePRsMap.set(pr.id, pr);
-        }
-      }
-
-      const uniquePRs = Array.from(uniquePRsMap.values());
-
-      uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketUniquePrs', { count: uniquePRs.length })));
-
-      // Step 6: Convert to CommonPullRequestInfo
-      return uniquePRs.map((pr) =>
-        this.completePullRequestInfo(pr)
-      );
+      return await this.collectMergedPrsForCommits(workspace, repoSlug, allBranches, commitHashes);
     } catch (err) {
       uxLog("warning", this, c.yellow(t('errorInListpullrequestsinbranchsincelastmerge', { String: String(err) })));
       return [];
     }
+  }
+
+  // List the Pull Requests included in a specific "go live" merge commit (e.g. the
+  // merge of preprod into main). Resolves the merge commit's first parent to bound
+  // the range, lists the commits the merge introduced, then matches merged PRs on
+  // the target branch and its children against those commits. Unlike a plain "list
+  // recent merged PRs", this excludes hotfixes merged to the target at other times.
+  public async listPullRequestsInGoLive(
+    branchName: string,
+    childBranchesNames: string[],
+    mergeCommitId: string,
+  ): Promise<CommonPullRequestInfo[]> {
+    if (!this.bitbucket || !process.env.BITBUCKET_WORKSPACE || !process.env.BITBUCKET_REPO_SLUG || !mergeCommitId) {
+      return [];
+    }
+    try {
+      const workspace = process.env.BITBUCKET_WORKSPACE;
+      const repoSlug = process.env.BITBUCKET_REPO_SLUG;
+
+      // Step 1: Resolve the merge commit's first parent (the mainline before the go live).
+      // Without it we cannot bound the go live and would over-report every merged PR.
+      let firstParent: string | undefined;
+      try {
+        const commitResponse = await this.bitbucket.repositories.getCommit({
+          workspace,
+          repo_slug: repoSlug,
+          commit: mergeCommitId,
+        } as any);
+        firstParent = (commitResponse?.data?.parents ?? [])[0]?.hash;
+      } catch (err) {
+        uxLog("warning", this, c.yellow('[Bitbucket Integration] ' + t('bitbucketErrorFetchingCommit', { commit: mergeCommitId, message: String(err) })));
+      }
+      if (!firstParent) {
+        return [];
+      }
+
+      // Step 2: Commits introduced by the go live (paginated)
+      uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketGettingCommits', { include: mergeCommitId, exclude: firstParent })));
+      const commits = await this.fetchAllPages(
+        (params) => this.bitbucket.commits.list(params),
+        {
+          workspace,
+          repo_slug: repoSlug,
+          include: mergeCommitId,
+          exclude: firstParent,
+          pagelen: 100,
+        },
+      );
+      uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketFoundCommits', { count: commits.length })));
+      if (commits.length === 0) {
+        return [];
+      }
+      const commitHashes: string[] = commits.map((c: any) => c.hash);
+
+      // Step 3-6: same matching as listPullRequestsInBranchSinceLastMerge
+      const allBranches = [branchName, ...childBranchesNames];
+      return await this.collectMergedPrsForCommits(workspace, repoSlug, allBranches, commitHashes);
+    } catch (err) {
+      uxLog("warning", this, c.yellow(t('errorInListpullrequestsinbranchsincelastmerge', { String: String(err) })));
+      return [];
+    }
+  }
+
+  // Shared tail of the "PRs in branch / go live" queries: fetch all merged PRs
+  // targeting each branch in allBranches, keep those whose merge commit is part of
+  // commitHashes, dedupe by PR id and convert to the common shape. Bitbucket's
+  // commits.list returns FULL 40-char hashes while pullrequests.list returns
+  // merge_commit.hash ABBREVIATED to 12 chars, so we compare with prefix awareness.
+  private async collectMergedPrsForCommits(
+    workspace: string,
+    repoSlug: string,
+    allBranches: string[],
+    commitHashes: string[],
+  ): Promise<CommonPullRequestInfo[]> {
+    uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketFetchingMergedPrs', { branches: allBranches.join(', ') })));
+    const prPromises = allBranches.map(async (branchName) => {
+      try {
+        const branchQuery = `destination.branch.name = "${branchName}" AND state = "MERGED"`;
+        // Paginated: a branch can have more merged PRs than fit on one page
+        const values = await this.fetchAllPages(
+          (params) => this.bitbucket.pullrequests.list(params),
+          {
+            workspace,
+            repo_slug: repoSlug,
+            q: branchQuery,
+            pagelen: 50,
+          },
+        );
+        uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketFoundMergedPrs', { count: values.length, branchName })));
+        return values;
+      } catch (err) {
+        uxLog("warning", this, c.yellow('[Bitbucket Integration] ' + t('bitbucketErrorFetchingMergedPrs', { branchName, message: String(err) })));
+        return [];
+      }
+    });
+
+    const prResults = await Promise.all(prPromises);
+    const allMergedPRs: any[] = prResults.flat();
+    uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketTotalMergedPrs', { count: allMergedPRs.length })));
+
+    // Keep PRs whose merge commit is in our commit list (prefix-aware match)
+    const relevantPRs = allMergedPRs.filter((pr) => {
+      const mergeCommitHash = pr.merge_commit?.hash;
+      return commitHashes.some((hash) => this.hashesMatch(hash, mergeCommitHash));
+    });
+    uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketRelevantPrs', { count: relevantPRs.length })));
+
+    // Remove duplicates by PR id
+    const uniquePRsMap = new Map();
+    for (const pr of relevantPRs) {
+      if (!uniquePRsMap.has(pr.id)) {
+        uniquePRsMap.set(pr.id, pr);
+      }
+    }
+    const uniquePRs = Array.from(uniquePRsMap.values());
+    uxLog("log", this, c.grey('[Bitbucket Integration] ' + t('bitbucketUniquePrs', { count: uniquePRs.length })));
+
+    return uniquePRs.map((pr) => this.completePullRequestInfo(pr));
   }
 
   public async postPullRequestMessage(prMessage: PullRequestMessageRequest): Promise<PullRequestMessageResult> {
@@ -699,10 +761,14 @@ ${getBannerMarkdownAndLink()}
       idStr: prData.id ? prData?.id?.toString() : '',
       sourceBranch: prData?.source?.branch?.name || '',
       targetBranch: prData?.destination?.branch?.name || '',
-      title: prData?.rendered?.title?.raw || prData?.rendered?.title?.markup || prData?.rendered?.title?.html || prData?.title || '',
-      description: prData?.rendered?.description?.raw || prData?.rendered?.description?.markup || prData?.rendered?.description?.html || (prData as any)?.description || '',
+      // Note: rendered.*.markup holds the format name ("markdown"), not content, so only raw/html are used as fallbacks
+      title: prData?.rendered?.title?.raw || prData?.rendered?.title?.html || prData?.title || '',
+      description: prData?.rendered?.description?.raw || prData?.rendered?.description?.html || (prData as any)?.description || '',
       webUrl: prData?.links?.html?.href || '',
       authorName: prData?.author?.display_name || '',
+      createdDate: (prData as any)?.created_on || undefined,
+      // Bitbucket has no dedicated merge date: updated_on of a MERGED PR is its merge time
+      mergedDate: prData?.state === 'MERGED' ? ((prData as any)?.updated_on || undefined) : undefined,
       mergeCommitSha: (prData as any)?.merge_commit?.hash || undefined,
       providerInfo: prData,
       customBehaviors: {}

--- a/src/common/gitProvider/gitProviderRoot.ts
+++ b/src/common/gitProvider/gitProviderRoot.ts
@@ -77,6 +77,17 @@ export abstract class GitProviderRoot {
     return [];
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  public async listPullRequestsInGoLive(
+    _branchName: string,
+    _childBranchesNames: string[],
+    _mergeCommitId: string,
+  ): Promise<CommonPullRequestInfo[]> {
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+    uxLog("other", this, `Method listPullRequestsInGoLive is not implemented yet on ${this.getLabel()}`);
+    return [];
+  }
+
   public async postPullRequestMessage(prMessage: PullRequestMessageRequest): Promise<PullRequestMessageResult> {
     uxLog("warning", this, c.yellow(t('methodPostpullrequestmessageIsNotYetImplementedOn') + this.getLabel() + " to post " + JSON.stringify(prMessage)));
     return { posted: false, providerResult: { error: "Not implemented in sfdx-hardis" } };

--- a/src/common/gitProvider/github.ts
+++ b/src/common/gitProvider/github.ts
@@ -510,52 +510,9 @@ ${getBannerMarkdownAndLink()}
 
       const commitSHAs = new Set(comparison.commits.map((c) => c.sha));
 
-      // Step 3: Get all merged PRs targeting currentBranch and child branches (parallelized)
+      // Step 3-6: Match merged PRs targeting currentBranch and child branches against those commits
       const allBranches = [currentBranchName, ...childBranchesNames];
-
-      const prPromises = allBranches.map(async (branchName) => {
-        try {
-          const { data: prs } = await this.octokit!.rest.pulls.list({
-            owner: this.repoOwner!,
-            repo: this.repoName!,
-            state: "closed",
-            base: branchName,
-            per_page: 1000,
-          });
-          uxLog("log", this, c.grey('[GitHub Integration] ' + t('githubFetchingMergedPrs', { branchName })));
-          return prs.filter((pr) => pr.merged_at);
-        } catch (err) {
-          uxLog(
-            "warning",
-            this,
-            c.yellow('[GitHub Integration] ' + t('githubErrorFetchingMergedPrs', { branchName, message: String(err) })),
-          );
-          return [];
-        }
-      });
-
-      const prResults = await Promise.all(prPromises);
-      const allMergedPRs: any[] = prResults.flat();
-
-      // Step 4: Filter PRs whose merge commit is in our commit list
-      const relevantPRs = allMergedPRs.filter((pr) => {
-        return pr.merge_commit_sha && commitSHAs.has(pr.merge_commit_sha);
-      });
-
-      // Step 5: Remove duplicates
-      const uniquePRsMap = new Map();
-      for (const pr of relevantPRs) {
-        if (!uniquePRsMap.has(pr.number)) {
-          uniquePRsMap.set(pr.number, pr);
-        }
-      }
-
-      const uniquePRs = Array.from(uniquePRsMap.values());
-
-      // Step 6: Convert to CommonPullRequestInfo
-      return uniquePRs.map((pr) =>
-        this.completePullRequestInfo(pr)
-      );
+      return await this.collectMergedPrsForCommits(allBranches, commitSHAs);
     } catch (err) {
       uxLog(
         "warning",
@@ -564,6 +521,96 @@ ${getBannerMarkdownAndLink()}
       );
       return [];
     }
+  }
+
+  // List the Pull Requests included in a specific "go live" merge commit (e.g. the merge
+  // of preprod into main). Bounds the range by the merge commit's first parent so hotfixes
+  // merged to the target branch at other times are excluded.
+  public async listPullRequestsInGoLive(
+    branchName: string,
+    childBranchesNames: string[],
+    mergeCommitId: string,
+  ): Promise<CommonPullRequestInfo[]> {
+    if (!this.octokit || !this.repoOwner || !this.repoName || !mergeCommitId) {
+      return [];
+    }
+    try {
+      // Step 1: Resolve the merge commit's first parent (the mainline before the go live)
+      const { data: mergeCommit } = await this.octokit.rest.repos.getCommit({
+        owner: this.repoOwner,
+        repo: this.repoName,
+        ref: mergeCommitId,
+      });
+      const firstParent = mergeCommit?.parents?.[0]?.sha;
+      if (!firstParent) {
+        return [];
+      }
+
+      // Step 2: Commits introduced by the go live
+      const { data: comparison } = await this.octokit.rest.repos.compareCommits({
+        owner: this.repoOwner,
+        repo: this.repoName,
+        base: firstParent,
+        head: mergeCommitId,
+        per_page: 1000,
+      });
+      const commitSHAs = new Set((comparison.commits || []).map((c) => c.sha));
+      commitSHAs.add(mergeCommitId);
+
+      // Step 3-6: Match merged PRs targeting branchName and child branches against those commits
+      const allBranches = [branchName, ...childBranchesNames];
+      return await this.collectMergedPrsForCommits(allBranches, commitSHAs);
+    } catch (err) {
+      uxLog(
+        "warning",
+        this,
+        c.yellow('[GitHub Integration] ' + t('githubErrorListingPrsSinceLastMerge', { message: String(err), stack: err instanceof Error ? err.stack : "" })),
+      );
+      return [];
+    }
+  }
+
+  // Shared tail: fetch merged PRs targeting each branch, keep those whose merge commit
+  // is part of commitSHAs, dedupe by PR number and convert to the common shape.
+  private async collectMergedPrsForCommits(
+    allBranches: string[],
+    commitSHAs: Set<string>,
+  ): Promise<CommonPullRequestInfo[]> {
+    const prPromises = allBranches.map(async (branchName) => {
+      try {
+        const { data: prs } = await this.octokit!.rest.pulls.list({
+          owner: this.repoOwner!,
+          repo: this.repoName!,
+          state: "closed",
+          base: branchName,
+          per_page: 1000,
+        });
+        uxLog("log", this, c.grey('[GitHub Integration] ' + t('githubFetchingMergedPrs', { branchName })));
+        return prs.filter((pr) => pr.merged_at);
+      } catch (err) {
+        uxLog(
+          "warning",
+          this,
+          c.yellow('[GitHub Integration] ' + t('githubErrorFetchingMergedPrs', { branchName, message: String(err) })),
+        );
+        return [];
+      }
+    });
+
+    const prResults = await Promise.all(prPromises);
+    const allMergedPRs: any[] = prResults.flat();
+
+    // Keep PRs whose merge commit is in our commit list
+    const relevantPRs = allMergedPRs.filter((pr) => pr.merge_commit_sha && commitSHAs.has(pr.merge_commit_sha));
+
+    // Remove duplicates by PR number
+    const uniquePRsMap = new Map();
+    for (const pr of relevantPRs) {
+      if (!uniquePRsMap.has(pr.number)) {
+        uniquePRsMap.set(pr.number, pr);
+      }
+    }
+    return Array.from(uniquePRsMap.values()).map((pr) => this.completePullRequestInfo(pr));
   }
 
   private completePullRequestInfo(prData: any): CommonPullRequestInfo {
@@ -576,6 +623,8 @@ ${getBannerMarkdownAndLink()}
       description: prData?.body || "",
       authorName: prData?.user?.login || "",
       webUrl: prData?.html_url || "",
+      createdDate: prData?.created_at || undefined,
+      mergedDate: prData?.merged_at || undefined,
       mergeCommitSha: prData?.merge_commit_sha || undefined,
       providerInfo: prData,
       customBehaviors: {}

--- a/src/common/gitProvider/gitlab.ts
+++ b/src/common/gitProvider/gitlab.ts
@@ -474,62 +474,100 @@ ${getBannerMarkdownAndLink()}
       // Create a Set of commit SHAs for fast lookup
       const commitSHAs = new Set(commitsSinceLastMerge.map((c) => c.id));
 
-      // Step 3: Get all merged MRs targeting currentBranch and child branches (parallelized)
+      // Step 3-6: Match merged MRs targeting currentBranch and child branches against those commits
       const allBranches = [currentBranchName, ...childBranchesNames];
-
-      const mrPromises = allBranches.map(async (branchName) => {
-        try {
-          const mergedMRs = await this.gitlabApi!.MergeRequests.all({
-            projectId,
-            targetBranch: branchName,
-            state: "merged",
-            perPage: 100,
-          });
-          uxLog("log", this, c.grey('[Gitlab Integration] ' + t('gitlabFetchingMergedMrs', { branchName })));
-          return mergedMRs;
-        } catch (err) {
-          uxLog("warning", this, c.yellow('[Gitlab Integration] ' + t('gitlabErrorFetchingMergedMrsForBranch', { branchName, message: String(err) })));
-          return [];
-        }
-      });
-
-      const mrResults = await Promise.all(mrPromises);
-      const allMergedMRs: any[] = mrResults.flat();
-
-      // Step 4: Filter MRs whose merge commit SHA is in our commit list
-      const relevantMRs = allMergedMRs.filter((mr) => {
-        // Check if the merge commit SHA is in our commits
-        const mergeCommitSha = mr.mergeCommitSha || mr.merge_commit_sha;
-        if (mergeCommitSha && commitSHAs.has(mergeCommitSha)) {
-          return true;
-        }
-
-        // Also check if the MR's SHA (last commit before merge) is in our commits
-        if (mr.sha && commitSHAs.has(mr.sha)) {
-          return true;
-        }
-
-        return false;
-      });
-
-      // Step 5: Remove duplicates (same MR might be found through different branches)
-      const uniqueMRsMap = new Map<number, any>();
-      for (const mr of relevantMRs) {
-        if (mr.iid && !uniqueMRsMap.has(mr.iid)) {
-          uniqueMRsMap.set(mr.iid, mr);
-        }
-      }
-
-      const uniqueMRs = Array.from(uniqueMRsMap.values());
-
-      // Step 6: Convert to CommonPullRequestInfo
-      return uniqueMRs.map((mr) =>
-        this.completePullRequestInfo(mr)
-      );
+      return await this.collectMergedPrsForCommits(projectId, allBranches, commitSHAs);
     } catch (err) {
       uxLog("warning", this, c.yellow('[Gitlab Integration] ' + t('gitlabErrorListingMrsSinceLastMerge', { message: String(err), stack: err instanceof Error ? err.stack : "" })));
       return [];
     }
+  }
+
+  // List the Merge Requests included in a specific "go live" merge commit (e.g. the merge
+  // of preprod into main). Bounds the range by the merge commit's first parent so hotfixes
+  // merged to the target branch at other times are excluded.
+  public async listPullRequestsInGoLive(
+    branchName: string,
+    childBranchesNames: string[],
+    mergeCommitId: string,
+  ): Promise<CommonPullRequestInfo[]> {
+    if (!this.gitlabApi || !mergeCommitId) {
+      return [];
+    }
+    try {
+      const projectId = process.env.CI_PROJECT_ID || process.env.CI_PROJECT_PATH;
+      if (!projectId) {
+        uxLog("warning", this, c.yellow('[Gitlab Integration] ' + t('gitlabCiProjectIdRequired')));
+        return [];
+      }
+
+      // Step 1: Resolve the merge commit's first parent (the mainline before the go live)
+      const mergeCommit: any = await this.gitlabApi.Commits.show(projectId, mergeCommitId);
+      const firstParent = mergeCommit?.parent_ids?.[0] || mergeCommit?.parentIds?.[0];
+      if (!firstParent) {
+        return [];
+      }
+
+      // Step 2: Commits introduced by the go live (firstParent..mergeCommit)
+      const comparison: any = await this.gitlabApi.Repositories.compare(projectId, firstParent, mergeCommitId, { straight: true });
+      const commitSHAs = new Set<string>((comparison?.commits || []).map((c: any) => c.id));
+      commitSHAs.add(mergeCommitId);
+
+      // Step 3-6: Match merged MRs targeting branchName and child branches against those commits
+      const allBranches = [branchName, ...childBranchesNames];
+      return await this.collectMergedPrsForCommits(projectId, allBranches, commitSHAs);
+    } catch (err) {
+      uxLog("warning", this, c.yellow('[Gitlab Integration] ' + t('gitlabErrorListingMrsSinceLastMerge', { message: String(err), stack: err instanceof Error ? err.stack : "" })));
+      return [];
+    }
+  }
+
+  // Shared tail: fetch merged MRs targeting each branch, keep those whose merge commit
+  // is part of commitSHAs, dedupe by MR iid and convert to the common shape.
+  private async collectMergedPrsForCommits(
+    projectId: string | number,
+    allBranches: string[],
+    commitSHAs: Set<string>,
+  ): Promise<CommonPullRequestInfo[]> {
+    const mrPromises = allBranches.map(async (branchName) => {
+      try {
+        const mergedMRs = await this.gitlabApi!.MergeRequests.all({
+          projectId,
+          targetBranch: branchName,
+          state: "merged",
+          perPage: 100,
+        });
+        uxLog("log", this, c.grey('[Gitlab Integration] ' + t('gitlabFetchingMergedMrs', { branchName })));
+        return mergedMRs;
+      } catch (err) {
+        uxLog("warning", this, c.yellow('[Gitlab Integration] ' + t('gitlabErrorFetchingMergedMrsForBranch', { branchName, message: String(err) })));
+        return [];
+      }
+    });
+
+    const mrResults = await Promise.all(mrPromises);
+    const allMergedMRs: any[] = mrResults.flat();
+
+    // Keep MRs whose merge commit SHA (or last commit before merge) is in our commit list
+    const relevantMRs = allMergedMRs.filter((mr) => {
+      const mergeCommitSha = mr.mergeCommitSha || mr.merge_commit_sha;
+      if (mergeCommitSha && commitSHAs.has(mergeCommitSha)) {
+        return true;
+      }
+      if (mr.sha && commitSHAs.has(mr.sha)) {
+        return true;
+      }
+      return false;
+    });
+
+    // Remove duplicates by MR iid
+    const uniqueMRsMap = new Map<number, any>();
+    for (const mr of relevantMRs) {
+      if (mr.iid && !uniqueMRsMap.has(mr.iid)) {
+        uniqueMRsMap.set(mr.iid, mr);
+      }
+    }
+    return Array.from(uniqueMRsMap.values()).map((mr) => this.completePullRequestInfo(mr));
   }
 
   private async findLastMergedMR(
@@ -594,6 +632,8 @@ ${getBannerMarkdownAndLink()}
       description: prData?.description || "",
       authorName: prData?.author?.name || "",
       webUrl: prData?.web_url || "",
+      createdDate: prData?.created_at || undefined,
+      mergedDate: prData?.merged_at || undefined,
       mergeCommitSha: prData?.merge_commit_sha || prData?.mergeCommitSha || undefined,
       providerInfo: prData,
       customBehaviors: {}

--- a/src/common/gitProvider/gitlab.ts
+++ b/src/common/gitProvider/gitlab.ts
@@ -475,12 +475,14 @@ ${getBannerMarkdownAndLink()}
       const commitSHAs = new Set(commitsSinceLastMerge.map((c) => c.id));
 
       // Step 3-6: Match merged MRs targeting currentBranch and child branches against those commits
+      /* jscpd:ignore-start */
       const allBranches = [currentBranchName, ...childBranchesNames];
       return await this.collectMergedPrsForCommits(projectId, allBranches, commitSHAs);
     } catch (err) {
       uxLog("warning", this, c.yellow('[Gitlab Integration] ' + t('gitlabErrorListingMrsSinceLastMerge', { message: String(err), stack: err instanceof Error ? err.stack : "" })));
       return [];
     }
+    /* jscpd:ignore-end */
   }
 
   // List the Merge Requests included in a specific "go live" merge commit (e.g. the merge
@@ -514,12 +516,14 @@ ${getBannerMarkdownAndLink()}
       commitSHAs.add(mergeCommitId);
 
       // Step 3-6: Match merged MRs targeting branchName and child branches against those commits
+      /* jscpd:ignore-start */
       const allBranches = [branchName, ...childBranchesNames];
       return await this.collectMergedPrsForCommits(projectId, allBranches, commitSHAs);
     } catch (err) {
       uxLog("warning", this, c.yellow('[Gitlab Integration] ' + t('gitlabErrorListingMrsSinceLastMerge', { message: String(err), stack: err instanceof Error ? err.stack : "" })));
       return [];
     }
+    /* jscpd:ignore-end */
   }
 
   // Shared tail: fetch merged MRs targeting each branch, keep those whose merge commit

--- a/src/common/utils/markdownUtils.ts
+++ b/src/common/utils/markdownUtils.ts
@@ -4,7 +4,7 @@ import getPort from "get-port";
 import { uxLog } from "./index.js";
 import { t } from './i18n.js';
 
-export async function generatePdfFileFromMarkdown(markdownFile: string, options: { timeoutMs?: number } = {}): Promise<string | false> {
+export async function generatePdfFileFromMarkdown(markdownFile: string, options: { timeoutMs?: number, landscape?: boolean, extraCss?: string } = {}): Promise<string | false> {
   try {
     const outputPdfFile = markdownFile.replace('.md', '.pdf');
     const timeoutMs = options.timeoutMs || 120000;
@@ -40,11 +40,15 @@ export async function generatePdfFileFromMarkdown(markdownFile: string, options:
               padding: 4px 8px;
               white-space: normal;
               word-break: normal;
-            }`,
+            }
+            ${options.extraCss || ""}`,
       stylesheet_encoding: 'utf-8',
       port: await getPort(),
       basedir: getDir(markdownFile),
     };
+    if (options.landscape) {
+      config.pdf_options = { ...(config.pdf_options || {}), landscape: true };
+    }
     const mergedConfig = {
       ...defaultConfig,
       ...config,

--- a/src/common/utils/releaseNotesUtils.ts
+++ b/src/common/utils/releaseNotesUtils.ts
@@ -122,7 +122,13 @@ export async function resolveReleaseScope(
   if (flags["merge-commit"] || flags["source-commit"]) {
     const targetBranch = flags["target-branch"] || (await promptTargetBranch(majorOrgs, agentMode));
     const toCommit = flags["merge-commit"] || "HEAD";
-    const fromCommit = flags["source-commit"] || "";
+    let fromCommit = flags["source-commit"] || "";
+    // When generating from a merge commit without an explicit source commit, bound the
+    // range with the merge commit's first parent (the mainline before the go live), so the
+    // metadata delta covers exactly what the merge introduced.
+    if (!fromCommit && flags["merge-commit"]) {
+      fromCommit = (await getFirstParentCommit(flags["merge-commit"])) || "";
+    }
     return { fromCommit, toCommit, targetBranch, mode };
   }
 
@@ -398,6 +404,19 @@ async function getCommitForTag(tag: string): Promise<string> {
   }
 }
 
+// Resolve the first parent of a (merge) commit: the mainline state before the go live.
+// Uses `--format=%P` (parents are space-separated) rather than `<commit>^1`, because the
+// caret is the escape character in the Windows shell and would corrupt the ref.
+async function getFirstParentCommit(commit: string): Promise<string | undefined> {
+  try {
+    const result = await execCommand(`git show -s --format=%P ${commit}`, null, { fail: true });
+    const sha = result.stdout.trim().split(/\s+/)[0];
+    return sha || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function getReleaseDate(scope: ReleaseNotesScope): Promise<string> {
   if (scope.mode === "prepare") {
     return new Date().toISOString().split("T")[0];
@@ -434,6 +453,9 @@ export async function collectPullRequests(
   const majorBranchNames = new Set(majorOrgs.map((o: any) => o.branchName));
 
   let pullRequests: CommonPullRequestInfo[] = [];
+  // PRs that are the release "go live" merge itself (e.g. preprod -> main). They
+  // are inter-major-branch but must survive the filter below, as they carry the release.
+  const releaseCommitPrIds = new Set<string>();
 
   // Date-based filtering
   if (scope.fromDate || scope.toDate) {
@@ -469,6 +491,36 @@ export async function collectPullRequests(
         { targetBranch: scope.targetBranch, status: "merged" },
       )) || [];
     }
+  } else if (scope.toCommit && scope.toCommit !== "HEAD" && !scope.releaseTag) {
+    // Commit-based (e.g. post mode with --merge-commit): scope PRs to the go-live
+    // introduced by the merge commit. This excludes hotfixes merged directly to the
+    // target branch at other times, which a plain "recent merged PRs" list catches.
+    const childBranches = recursiveGetChildBranches(scope.targetBranch, majorOrgs);
+    try {
+      pullRequests = await gitProvider.listPullRequestsInGoLive(
+        scope.targetBranch,
+        [...childBranches],
+        scope.toCommit,
+      );
+    } catch (e: any) {
+      uxLog("warning", commandRef, c.yellow(t("releaseNotesCouldNotListPrs", { message: e.message })));
+    }
+    if (!pullRequests || pullRequests.length === 0) {
+      // Fallback (e.g. provider without go-live support): list merged PRs for the target branch
+      pullRequests = (await gitProvider.listPullRequests(
+        { targetBranch: scope.targetBranch, status: "merged" },
+      )) || [];
+    } else {
+      // The go-live merge PR itself (e.g. preprod -> main) carries the release and
+      // must survive the inter-major-branch filter below.
+      for (const pr of pullRequests) {
+        const sha = pr.mergeCommitSha;
+        const to = scope.toCommit;
+        if (sha && (sha === to || sha.startsWith(to) || to.startsWith(sha))) {
+          releaseCommitPrIds.add(pr.idStr);
+        }
+      }
+    }
   } else {
     // Tag-based or generic: list merged PRs for the target branch
     pullRequests = (await gitProvider.listPullRequests(
@@ -476,8 +528,11 @@ export async function collectPullRequests(
     )) || [];
   }
 
-  // Filter out inter-major-branch PRs
+  // Filter out inter-major-branch PRs, but always keep the release go-live merge PR
   pullRequests = pullRequests.filter((pr) => {
+    if (releaseCommitPrIds.has(pr.idStr)) {
+      return true;
+    }
     return !(majorBranchNames.has(pr.sourceBranch) && majorBranchNames.has(pr.targetBranch));
   });
 
@@ -519,7 +574,7 @@ export async function collectTickets(
   }
   let allTickets: Ticket[] = [];
   for (const pr of pullRequests) {
-    const text = `${pr.title} ${pr.description || ""}`;
+    const text = [pr.title, pr.description || "", pr.sourceBranch || ""].filter(Boolean).join("\n");
     try {
       const prTickets = await TicketProvider.getProvidersTicketsFromString(text, { commits: [] });
       const ticketIds: string[] = [];
@@ -659,7 +714,9 @@ export async function collectDeploymentActions(
         }
       }
       if (allEntries.length > 0) {
-        return sortDeploymentActions(allEntries);
+        // State exists for these PRs: return the processed actions (skipped excluded, deduped),
+        // even if that leaves the list empty - do not fall back to re-listing action definitions.
+        return filterAndDedupeDeploymentActions(allEntries);
       }
     }
   } catch (e: any) {
@@ -693,7 +750,26 @@ export async function collectDeploymentActions(
       // Ignore per-PR read errors
     }
   }
-  return sortDeploymentActions(fallbackEntries);
+  return filterAndDedupeDeploymentActions(fallbackEntries);
+}
+
+// Keep only processed actions (drop skipped) and remove duplicates: the same action can be
+// recorded once per org branch, which would render as identical rows since the table does not
+// show the org branch. Collapse to one row per action + phase + PR, keeping the most meaningful status.
+function filterAndDedupeDeploymentActions(entries: DeploymentActionStateEntry[]): DeploymentActionStateEntry[] {
+  const statusPriority: Record<string, number> = { success: 3, failed: 2, manual: 1 };
+  const byKey = new Map<string, DeploymentActionStateEntry>();
+  for (const entry of entries) {
+    if (entry.status === "skipped") {
+      continue;
+    }
+    const key = `${entry.actionId}::${entry.when}::${entry.prNumber ?? ""}`;
+    const existing = byKey.get(key);
+    if (!existing || (statusPriority[entry.status] || 0) > (statusPriority[existing.status] || 0)) {
+      byKey.set(key, entry);
+    }
+  }
+  return sortDeploymentActions(Array.from(byKey.values()));
 }
 
 function sortDeploymentActions(entries: DeploymentActionStateEntry[]): DeploymentActionStateEntry[] {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -244,6 +244,7 @@
   "bitbucketAddingPrComment": "Pull Request-Kommentar wird auf Bitbucket hinzugefügt...",
   "bitbucketCannotCreatePrMissingRepoInfo": "Pull Request kann nicht erstellt werden: BITBUCKET_WORKSPACE oder BITBUCKET_REPO_SLUG fehlt.",
   "bitbucketCreatingPullRequest": "Erstelle Pull Request von {{source}} nach {{target}}...",
+  "bitbucketErrorFetchingCommit": "Fehler beim Abrufen von commit {{commit}}: {{message}}",
   "bitbucketErrorFetchingMergedPrs": "Fehler beim Abrufen zusammengeführter Pull Requests für Branch {{branchName}}: {{message}}",
   "bitbucketErrorListingPullRequests": "Fehler beim Auflisten der Pull Requests: {{message}}",
   "bitbucketFetchingMergedPrs": "Zusammengeführte Pull Requests für Branches werden abgerufen: {{branches}}",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -244,6 +244,7 @@
   "bitbucketAddingPrComment": "Adding Pull Request Comment on Bitbucket...",
   "bitbucketCannotCreatePrMissingRepoInfo": "Cannot create pull request: missing BITBUCKET_WORKSPACE or BITBUCKET_REPO_SLUG.",
   "bitbucketCreatingPullRequest": "Creating pull request from {{source}} to {{target}}...",
+  "bitbucketErrorFetchingCommit": "Error fetching commit {{commit}}: {{message}}",
   "bitbucketErrorFetchingMergedPrs": "Error fetching merged PRs for branch {{branchName}}: {{message}}",
   "bitbucketErrorListingPullRequests": "Error listing pull requests: {{message}}",
   "bitbucketFetchingMergedPrs": "Fetching merged PRs for branches: {{branches}}",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -244,6 +244,7 @@
   "bitbucketAddingPrComment": "Añadiendo comentario de Pull Request en Bitbucket...",
   "bitbucketCannotCreatePrMissingRepoInfo": "No se puede crear la pull request: falta BITBUCKET_WORKSPACE o BITBUCKET_REPO_SLUG.",
   "bitbucketCreatingPullRequest": "Creando pull request de {{source}} a {{target}}...",
+  "bitbucketErrorFetchingCommit": "Error al obtener el commit {{commit}}: {{message}}",
   "bitbucketErrorFetchingMergedPrs": "Error al obtener PRs fusionadas para la branch {{branchName}}: {{message}}",
   "bitbucketErrorListingPullRequests": "Error al listar las pull requests: {{message}}",
   "bitbucketFetchingMergedPrs": "Obteniendo PRs fusionadas para las branches: {{branches}}",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -244,6 +244,7 @@
   "bitbucketAddingPrComment": "Ajout d'un commentaire de Pull Request sur Bitbucket...",
   "bitbucketCannotCreatePrMissingRepoInfo": "Impossible de créer la pull request : BITBUCKET_WORKSPACE ou BITBUCKET_REPO_SLUG manquant.",
   "bitbucketCreatingPullRequest": "Création de la pull request de {{source}} vers {{target}}...",
+  "bitbucketErrorFetchingCommit": "Erreur lors de la récupération du commit {{commit}} : {{message}}",
   "bitbucketErrorFetchingMergedPrs": "Erreur lors de la récupération des PRs fusionnées pour la branche {{branchName}} : {{message}}",
   "bitbucketErrorListingPullRequests": "Erreur lors de la liste des pull requests : {{message}}",
   "bitbucketFetchingMergedPrs": "Récupération des PRs fusionnées pour les branches : {{branches}}",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -244,6 +244,7 @@
   "bitbucketAddingPrComment": "Aggiunta di un commento alla Pull Request su Bitbucket...",
   "bitbucketCannotCreatePrMissingRepoInfo": "Impossibile creare la pull request: BITBUCKET_WORKSPACE o BITBUCKET_REPO_SLUG mancante.",
   "bitbucketCreatingPullRequest": "Creazione pull request da {{source}} a {{target}}...",
+  "bitbucketErrorFetchingCommit": "Errore nel recupero del commit {{commit}}: {{message}}",
   "bitbucketErrorFetchingMergedPrs": "Errore nel recupero delle PR unite per il branch {{branchName}}: {{message}}",
   "bitbucketErrorListingPullRequests": "Errore nell'elencare le pull request: {{message}}",
   "bitbucketFetchingMergedPrs": "Recupero delle PR unite per i branch: {{branches}}",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -244,6 +244,7 @@
   "bitbucketAddingPrComment": "Bitbucket に Pull Request コメントを追加しています...",
   "bitbucketCannotCreatePrMissingRepoInfo": "Pull Requestを作成できません: BITBUCKET_WORKSPACEまたはBITBUCKET_REPO_SLUGが設定されていません。",
   "bitbucketCreatingPullRequest": "{{source}}から{{target}}へのPull Requestを作成しています...",
+  "bitbucketErrorFetchingCommit": "commit {{commit}} の取得中にエラーが発生しました: {{message}}",
   "bitbucketErrorFetchingMergedPrs": "branch {{branchName}} の merge 済み PR の取得中にエラーが発生しました: {{message}}",
   "bitbucketErrorListingPullRequests": "Pull Requestの一覧取得エラー: {{message}}",
   "bitbucketFetchingMergedPrs": "branch {{branches}} の merge 済み PR を取得しています",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -244,6 +244,7 @@
   "bitbucketAddingPrComment": "Pull Request opmerking toevoegen op Bitbucket...",
   "bitbucketCannotCreatePrMissingRepoInfo": "Kan geen pull request aanmaken: BITBUCKET_WORKSPACE of BITBUCKET_REPO_SLUG ontbreekt.",
   "bitbucketCreatingPullRequest": "Pull request aanmaken van {{source}} naar {{target}}...",
+  "bitbucketErrorFetchingCommit": "Fout bij het ophalen van commit {{commit}}: {{message}}",
   "bitbucketErrorFetchingMergedPrs": "Fout bij ophalen van gemerge PRs voor branch {{branchName}}: {{message}}",
   "bitbucketErrorListingPullRequests": "Fout bij het ophalen van pull requests: {{message}}",
   "bitbucketFetchingMergedPrs": "Gemerge PRs ophalen voor branches: {{branches}}",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -244,6 +244,7 @@
   "bitbucketAddingPrComment": "Dodawanie komentarza Pull Request na Bitbucket...",
   "bitbucketCannotCreatePrMissingRepoInfo": "Nie można utworzyć pull request: brak BITBUCKET_WORKSPACE lub BITBUCKET_REPO_SLUG.",
   "bitbucketCreatingPullRequest": "Tworzenie pull request z {{source}} do {{target}}...",
+  "bitbucketErrorFetchingCommit": "Błąd podczas pobierania commit {{commit}}: {{message}}",
   "bitbucketErrorFetchingMergedPrs": "Błąd podczas pobierania scalonych PR dla branch {{branchName}}: {{message}}",
   "bitbucketErrorListingPullRequests": "Błąd podczas pobierania listy pull requestów: {{message}}",
   "bitbucketFetchingMergedPrs": "Pobieranie scalonych PR dla branchy: {{branches}}",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -240,6 +240,7 @@
   "beforeLaunchingTheDataLoadingPleaseMake": "Antes de iniciar o carregamento de dados, certifique-se de que seu usuário {{orgUsername}} possui os Bypasses / Configurações de Ativação / Permissões Personalizadas / o que for necessário antes de iniciar o carregamento de dados.",
   "beforeRefreshCommandPerformedSuccessfully": "Comando before-refresh executado com sucesso",
   "bitbucketAddingPrComment": "Adicionando Comentário de Pull Request no Bitbucket...",
+  "bitbucketErrorFetchingCommit": "Erro ao buscar o commit {{commit}}: {{message}}",
   "bitbucketErrorFetchingMergedPrs": "Erro ao buscar PRs mesclados para a branch {{branchName}}: {{message}}",
   "bitbucketErrorListingPullRequests": "Erro ao listar pull requests: {{message}}",
   "bitbucketFetchingMergedPrs": "Buscando PRs mesclados para as branches: {{branches}}",


### PR DESCRIPTION
The `hardis:doc:release-notes` command has been significantly improved for generating release notes, especially from a "go-live" merge commit.

Key enhancements include:
- **Accurate Go-Live PR Scoping:** When generating from a merge commit (e.g., `preprod` into `main`), the command now identifies the merge commit's first parent to precisely scope Pull Requests to only those introduced by that specific merge, excluding unrelated hotfixes. This applies across GitHub, GitLab, Azure DevOps, and Bitbucket.
- **Improved PDF Output:** The generated PDF now defaults to landscape orientation to better fit wide Pull Request and ticket tables, with a new `--portrait` flag to revert to portrait. Additionally, it applies CSS to prevent ticket IDs and PR numbers from wrapping.
- **Clearer Deployment Actions:** Deployment actions are now filtered to exclude "skipped" entries and deduplicated, displaying only processed actions with the most relevant status (success, failed, manual).
- **Richer Pull Request Metadata:** `createdDate` and `mergedDate` are now consistently populated for Pull Request information retrieved from all supported Git providers.
- **Updated Changelog Guidelines:** The `SKILL.md` file now provides explicit instructions and examples for grouping multiple user-visible changes under a single command link in `CHANGELOG.md`, enhancing readability for end-users.
```
