### PR TITLE
fix(docker): install a fixed Node.js 24 patch to unblock Salesforce CLI auth

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -1010,6 +1010,7 @@
     "peut",
     "picklist",
     "picomatch",
+    "pipefail",
     "pjson",
     "plantuml",
     "ployer",

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -79,6 +79,24 @@ jobs:
           tags: |
             sfdx-hardis:security-scan
 
+      # Smoke-test the CLI in the built image. Auth is not tested (no org in CI).
+      # Each command is wrapped in `timeout` so the Node "unsettled top-level await"
+      # hang / exit 13 fails the job (https://github.com/hardisgroupcom/sfdx-hardis/issues/1972).
+      - name: Run CLI smoke tests
+        run: |
+          set -euo pipefail
+          image=sfdx-hardis:security-scan
+          echo "== node --version =="
+          docker run --rm "$image" node --version
+          echo "== sf --version =="
+          timeout 180 docker run --rm "$image" sf --version
+          echo "== sf org list --json (must succeed with no default org) =="
+          timeout 180 docker run --rm "$image" sf org list --json
+          echo "== sf hardis --help (plugin loads) =="
+          timeout 180 docker run --rm "$image" sf hardis --help
+          echo "== sf hardis:doc:project2markdown --help (command wired) =="
+          timeout 180 docker run --rm "$image" sf hardis:doc:project2markdown --help
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0 # zizmor: ignore[unpinned-tools] trivy-action downloads the trivy binary at runtime, no version to pin in the workflow
         with:
@@ -171,6 +189,24 @@ jobs:
           tags: |
             sfdx-hardis-ubuntu:security-scan
 
+      # Smoke-test the CLI in the built image. Auth is not tested (no org in CI).
+      # Each command is wrapped in `timeout` so the Node "unsettled top-level await"
+      # hang / exit 13 fails the job (https://github.com/hardisgroupcom/sfdx-hardis/issues/1972).
+      - name: Run CLI smoke tests (Ubuntu)
+        run: |
+          set -euo pipefail
+          image=sfdx-hardis-ubuntu:security-scan
+          echo "== node --version =="
+          docker run --rm "$image" node --version
+          echo "== sf --version =="
+          timeout 180 docker run --rm "$image" sf --version
+          echo "== sf org list --json (must succeed with no default org) =="
+          timeout 180 docker run --rm "$image" sf org list --json
+          echo "== sf hardis --help (plugin loads) =="
+          timeout 180 docker run --rm "$image" sf hardis --help
+          echo "== sf hardis:doc:project2markdown --help (command wired) =="
+          timeout 180 docker run --rm "$image" sf hardis:doc:project2markdown --help
+
       - name: Run Trivy vulnerability scanner (Ubuntu)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0 # zizmor: ignore[unpinned-tools] trivy-action downloads the trivy binary at runtime, no version to pin in the workflow
         with:
@@ -226,108 +262,3 @@ jobs:
             sfdx-hardis-ubuntu-image-sbom.spdx.json
             sfdx-hardis-ubuntu-trivy-image-results.txt
             sfdx-hardis-ubuntu-trivy-image-results.sarif
-
-  # Smoke-test the CLI inside the built images. Runs in parallel with the Trivy
-  # scan jobs (both only need prepare-package) so it stays off the critical path.
-  # Auth is not tested: no org is available in CI. Each command is wrapped in
-  # `timeout` so the Node "unsettled top-level await" hang / exit 13 fails the job
-  # (see https://github.com/hardisgroupcom/sfdx-hardis/issues/1972).
-  docker-cli-smoke-test-alpine:
-    name: Smoke-test sfdx-hardis CLI (Alpine)
-    needs: prepare-package
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
-
-      - name: Download packaged plugin
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-        with:
-          name: sfdx-hardis-local
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Build Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          build-args: |
-            SFDX_HARDIS_VERSION=latest
-            SFDX_HARDIS_TGZ=sfdx-hardis-local.tgz
-            SFDX_CLI_VERSION=latest
-          load: true
-          push: false
-          tags: |
-            sfdx-hardis:cli-smoke-test
-
-      - name: Run CLI smoke tests (Alpine)
-        run: |
-          set -euo pipefail
-          image=sfdx-hardis:cli-smoke-test
-          echo "== node --version =="
-          docker run --rm "$image" node --version
-          echo "== sf --version =="
-          timeout 180 docker run --rm "$image" sf --version
-          echo "== sf org list --json (must succeed with no default org) =="
-          timeout 180 docker run --rm "$image" sf org list --json
-          echo "== sf hardis --help (plugin loads) =="
-          timeout 180 docker run --rm "$image" sf hardis --help
-          echo "== sf hardis:doc:project2markdown --help (command wired) =="
-          timeout 180 docker run --rm "$image" sf hardis:doc:project2markdown --help
-
-  docker-cli-smoke-test-ubuntu:
-    name: Smoke-test sfdx-hardis CLI (Ubuntu)
-    needs: prepare-package
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
-
-      - name: Download packaged plugin
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-        with:
-          name: sfdx-hardis-local
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Build Docker Ubuntu image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          file: Dockerfile-ubuntu
-          platforms: linux/amd64
-          build-args: |
-            SFDX_HARDIS_VERSION=latest
-            SFDX_HARDIS_TGZ=sfdx-hardis-local.tgz
-            SFDX_CLI_VERSION=latest
-          load: true
-          push: false
-          tags: |
-            sfdx-hardis-ubuntu:cli-smoke-test
-
-      - name: Run CLI smoke tests (Ubuntu)
-        run: |
-          set -euo pipefail
-          image=sfdx-hardis-ubuntu:cli-smoke-test
-          echo "== node --version =="
-          docker run --rm "$image" node --version
-          echo "== sf --version =="
-          timeout 180 docker run --rm "$image" sf --version
-          echo "== sf org list --json (must succeed with no default org) =="
-          timeout 180 docker run --rm "$image" sf org list --json
-          echo "== sf hardis --help (plugin loads) =="
-          timeout 180 docker run --rm "$image" sf hardis --help
-          echo "== sf hardis:doc:project2markdown --help (command wired) =="
-          timeout 180 docker run --rm "$image" sf hardis:doc:project2markdown --help

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -226,3 +226,104 @@ jobs:
             sfdx-hardis-ubuntu-image-sbom.spdx.json
             sfdx-hardis-ubuntu-trivy-image-results.txt
             sfdx-hardis-ubuntu-trivy-image-results.sarif
