### PR TITLE
fix: correct inverted notification types in org monitor errors

### DIFF
--- a/src/commands/hardis/org/monitor/errors.ts
+++ b/src/commands/hardis/org/monitor/errors.ts
@@ -572,7 +572,7 @@ In agent mode:
         : t('monitorErrorsApexNone', { org: orgMarkdown, days: this.days });
 
     return {
-      type: 'FLOW_ERROR',
+      type: 'APEX_ERROR',
       text: notifText,
       buttons: notifButtons,
       attachments: this.buildApexAttachments(),
@@ -598,7 +598,7 @@ In agent mode:
         : t('monitorErrorsFlowNone', { org: orgMarkdown, days: this.days });
 
     return {
-      type: 'APEX_ERROR',
+      type: 'FLOW_ERROR',
       text: notifText,
       buttons: notifButtons,
       attachments: this.buildFlowAttachments(),


### PR DESCRIPTION
This PR fixes an inverted notification type assignment in `src/commands/hardis/org/monitor/errors.ts`.

Current behavior:
- Apex notification is sent with `type: 'FLOW_ERROR'`
- Flow notification is sent with `type: 'APEX_ERROR'`

Expected behavior:
- Apex notification should use `type: 'APEX_ERROR'`
- Flow notification should use `type: 'FLOW_ERROR'`

## Changes made

- updated `buildApexNotification()` to return `type: 'APEX_ERROR'`
- updated `buildFlowNotification()` to return `type: 'FLOW_ERROR'`

## Impact

This change does not modify how Apex and Flow errors are collected.
It only corrects the notification labeling for downstream consumers such as monitoring integrations and Grafana-based filtering/routing.