+
+  # Smoke-test the CLI inside the built images. Runs in parallel with the Trivy
+  # scan jobs (both only need prepare-package) so it stays off the critical path.
+  # Auth is not tested: no org is available in CI. Each command is wrapped in
+  # `timeout` so the Node "unsettled top-level await" hang / exit 13 fails the job
+  # (see https://github.com/hardisgroupcom/sfdx-hardis/issues/1972).
+  docker-cli-smoke-test-alpine:
+    name: Smoke-test sfdx-hardis CLI (Alpine)
+    needs: prepare-package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Download packaged plugin
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: sfdx-hardis-local
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            SFDX_HARDIS_VERSION=latest
+            SFDX_HARDIS_TGZ=sfdx-hardis-local.tgz
+            SFDX_CLI_VERSION=latest
+          load: true
+          push: false
+          tags: |
+            sfdx-hardis:cli-smoke-test
+
+      - name: Run CLI smoke tests (Alpine)
+        run: |
+          set -euo pipefail
+          image=sfdx-hardis:cli-smoke-test
+          echo "== node --version =="
+          docker run --rm "$image" node --version
+          echo "== sf --version =="
+          timeout 180 docker run --rm "$image" sf --version
+          echo "== sf hardis --help (plugin loads) =="
+          timeout 180 docker run --rm "$image" sf hardis --help
+          echo "== sf hardis:doc:project2markdown --help (command wired) =="
+          timeout 180 docker run --rm "$image" sf hardis:doc:project2markdown --help
+
+  docker-cli-smoke-test-ubuntu:
+    name: Smoke-test sfdx-hardis CLI (Ubuntu)
+    needs: prepare-package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Download packaged plugin
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: sfdx-hardis-local
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build Docker Ubuntu image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile-ubuntu
+          platforms: linux/amd64
+          build-args: |
+            SFDX_HARDIS_VERSION=latest
+            SFDX_HARDIS_TGZ=sfdx-hardis-local.tgz
+            SFDX_CLI_VERSION=latest
+          load: true
+          push: false
+          tags: |
+            sfdx-hardis-ubuntu:cli-smoke-test
+
+      - name: Run CLI smoke tests (Ubuntu)
+        run: |
+          set -euo pipefail
+          image=sfdx-hardis-ubuntu:cli-smoke-test
+          echo "== node --version =="
+          docker run --rm "$image" node --version
+          echo "== sf --version =="
+          timeout 180 docker run --rm "$image" sf --version
+          echo "== sf hardis --help (plugin loads) =="
+          timeout 180 docker run --rm "$image" sf hardis --help
+          echo "== sf hardis:doc:project2markdown --help (command wired) =="
+          timeout 180 docker run --rm "$image" sf hardis:doc:project2markdown --help

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -275,6 +275,8 @@ jobs:
           docker run --rm "$image" node --version
           echo "== sf --version =="
           timeout 180 docker run --rm "$image" sf --version
+          echo "== sf org list --json (must succeed with no default org) =="
+          timeout 180 docker run --rm "$image" sf org list --json
           echo "== sf hardis --help (plugin loads) =="
           timeout 180 docker run --rm "$image" sf hardis --help
           echo "== sf hardis:doc:project2markdown --help (command wired) =="
@@ -323,6 +325,8 @@ jobs:
           docker run --rm "$image" node --version
           echo "== sf --version =="
           timeout 180 docker run --rm "$image" sf --version
+          echo "== sf org list --json (must succeed with no default org) =="
+          timeout 180 docker run --rm "$image" sf org list --json
           echo "== sf hardis --help (plugin loads) =="
           timeout 180 docker run --rm "$image" sf hardis --help
           echo "== sf hardis:doc:project2markdown --help (command wired) =="

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [beta] (main)
 
+- Fix Docker images (Alpine and Ubuntu) hanging on Salesforce CLI auth: install a Node.js 24 patch that carries the fix for the CVE-2026-48931 http.Agent regression (24.18.0+), instead of the broken Node 24.17.0 still served by Alpine's package repo (closes #1972).
+
 ## [7.19.1] 2026-07-05
 
 - Fix JWT login to a DevHub defaulting to `https://login.salesforce.com`: read `devHubInstanceUrl` from config when authenticating to a DevHub, instead of always reading `instanceUrl` (closes #1979).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,33 @@
 # Docker image to run sfdx-hardis
 
+# Node.js is deliberately NOT installed from Alpine's apk repo.
+# As of July 2026, Alpine 3.23 ships nodejs 24.17.0, which sits in the broken band of the
+# CVE-2026-48931 http.Agent security fix and hangs the Salesforce CLI / jsforce with an
+# "unsettled top-level await" error (see https://github.com/hardisgroupcom/sfdx-hardis/issues/1972).
+# The follow-up fix (PR #64004) landed one patch later, in Node 24.18.0, which Alpine's repo
+# does not serve yet. So we copy a fixed Node 24 build from the official node:24-alpine image
+# (currently 24.18.0), while keeping the official python base so pip/MkDocs keeps working
+# (no PEP-668 issues).
+ARG NODE_IMAGE=node:24-alpine
+FROM ${NODE_IMAGE} AS node
+
 FROM python:3.12.12-alpine3.23
 
 LABEL maintainer="Nicolas VUILLAMY <nicolas.vuillamy@cloudity.com>"
+
+# Copy the fixed Node.js 24 runtime (node + npm + corepack) from the official node image
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
+    ln -sf /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
 
 RUN apk add --update --no-cache \
             coreutils \
             git \
             bash \
-            nodejs \
-            npm \
+            # Required for the copied Node.js binary (musl C++ runtime)
+            libstdc++ \
             # Required for docker
             docker \
             openrc \

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -6,6 +6,9 @@ LABEL maintainer="Nicolas VUILLAMY <nicolas.vuillamy@cloudity.com>"
 
 ENV SF_DATA_DIR=/usr/local/lib
 
+# Node.js major version installed from NodeSource (see note in the install step below)
+ARG NODE_MAJOR=24
+
 # Update package list and install required packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
@@ -48,7 +51,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     ln -sf /usr/bin/pip3 /usr/bin/pip && \
     # Install Node.js
-    curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    # Pin to the Node 24 line: NodeSource serves its latest patch (24.18.0+), which includes
+    # the PR #64004 follow-up to the CVE-2026-48931 http.Agent fix. Without that follow-up
+    # (i.e. Node 24.17.0) the Salesforce CLI / jsforce hangs with an "unsettled top-level await"
+    # error (see https://github.com/hardisgroupcom/sfdx-hardis/issues/1972).
+    curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y nodejs && \
     # Chrome installation 
     wget -q -O google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \


### PR DESCRIPTION
## Problem

Docker images (Alpine and Ubuntu) hang on Salesforce CLI auth with an `unsettled top-level await` error at `@salesforce/cli/bin/run.js` (closes #1972).

Root cause is a Node.js patch-level regression, not a major-version issue:

- **Node 24.17.0** shipped the `http.Agent` response-queue-poisoning security fix (CVE-2026-48931), which exposes a gap in jsforce's `node-fetch@2` transport and leaves the request promise unsettled.
- **Node 24.18.0** added the follow-up PR #64004 (`http: avoid stream listeners on idle agent sockets`) that restores compatibility.

The images landed in the broken band because:

| Source | Node served | Status |
|--------|-------------|--------|
| Alpine 3.23 `apk add nodejs` | 24.17.0 | broken |
| NodeSource `setup_lts.x` | resolves to 24.x | depends on patch |

Alpine's package repo still serves the pre-fix `24.17.0`, so a plain rebuild does not help on Alpine.

## Fix

- **`Dockerfile` (Alpine):** stop installing Node from `apk` (stuck at broken 24.17.0). Multi-stage copy a fixed Node 24 build (currently 24.18.0) from the official `node:24-alpine` image, keeping the `python:3.12.12-alpine3.23` base so pip/MkDocs keeps working (a `node:`-based swap would hit PEP-668). Add `libstdc++` for the copied binary.
- **`Dockerfile-ubuntu`:** pin NodeSource to `setup_24.x` (`NODE_MAJOR=24`), which serves the latest patch (24.18.0+).

Both build sources are past the CVE-2026-48931 patch band and include PR #64004, so `sf`/auth no longer hangs. `deploy.yml` needs no change: the Dockerfile defaults produce the fixed Node, so every tag inherits it on the next build.

## Verification

- Version boundaries verified against the Node.js V22/V24 changelogs, the jsforce (#1806) and forcedotcom/cli (#3180) issues, and live Alpine / NodeSource / `node:24-alpine` version data.
- Local Docker build not run yet (no daemon available in the dev environment); relying on CI image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)