### PR TITLE
feat(doctor): introduce hardis:doctor command and enhance uxLog options

### DIFF
--- a/.claude/skills/uxlog-usage/SKILL.md
+++ b/.claude/skills/uxlog-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uxlog-usage
-description: How to pick the correct uxLog level (action, log, warning, error, success, other), the matching chalk color, sensitive logging, VS Code UI suppression, and uxLogTable. Use when adding or modifying any uxLog call.
+description: How to pick the correct uxLog level (action, log, warning, error, success, other), the matching chalk color, the options object (sensitive, alwaysVisible), VS Code UI suppression, and uxLogTable. Use when adding or modifying any uxLog call.
 user-invocable: false
 ---
 
@@ -66,21 +66,35 @@ uxLog("other", this, JSON.stringify(rawApiResponse, null, 2));
 - Do not use `log` (which goes to the UI in grey) for noisy diagnostic output - prefer `other`.
 - Do not omit chalk - every `uxLog` should be wrapped in the matching color so terminal output stays readable.
 
-## Sensitive logging (`sensitive=true`)
+## Options (4th argument)
 
-Pass `true` as the fourth argument when the line contains credentials, tokens, secrets, or any data that must not land in the file log or the VS Code UI.
+The optional fourth argument is a `UxLogOptions` object: `{ sensitive?: boolean; alwaysVisible?: boolean }`.
 
 ```typescript
-uxLog("log", this, c.grey(`Authenticating with token ${token}`), true);
+uxLog("log", this, c.grey(`Authenticating with token ${token}`), { sensitive: true });
+uxLog("action", this, c.cyan("Installation summary:"), { alwaysVisible: true });
 ```
+
+> Backward compatibility: the 4th argument also still accepts a bare boolean (the legacy `sensitive` flag), because `uxLog` is called by external plugins. `uxLog(..., true)` is equivalent to `uxLog(..., { sensitive: true })`. **For new code, always use the options object.**
+
+### `sensitive`
+
+Set `{ sensitive: true }` when the line contains credentials, tokens, secrets, or any data that must not land in the file log or the VS Code UI. Use it for any line that interpolates an access token, refresh token, client secret, password, or third-party API key.
 
 Behaviour:
 
 - Terminal: shows the real text (so the user running the command can still see it locally).
 - File log (`hardisLogFileStream`): writes the literal string `OBFUSCATED LOG LINE`.
-- VS Code UI: sends `OBFUSCATED LOG LINE`. Exception: lines containing `SFDX_CLIENT_ID_`, `SFDX_CLIENT_KEY_`, or `SFDX_CLIENT_CERT_` are sent as-is even when `sensitive=true`.
+- VS Code UI: sends `OBFUSCATED LOG LINE`. Exception: lines containing `SFDX_CLIENT_ID_`, `SFDX_CLIENT_KEY_`, or `SFDX_CLIENT_CERT_` are sent as-is even when `sensitive` is set.
 
-Use `sensitive=true` for any line that interpolates an access token, refresh token, client secret, password, or third-party API key.
+### `alwaysVisible`
+
+Set `{ alwaysVisible: true }` to keep the enclosing VS Code UI section expanded by default, instead of auto-collapsing when a later section opens (and staying open in the UI's "simple" mode too). A manual collapse by the user still wins.
+
+- On an `action` line: keeps the section that line **starts** expanded.
+- On any other level (`log`, `warning`, `error`, ...): keeps the section that **contains** the line expanded.
+
+Use it for a summary block the user should keep seeing while they act on the next prompt (e.g. an install summary shown just before a confirmation). No effect outside the VS Code LWC UI.
 
 ## VS Code / LWC UI suppression
 

--- a/.megalinter_github_conf/branch_protection_rules.json
+++ b/.megalinter_github_conf/branch_protection_rules.json
@@ -1,0 +1,5 @@
+{
+    "message": "Not Found",
+    "documentation_url": "https://docs.github.com/rest",
+    "status": "404"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [beta] (main)
 
+- New [hardis:doctor](https://sfdx-hardis.cloudity.com/hardis/doctor/): Gather your local install info and open a pre-filled GitHub issue to report a bug faster.
+
 ## [7.19.2] 2026-07-06
 
 - Fix Docker images (Alpine and Ubuntu) hanging on Salesforce CLI auth: install a Node.js 24 patch that carries the fix for the CVE-2026-48931 http.Agent regression (24.18.0+), instead of the broken Node 24.17.0 still served by Alpine's package repo (closes #1972).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,9 +56,9 @@
 
 ## hardis:doctor
 
-| Command                                                                     | Title |
-|:----------------------------------------------------------------------------|:------|
-| [**hardis:doctor**](hardis/doctor.md)                                       |       |
+| Command                               | Title |
+|:--------------------------------------|:------|
+| [**hardis:doctor**](hardis/doctor.md) |       |
 
 ## hardis:git
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -54,6 +54,12 @@
 | [**hardis:doc:project2markdown**](hardis/doc/project2markdown.md)           |       |
 | [**hardis:doc:release-notes**](hardis/doc/release-notes.md)                 |       |
 
+## hardis:doctor
+
+| Command                                                                     | Title |
+|:----------------------------------------------------------------------------|:------|
+| [**hardis:doctor**](hardis/doctor.md)                                       |       |
+
 ## hardis:git
 
 | Command                                                                     | Title |

--- a/docs/hardis/doctor.md
+++ b/docs/hardis/doctor.md
@@ -45,16 +45,16 @@ In agent mode (or in CI):
 
 ## Parameters
 
-|Name|Type|Description|Default|Required|Options|
-|:---|:--:|:----------|:-----:|:------:|:-----:|
-|agent|boolean|Run in non-interactive mode for agents and automation||||
-|debug<br/>-d|boolean|Activate debug mode (more logs)||||
-|flags-dir|option|undefined||||
-|json|boolean|Format output as json.||||
-|open<br/>-o|boolean|Open the GitHub new issue page directly without prompting||||
-|skip-version-check|boolean|Do not query npm for the latest versions (faster, works offline)||||
-|skipauth|boolean|Skip authentication check when a default username is required||||
-|websocket|option|Websocket host:port for VsCode SFDX Hardis UI integration||||
+| Name               |  Type   | Description                                                      | Default | Required | Options |
+|:-------------------|:-------:|:-----------------------------------------------------------------|:-------:|:--------:|:-------:|
+| agent              | boolean | Run in non-interactive mode for agents and automation            |         |          |         |
+| debug<br/>-d       | boolean | Activate debug mode (more logs)                                  |         |          |         |
+| flags-dir          | option  | undefined                                                        |         |          |         |
+| json               | boolean | Format output as json.                                           |         |          |         |
+| open<br/>-o        | boolean | Open the GitHub new issue page directly without prompting        |         |          |         |
+| skip-version-check | boolean | Do not query npm for the latest versions (faster, works offline) |         |          |         |
+| skipauth           | boolean | Skip authentication check when a default username is required    |         |          |         |
+| websocket          | option  | Websocket host:port for VsCode SFDX Hardis UI integration        |         |          |         |
 
 ## Examples
 

--- a/docs/hardis/doctor.md
+++ b/docs/hardis/doctor.md
@@ -1,0 +1,69 @@
+<!-- This file has been generated with command 'sf hardis:doc:plugin:generate'. Please do not update it manually or it may be overwritten -->
+# hardis:doctor
+
+## Description
+
+
+## Command Behavior
+
+**Collects your local sfdx-hardis install info and helps you open a pre-filled GitHub issue.**
+
+This command gathers everything a maintainer usually asks for when investigating a bug, then prints it as a ready-to-paste report and offers to open the sfdx-hardis "New issue" page with the report already filled in.
+
+Key functionalities:
+
+- **Install info gathering:** sfdx-hardis version, Salesforce CLI version, Node.js version, OS, shell, language and the full list of installed SF CLI plugins with their versions.
+- **Latest version check:** Queries npm for the latest published versions and flags any outdated component (shown as `(latest: x.y.z)` in the report). If anything is outdated, it warns you to upgrade first, in case the issue is already fixed in a newer version. Disable with `--skip-version-check`.
+- **VS Code extension detection:** When the command runs inside VS Code with the sfdx-hardis extension linked, the extension version is added to the report.
+- **CI detection:** Detects whether it runs in a CI environment and which provider.
+- **Pre-filled GitHub issue:** Builds the "New issue" URL of the sfdx-hardis repository with the report pre-filled in the body, and (interactively) opens it in your browser.
+
+The report is always printed in your terminal, so you can copy it manually if the browser page is not enough.
+
+<details markdown="1">
+<summary>Technical explanations</summary>
+
+- **oclif Config:** Install info is read from the oclif `Config` object (`config.version`, `config.shell`, `config.plugins`), so no shell command is executed to list plugins.
+- **Node & OS:** Node version comes from `process.version`; OS details come from the Node.js `os` module.
+- **VS Code extension version:** Requested over the existing WebSocket connection (`getExtensionVersion` event). The extension answers with its version; the request times out gracefully after a few seconds and reports "not available" if no compatible extension is linked.
+- **Issue URL:** Built as `https://github.com/hardisgroupcom/sfdx-hardis/issues/new` with `title` and `body` query parameters. If the encoded URL would exceed the browser limit, the plugin list is trimmed from the URL body (the full report stays in the terminal).
+- **Browser:** Uses the `open` package to launch the default browser after user confirmation.
+</details>
+
+### Agent Mode
+
+Supports non-interactive execution with `--agent`:
+
+```sh
+sf hardis:doctor --agent
+```
+
+In agent mode (or in CI):
+- The install info report and the GitHub issue URL are printed.
+- No prompt is displayed and the browser is never opened.
+
+
+## Parameters
+
+|Name|Type|Description|Default|Required|Options|
+|:---|:--:|:----------|:-----:|:------:|:-----:|
+|agent|boolean|Run in non-interactive mode for agents and automation||||
+|debug<br/>-d|boolean|Activate debug mode (more logs)||||
+|flags-dir|option|undefined||||
+|json|boolean|Format output as json.||||
+|open<br/>-o|boolean|Open the GitHub new issue page directly without prompting||||
+|skip-version-check|boolean|Do not query npm for the latest versions (faster, works offline)||||
+|skipauth|boolean|Skip authentication check when a default username is required||||
+|websocket|option|Websocket host:port for VsCode SFDX Hardis UI integration||||
+
+## Examples
+
+```shell
+$ sf hardis:doctor
+```
+
+```shell
+$ sf hardis:doctor --agent
+```
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -577,6 +577,12 @@ sfdx-hardis is primarily led by Nicolas Vuillamy & [Cloudity](https://www.cloudi
 | [**hardis:doc:project2markdown**](hardis/doc/project2markdown.md)           |       |
 | [**hardis:doc:release-notes**](hardis/doc/release-notes.md)                 |       |
 
+### hardis:doctor
+
+| Command                                                                     | Title |
+|:----------------------------------------------------------------------------|:------|
+| [**hardis:doctor**](hardis/doctor.md)                                       |       |
+
 ### hardis:git
 
 | Command                                                                     | Title |

--- a/docs/index.md
+++ b/docs/index.md
@@ -579,9 +579,9 @@ sfdx-hardis is primarily led by Nicolas Vuillamy & [Cloudity](https://www.cloudi
 
 ### hardis:doctor
 
-| Command                                                                     | Title |
-|:----------------------------------------------------------------------------|:------|
-| [**hardis:doctor**](hardis/doctor.md)                                       |       |
+| Command                               | Title |
+|:--------------------------------------|:------|
+| [**hardis:doctor**](hardis/doctor.md) |       |
 
 ### hardis:git
 

--- a/docs/salesforce-agentic-automation.md
+++ b/docs/salesforce-agentic-automation.md
@@ -259,6 +259,7 @@ The table below lists every sfdx-hardis command that supports `--agent`. Click t
 | [**hardis:auth:login**](hardis/auth/login.md)                                           | Log in to a Salesforce org interactively or via JWT / connected-app OAuth                                     |
 | [**hardis:cache:clear**](hardis/cache/clear.md)                                         | Clear the sfdx-hardis local cache (useful when encountering stale metadata or config data)                    |
 | [**hardis:config:get**](hardis/config/get.md)                                           | Read and display the merged project / branch / user configuration for the current project                     |
+| [**hardis:doctor**](hardis/doctor.md)                                                   | Gather local install info and print a ready-to-paste report plus a pre-filled GitHub issue URL                |
 | [**hardis:git:pull-requests:extract**](hardis/git/pull-requests/extract.md)             | Extract pull/merge request data from GitHub, GitLab, or Azure DevOps for reporting and auditing               |
 | [**hardis:mdapi:deploy**](hardis/mdapi/deploy.md)                                       | Deploy a Metadata API format directory or zip to a Salesforce org                                             |
 | [**hardis:misc:custom-label-translations**](hardis/misc/custom-label-translations.md)   | Isolate and export specific custom label translations                                                         |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -281,6 +281,8 @@ nav:
           - packagexml2markdown: hardis/doc/packagexml2markdown.md
           - plugin generate: hardis/doc/plugin/generate.md
           - project2markdown: hardis/doc/project2markdown.md
+      - hardis:doctor:
+          - doctor: hardis/doctor.md
       - hardis:git:
           - pull-requests extract: hardis/git/pull-requests/extract.md
       - hardis:lint:

--- a/src/commands/hardis/doctor.ts
+++ b/src/commands/hardis/doctor.ts
@@ -1,0 +1,422 @@
+/* jscpd:ignore-start */
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+import { AnyJson } from '@salesforce/ts-types';
+import * as os from 'node:os';
+import axios from 'axios';
+import c from 'chalk';
+import open from 'open';
+import semver from 'semver';
+import { getEnvVar } from '../../config/index.js';
+import { isCI, uxLog, uxLogTable } from '../../common/utils/index.js';
+import { prompts } from '../../common/utils/prompts.js';
+import { WebSocketClient } from '../../common/websocketClient.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('sfdx-hardis', 'org');
+
+const NEW_ISSUE_URL = 'https://github.com/hardisgroupcom/sfdx-hardis/issues/new';
+// Keep the generated URL comfortably under the ~8k browser limit.
+const MAX_ISSUE_URL_LENGTH = 7000;
+// npm package name of the Salesforce CLI (used to check the CLI latest version)
+const SF_CLI_NPM_NAME = '@salesforce/cli';
+
+interface PluginInfo {
+  name: string;
+  version: string;
+  type: string;
+  latest?: string;
+  outdated?: boolean;
+}
+
+// Minimal structural shape of the oclif Config we rely on.
+// Typed structurally to avoid dual-package type conflicts between the oclif
+// copy used by @salesforce/sf-plugins-core and the top-level one.
+interface OclifConfigLike {
+  version: string;
+  shell: string;
+  pjson?: { version?: string };
+  plugins?: Map<string, { name: string; version: string; type: string }>;
+}
+
+interface DoctorInfo {
+  sfdxHardisVersion: string;
+  sfdxHardisLatest?: string;
+  sfdxHardisOutdated?: boolean;
+  sfCliVersion: string;
+  sfCliLatest?: string;
+  sfCliOutdated?: boolean;
+  nodeVersion: string;
+  os: string;
+  shell: string;
+  lang: string;
+  isCI: boolean;
+  ciProvider?: string;
+  plugins: PluginInfo[];
+  vscodeExtensionVersion?: string;
+  // Human-readable names of the components that are not on their latest version
+  outdatedItems: string[];
+}
+
+export default class Doctor extends SfCommand<any> {
+  public static title = 'Doctor';
+
+  public static description = `
+## Command Behavior
+
+**Collects your local sfdx-hardis install info and helps you open a pre-filled GitHub issue.**
+
+This command gathers everything a maintainer usually asks for when investigating a bug, then prints it as a ready-to-paste report and offers to open the sfdx-hardis "New issue" page with the report already filled in.
+
+Key functionalities:
+
+- **Install info gathering:** sfdx-hardis version, Salesforce CLI version, Node.js version, OS, shell, language and the full list of installed SF CLI plugins with their versions.
+- **Latest version check:** Queries npm for the latest published versions and flags any outdated component (shown as \`(latest: x.y.z)\` in the report). If anything is outdated, it warns you to upgrade first, in case the issue is already fixed in a newer version. Disable with \`--skip-version-check\`.
+- **VS Code extension detection:** When the command runs inside VS Code with the sfdx-hardis extension linked, the extension version is added to the report.
+- **CI detection:** Detects whether it runs in a CI environment and which provider.
+- **Pre-filled GitHub issue:** Builds the "New issue" URL of the sfdx-hardis repository with the report pre-filled in the body, and (interactively) opens it in your browser.
+
+The report is always printed in your terminal, so you can copy it manually if the browser page is not enough.
+
+<details markdown="1">
+<summary>Technical explanations</summary>
+
+- **oclif Config:** Install info is read from the oclif \`Config\` object (\`config.version\`, \`config.shell\`, \`config.plugins\`), so no shell command is executed to list plugins.
+- **Node & OS:** Node version comes from \`process.version\`; OS details come from the Node.js \`os\` module.
+- **Latest versions:** Queried from the npm registry (\`registry.npmjs.org\`) in parallel, with a short timeout and full best-effort handling, then compared with \`semver\`. Core plugins are not flagged, as they are pinned to the Salesforce CLI.
+- **VS Code extension version:** Requested over the existing WebSocket connection (\`getExtensionVersion\` event). The extension answers with its version; the request times out gracefully after a few seconds and reports "not available" if no compatible extension is linked.
+- **Issue URL:** Built as \`https://github.com/hardisgroupcom/sfdx-hardis/issues/new\` with \`title\` and \`body\` query parameters. If the encoded URL would exceed the browser limit, the plugin list is trimmed from the URL body (the full report stays in the terminal).
+- **Browser:** Uses the \`open\` package to launch the default browser after user confirmation.
+</details>
+
+### Agent Mode
+
+Supports non-interactive execution with \`--agent\`:
+
+\`\`\`sh
+sf hardis:doctor --agent
+\`\`\`
+
+In agent mode (or in CI):
+- The install info report and the GitHub issue URL are printed.
+- No prompt is displayed and the browser is never opened.
+`;
+
+  public static examples = ['$ sf hardis:doctor', '$ sf hardis:doctor --agent'];
+
+  public static flags: any = {
+    agent: Flags.boolean({
+      default: false,
+      description: 'Run in non-interactive mode for agents and automation',
+    }),
+    open: Flags.boolean({
+      char: 'o',
+      default: false,
+      description: 'Open the GitHub new issue page directly without prompting',
+    }),
+    'skip-version-check': Flags.boolean({
+      default: false,
+      description: 'Do not query npm for the latest versions (faster, works offline)',
+    }),
+    debug: Flags.boolean({
+      char: 'd',
+      default: false,
+      description: messages.getMessage('debugMode'),
+    }),
+    websocket: Flags.string({
+      description: messages.getMessage('websocket'),
+    }),
+    skipauth: Flags.boolean({
+      description: 'Skip authentication check when a default username is required',
+    }),
+  };
+
+  // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
+  public static requiresProject = false;
+
+  /* jscpd:ignore-end */
+
+  public async run(): Promise<AnyJson> {
+    const { flags } = await this.parse(Doctor);
+    const agentMode = flags.agent === true;
+
+    uxLog("action", this, c.cyan('Collecting installation info...'));
+
+    // Gather local install info (no shell command needed).
+    // Version checking queries npm to flag outdated components (unless skipped).
+    const checkVersions = flags['skip-version-check'] !== true;
+    const info = await this.gatherInstallInfo(this.config as unknown as OclifConfigLike, checkVersions);
+
+    // Best-effort: get VS Code extension version if linked
+    const extensionVersion = await WebSocketClient.getExtensionVersion();
+    info.vscodeExtensionVersion = extensionVersion || 'not available (run inside VS Code with the extension linked)';
+
+    // Build and print the markdown report (ready to paste into a GitHub issue)
+    const report = this.buildDoctorReport(info);
+    uxLog("action", this, c.cyan('sfdx-hardis install info (paste this into your GitHub issue):'));
+    uxLog("log", this, c.grey(report));
+
+    // Warn if some components are not on their latest version
+    if (info.outdatedItems.length > 0) {
+      uxLog(
+        "warning",
+        this,
+        c.yellow(
+          `Before posting an issue, we detected that you are not using the latest versions of ${info.outdatedItems.join(', ')}. Maybe upgrade them first, to check whether the problem is not already resolved in a more recent version?`
+        )
+      );
+    }
+
+    // Build the pre-filled GitHub issue URL
+    const issueUrl = this.buildIssueUrl(report);
+    uxLog("other", this, c.cyan(`GitHub new issue page: ${c.yellow(issueUrl)}`));
+
+    // In CI or agent mode: never prompt, never open a browser
+    if (isCI || agentMode) {
+      return { outputString: report, installInfo: info, issueUrl } as unknown as AnyJson;
+    }
+
+    // Display a readable summary of the gathered info just before prompting.
+    // alwaysVisible keeps this section open in the VS Code UI so the tables stay visible.
+    uxLog("action", this, c.cyan('Installation summary'), { alwaysVisible: true });
+    uxLogTable(this, this.buildEnvironmentRows(info), ['Item', 'Value']);
+    uxLogTable(this, this.buildPluginRows(info), ['Plugin', 'Version', 'Type', 'Latest']);
+
+    // Decide whether to open the browser
+    let shouldOpen = flags.open === true;
+    if (!shouldOpen) {
+      const openRes = await prompts({
+        type: 'confirm',
+        name: 'value',
+        message: c.cyan('Open the GitHub new issue page in your browser now?'),
+        description: 'The issue body will be pre-filled with your install info. Complete the bug description before submitting.',
+        initial: true,
+      });
+      shouldOpen = openRes.value === true;
+    }
+
+    if (shouldOpen) {
+      await open(issueUrl);
+    }
+
+    return { outputString: report, installInfo: info, issueUrl } as unknown as AnyJson;
+  }
+
+  // Gather local install info from the oclif config, Node.js and environment.
+  // No shell command is executed: plugin versions come from config.plugins.
+  // When checkVersions is true, the latest published versions are fetched from npm.
+  private async gatherInstallInfo(config: OclifConfigLike, checkVersions: boolean): Promise<DoctorInfo> {
+    const plugins: PluginInfo[] = [];
+    for (const plugin of config.plugins?.values?.() ?? []) {
+      // Skip oclif framework plugins: they are internal and not useful in an issue report
+      if (plugin.name.startsWith('@oclif/')) {
+        continue;
+      }
+      plugins.push({ name: plugin.name, version: plugin.version, type: plugin.type });
+    }
+    plugins.sort((a, b) => a.name.localeCompare(b.name));
+
+    const sfdxHardisPlugin = plugins.find((plugin) => plugin.name === 'sfdx-hardis');
+
+    const info: DoctorInfo = {
+      sfdxHardisVersion: sfdxHardisPlugin?.version ?? config.pjson?.version ?? 'unknown',
+      sfCliVersion: config.version,
+      nodeVersion: process.version,
+      os: `${os.platform()} ${os.release()} (${os.arch()})`,
+      shell: config.shell,
+      lang: getEnvVar('SFDX_HARDIS_LANG') || 'en',
+      isCI: isCI,
+      ciProvider: this.detectCiProvider(),
+      plugins: plugins,
+      outdatedItems: [],
+    };
+
+    if (checkVersions === true) {
+      await this.enrichWithLatestVersions(info);
+    }
+
+    return info;
+  }
+
+  // Best-effort detection of the CI provider from well-known environment variables
+  private detectCiProvider(): string | undefined {
+    if (getEnvVar('GITHUB_ACTIONS')) return 'GitHub Actions';
+    if (getEnvVar('GITLAB_CI')) return 'GitLab CI';
+    if (getEnvVar('TF_BUILD')) return 'Azure Pipelines';
+    if (getEnvVar('BITBUCKET_BUILD_NUMBER')) return 'Bitbucket Pipelines';
+    if (getEnvVar('CIRCLECI')) return 'CircleCI';
+    if (getEnvVar('JENKINS_URL')) return 'Jenkins';
+    if (getEnvVar('CI')) return 'Unknown (generic CI)';
+    return undefined;
+  }
+
+  // Fetches latest versions from npm (in parallel) and fills the outdated flags.
+  private async enrichWithLatestVersions(info: DoctorInfo): Promise<void> {
+    // A plugin is worth checking when the user can upgrade it independently.
+    // Core plugins are pinned to the Salesforce CLI, so upgrading the CLI covers them.
+    const isCheckable = (plugin: PluginInfo) => plugin.type === 'user' || plugin.name === 'sfdx-hardis';
+    const checkablePlugins = info.plugins.filter(isCheckable);
+    const npmNames = [...new Set([...checkablePlugins.map((plugin) => plugin.name), SF_CLI_NPM_NAME])];
+
+    const latestByName = new Map<string, string | null>();
+    await Promise.all(
+      npmNames.map(async (name) => {
+        latestByName.set(name, await this.getLatestNpmVersion(name));
+      })
+    );
+
+    // Plugins
+    for (const plugin of checkablePlugins) {
+      const latest = latestByName.get(plugin.name) ?? null;
+      if (latest) {
+        plugin.latest = latest;
+        plugin.outdated = this.isOutdated(plugin.version, latest);
+      }
+    }
+
+    // Salesforce CLI
+    const sfCliLatest = latestByName.get(SF_CLI_NPM_NAME) ?? undefined;
+    info.sfCliLatest = sfCliLatest;
+    info.sfCliOutdated = this.isOutdated(info.sfCliVersion, sfCliLatest);
+
+    // sfdx-hardis (mirror the plugin entry so the dedicated table row is consistent)
+    const sfdxHardisPlugin = info.plugins.find((plugin) => plugin.name === 'sfdx-hardis');
+    info.sfdxHardisLatest = sfdxHardisPlugin?.latest;
+    info.sfdxHardisOutdated = sfdxHardisPlugin?.outdated === true;
+
+    // Build the list of outdated component names for the warning message
+    const outdated: string[] = [];
+    if (info.sfdxHardisOutdated) outdated.push('sfdx-hardis');
+    if (info.sfCliOutdated) outdated.push('Salesforce CLI');
+    for (const plugin of checkablePlugins) {
+      if (plugin.name !== 'sfdx-hardis' && plugin.outdated === true) {
+        outdated.push(plugin.name);
+      }
+    }
+    info.outdatedItems = outdated;
+  }
+
+  // Best-effort fetch of the latest published version of an npm package.
+  // Returns null on any error so version checking never blocks the command.
+  private async getLatestNpmVersion(packageName: string): Promise<string | null> {
+    try {
+      const res = await axios.get(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`, {
+        timeout: 7000,
+        // Abbreviated metadata: smaller payload that still carries dist-tags
+        headers: { Accept: 'application/vnd.npm.install-v1+json' },
+      });
+      return res.data?.['dist-tags']?.latest ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  // Returns true when current is a valid version strictly lower than latest.
+  private isOutdated(current: string, latest: string | null | undefined): boolean {
+    if (!latest || !semver.valid(current) || !semver.valid(latest)) {
+      return false;
+    }
+    return semver.lt(current, latest);
+  }
+
+  // Renders a version cell, appending "(latest: x.y.z)" when the component is outdated.
+  private versionCell(current: string, latest: string | undefined, outdated: boolean | undefined): string {
+    return outdated && latest ? `${current} (latest: ${latest})` : current;
+  }
+
+  private buildPluginsBlock(info: DoctorInfo): string {
+    if (info.plugins.length === 0) {
+      return '(none detected)';
+    }
+    const lines: string[] = [];
+    lines.push('| Plugin | Version | Type | Latest |');
+    lines.push('| --- | --- | --- | --- |');
+    for (const plugin of info.plugins) {
+      const latest = plugin.outdated && plugin.latest ? plugin.latest : '';
+      lines.push(`| ${plugin.name} | ${plugin.version} | ${plugin.type} | ${latest} |`);
+    }
+    return lines.join('\n');
+  }
+
+  // Builds the Environment table rows for console display.
+  private buildEnvironmentRows(info: DoctorInfo): any[] {
+    return [
+      { Item: 'sfdx-hardis version', Value: this.versionCell(info.sfdxHardisVersion, info.sfdxHardisLatest, info.sfdxHardisOutdated) },
+      { Item: 'Salesforce CLI version', Value: this.versionCell(info.sfCliVersion, info.sfCliLatest, info.sfCliOutdated) },
+      { Item: 'Node.js version', Value: info.nodeVersion },
+      { Item: 'OS', Value: info.os },
+      { Item: 'Shell', Value: info.shell },
+      { Item: 'Language (SFDX_HARDIS_LANG)', Value: info.lang },
+      { Item: 'Running in CI', Value: info.isCI ? `yes${info.ciProvider ? ` (${info.ciProvider})` : ''}` : 'no' },
+      { Item: 'VS Code extension version', Value: info.vscodeExtensionVersion ?? 'not available' },
+    ];
+  }
+
+  // Builds the plugins table rows for console display.
+  // Core plugins are filtered out (they are pinned to the CLI), except @salesforce/cli itself.
+  private buildPluginRows(info: DoctorInfo): any[] {
+    return info.plugins
+      .filter((plugin) => plugin.type !== 'core' || plugin.name === '@salesforce/cli')
+      .map((plugin) => ({
+        Plugin: plugin.name,
+        Version: plugin.version,
+        Type: plugin.type,
+        // Outdated: show the latest version. Up to date: green check. Not checked: empty.
+        Latest: plugin.outdated && plugin.latest ? plugin.latest : plugin.latest ? '✅' : '',
+      }));
+  }
+
+  // Builds the English markdown report used both for the console output and the GitHub issue body.
+  private buildDoctorReport(info: DoctorInfo): string {
+    const lines: string[] = [];
+    lines.push('### Bug description');
+    lines.push('');
+    lines.push('<!-- Describe the issue you are facing here -->');
+    lines.push('');
+    lines.push('### Steps to reproduce');
+    lines.push('');
+    lines.push('1. ');
+    lines.push('2. ');
+    lines.push('3. ');
+    lines.push('');
+    lines.push('### Environment');
+    lines.push('');
+    lines.push('| Item | Value |');
+    lines.push('| --- | --- |');
+    lines.push(`| sfdx-hardis version | ${this.versionCell(info.sfdxHardisVersion, info.sfdxHardisLatest, info.sfdxHardisOutdated)} |`);
+    lines.push(`| Salesforce CLI version | ${this.versionCell(info.sfCliVersion, info.sfCliLatest, info.sfCliOutdated)} |`);
+    lines.push(`| Node.js version | ${info.nodeVersion} |`);
+    lines.push(`| OS | ${info.os} |`);
+    lines.push(`| Shell | ${info.shell} |`);
+    lines.push(`| Language (SFDX_HARDIS_LANG) | ${info.lang} |`);
+    lines.push(`| Running in CI | ${info.isCI ? `yes${info.ciProvider ? ` (${info.ciProvider})` : ''}` : 'no'} |`);
+    lines.push(`| VS Code extension version | ${info.vscodeExtensionVersion ?? 'not available'} |`);
+    lines.push('');
+    lines.push('### Installed SF CLI plugins');
+    lines.push('');
+    lines.push(this.buildPluginsBlock(info));
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  // Builds the GitHub "new issue" URL with a pre-filled title and body.
+  // If the encoded URL exceeds the browser limit, the plugin list is dropped and a note is added,
+  // since the full report is always printed in the terminal.
+  private buildIssueUrl(report: string): string {
+    const title = 'Issue report: ';
+    const buildUrl = (body: string) =>
+      `${NEW_ISSUE_URL}?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+
+    const url = buildUrl(report);
+    if (url.length <= MAX_ISSUE_URL_LENGTH) {
+      return url;
+    }
+
+    // Too long: keep everything up to the plugins section and add a paste note
+    const pluginsHeaderIndex = report.indexOf('### Installed SF CLI plugins');
+    const trimmedReport =
+      (pluginsHeaderIndex > -1 ? report.slice(0, pluginsHeaderIndex) : report) +
+      '\n_(report truncated - the full details, including installed plugins, were printed in your terminal, please paste them here)_\n';
+    return buildUrl(trimmedReport);
+  }
+}

--- a/src/commands/hardis/doctor.ts
+++ b/src/commands/hardis/doctor.ts
@@ -156,17 +156,6 @@ In agent mode (or in CI):
     uxLog("action", this, c.cyan('sfdx-hardis install info (paste this into your GitHub issue):'));
     uxLog("log", this, c.grey(report));
 
-    // Warn if some components are not on their latest version
-    if (info.outdatedItems.length > 0) {
-      uxLog(
-        "warning",
-        this,
-        c.yellow(
-          `Before posting an issue, we detected that you are not using the latest versions of ${info.outdatedItems.join(', ')}. Maybe upgrade them first, to check whether the problem is not already resolved in a more recent version?`
-        )
-      );
-    }
-
     // Build the pre-filled GitHub issue URL
     const issueUrl = this.buildIssueUrl(report);
     uxLog("other", this, c.cyan(`GitHub new issue page: ${c.yellow(issueUrl)}`));
@@ -177,10 +166,21 @@ In agent mode (or in CI):
     }
 
     // Display a readable summary of the gathered info just before prompting.
-    // alwaysVisible keeps this section open in the VS Code UI so the tables stay visible.
+    // alwaysVisible keeps this section open in the VS Code UI so the tables (and the warning below) stay visible.
     uxLog("action", this, c.cyan('Installation summary'), { alwaysVisible: true });
     uxLogTable(this, this.buildEnvironmentRows(info), ['Item', 'Value']);
     uxLogTable(this, this.buildPluginRows(info), ['Plugin', 'Version', 'Type', 'Latest']);
+
+    // Warn (inside the summary section) if some components are not on their latest version
+    if (info.outdatedItems.length > 0) {
+      uxLog(
+        "warning",
+        this,
+        c.yellow(
+          `Before posting an issue, we detected that you are not using the latest versions of ${info.outdatedItems.join(', ')}. Maybe upgrade them first, to check whether the problem is not already resolved in a more recent version?`
+        )
+      );
+    }
 
     // Decide whether to open the browser
     let shouldOpen = flags.open === true;
@@ -324,6 +324,14 @@ In agent mode (or in CI):
     return outdated && latest ? `${current} (latest: ${latest})` : current;
   }
 
+  // Renders the "Latest" cell: latest version when outdated, green check when up to date, empty when not checked.
+  private latestCell(plugin: PluginInfo): string {
+    if (plugin.outdated && plugin.latest) {
+      return plugin.latest;
+    }
+    return plugin.latest ? '✅' : '';
+  }
+
   private buildPluginsBlock(info: DoctorInfo): string {
     if (info.plugins.length === 0) {
       return '(none detected)';
@@ -332,8 +340,7 @@ In agent mode (or in CI):
     lines.push('| Plugin | Version | Type | Latest |');
     lines.push('| --- | --- | --- | --- |');
     for (const plugin of info.plugins) {
-      const latest = plugin.outdated && plugin.latest ? plugin.latest : '';
-      lines.push(`| ${plugin.name} | ${plugin.version} | ${plugin.type} | ${latest} |`);
+      lines.push(`| ${plugin.name} | ${plugin.version} | ${plugin.type} | ${this.latestCell(plugin)} |`);
     }
     return lines.join('\n');
   }
@@ -362,7 +369,7 @@ In agent mode (or in CI):
         Version: plugin.version,
         Type: plugin.type,
         // Outdated: show the latest version. Up to date: green check. Not checked: empty.
-        Latest: plugin.outdated && plugin.latest ? plugin.latest : plugin.latest ? '✅' : '',
+        Latest: this.latestCell(plugin),
       }));
   }
 

--- a/src/commands/hardis/doctor.ts
+++ b/src/commands/hardis/doctor.ts
@@ -254,7 +254,9 @@ In agent mode (or in CI):
   private async enrichWithLatestVersions(info: DoctorInfo): Promise<void> {
     // A plugin is worth checking when the user can upgrade it independently.
     // Core plugins are pinned to the Salesforce CLI, so upgrading the CLI covers them.
-    const isCheckable = (plugin: PluginInfo) => plugin.type === 'user' || plugin.name === 'sfdx-hardis';
+    // The Salesforce CLI itself is checked so its "Latest" cell is populated too.
+    const isCheckable = (plugin: PluginInfo) =>
+      plugin.type === 'user' || plugin.name === 'sfdx-hardis' || plugin.name === SF_CLI_NPM_NAME;
     const checkablePlugins = info.plugins.filter(isCheckable);
     const npmNames = [...new Set([...checkablePlugins.map((plugin) => plugin.name), SF_CLI_NPM_NAME])];
 
@@ -324,10 +326,10 @@ In agent mode (or in CI):
     return outdated && latest ? `${current} (latest: ${latest})` : current;
   }
 
-  // Renders the "Latest" cell: latest version when outdated, green check when up to date, empty when not checked.
+  // Renders the "Latest" cell: warning + latest version when outdated, green check when up to date, empty when not checked.
   private latestCell(plugin: PluginInfo): string {
     if (plugin.outdated && plugin.latest) {
-      return plugin.latest;
+      return `⚠️ (${plugin.latest})`;
     }
     return plugin.latest ? '✅' : '';
   }

--- a/src/commands/hardis/org/ext-client-app/rotate-credentials.ts
+++ b/src/commands/hardis/org/ext-client-app/rotate-credentials.ts
@@ -308,13 +308,13 @@ In agent mode:
       "log",
       this,
       c.grey(c.cyanBright(`- Consumer Key: ${c.bold(c.green(keyDisplay))}`)),
-      true
+      { sensitive: true }
     );
     uxLog(
       "log",
       this,
       c.grey(c.cyanBright(`- Consumer Secret: ${c.bold(c.green(secretDisplay))}`)),
-      true
+      { sensitive: true }
     );
     uxLog("warning", this, c.yellow(t('ecaRotateUpdateCiReminder')));
   }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1430,7 +1430,20 @@ export async function generateReports(
   ];
 }
 
-export function uxLog(logType: LogType, commandThis: any, textInit: string, sensitive = false): void {
+// Options for uxLog. `sensitive` obfuscates the value in log files; `alwaysVisible` keeps the
+// enclosing VS Code UI section expanded by default.
+export interface UxLogOptions {
+  sensitive?: boolean;
+  alwaysVisible?: boolean;
+}
+
+export function uxLog(logType: LogType, commandThis: any, textInit: string, optionsOrSensitive: boolean | UxLogOptions = {}): void {
+  // Backward compatibility: the 4th argument used to be a boolean "sensitive" flag.
+  // uxLog can be called by external plugins, so keep accepting that legacy form.
+  const options: UxLogOptions =
+    typeof optionsOrSensitive === 'boolean' ? { sensitive: optionsOrSensitive } : (optionsOrSensitive || {});
+  const sensitive = options.sensitive === true;
+  const alwaysVisible = options.alwaysVisible === true;
   const text = textInit.includes('[sfdx-hardis]') ? textInit : '[sfdx-hardis]' + (textInit.startsWith('[') ? '' : ' ') + textInit;
   // Console log
   if (commandThis?.ux) {
@@ -1464,7 +1477,7 @@ export function uxLog(logType: LogType, commandThis: any, textInit: string, sens
 
       // Send message to WebSocket client
       if (logType !== "other") {
-        WebSocketClient.sendCommandLogLineMessage(textToSend, logType, isQuestion);
+        WebSocketClient.sendCommandLogLineMessage(textToSend, logType, isQuestion, alwaysVisible);
       }
     }
   }
@@ -1899,7 +1912,7 @@ export async function generateSSLCertificate(
           )}
           - Value: ${c.bold(c.green(idKeyValues.clientIdValueString))}`
         )),
-      true
+      { sensitive: true }
     );
     uxLog(
       "log",
@@ -1910,7 +1923,7 @@ export async function generateSSLCertificate(
         )}
         - Value: ${c.bold(c.green(idKeyValues.clientKeyValueString))}`
       )),
-      true
+      { sensitive: true }
     );
     if (storeCertificateInVariable) {
       uxLog(
@@ -1922,7 +1935,7 @@ export async function generateSSLCertificate(
           )}
           - Value: ${c.bold(c.green(idKeyValues.clientCertValueString))}`
         )),
-        true
+        { sensitive: true }
       );
     }
     uxLog(
@@ -1947,7 +1960,7 @@ export async function generateSSLCertificate(
         "log",
         commandThis,
         c.grey(c.cyanBright(`- ${c.bold(c.green(idKeyValues.clientCertString))}\n- Value: ${c.bold(c.green(idKeyValues.clientCertValueString))}`)),
-        true
+        { sensitive: true }
       );
       uxLog("warning", commandThis, c.yellow(t('externalStorageCertNotCommitted')));
     }

--- a/src/common/websocketClient.ts
+++ b/src/common/websocketClient.ts
@@ -48,6 +48,7 @@ export class WebSocketClient {
   private isDead = false;
   private isInitialized = false;
   private userInput: string | null = null;
+  private extensionVersionResponse: string | null = null;
 
   /**
    * Returns the active WebSocketClient instance.
@@ -98,6 +99,16 @@ export class WebSocketClient {
 
   static isAliveWithLwcUI(): boolean {
     return WebSocketClient.isAlive() && WebSocketClient.activeInstance?.userInput === 'ui-lwc';
+  }
+
+  // Best-effort request of the connected VS Code extension version.
+  // Returns null when no VS Code extension is linked or when it does not answer in time.
+  static async getExtensionVersion(): Promise<string | null> {
+    const instance = WebSocketClient.activeInstance;
+    if (!WebSocketClient.isAlive() || !instance) {
+      return null;
+    }
+    return instance.requestExtensionVersion();
   }
 
 static sendMessage(data: any) {
@@ -195,12 +206,13 @@ static sendMessage(data: any) {
   }
 
   // Send command log line message
-  static sendCommandLogLineMessage(message: string, logType?: LogType, isQuestion?: boolean) {
+  static sendCommandLogLineMessage(message: string, logType?: LogType, isQuestion?: boolean, alwaysVisible?: boolean) {
     WebSocketClient.sendMessage({
       event: 'commandLogLine',
       logType: logType,
       message: message,
       isQuestion: isQuestion,
+      alwaysVisible: alwaysVisible,
     });
   }
 
@@ -364,6 +376,9 @@ static sendMessage(data: any) {
       this.userInput = data.userInput;
       this.isInitialized = true;
     }
+    else if (data.event === 'extensionVersionResponse') {
+      this.extensionVersionResponse = data.extensionVersion ?? 'unknown';
+    }
     else if (data.event === 'cancelCommand') {
       if (this.wsContext?.command === data?.context?.command && this.wsContext.id === data?.context?.id) {
         uxLog("error", this, c.red(t('commandCancelledByUser')));
@@ -375,6 +390,27 @@ static sendMessage(data: any) {
   sendMessageToServer(data: any) {
     data.context = this.wsContext;
     this.ws.send(JSON.stringify(data));
+  }
+
+  // Sends a getExtensionVersion request and waits (with a short timeout) for the response.
+  // Resolves null on timeout so the caller never blocks on a missing/older extension.
+  requestExtensionVersion(): Promise<string | null> {
+    this.extensionVersionResponse = null;
+    this.sendMessageToServer({ event: 'getExtensionVersion' });
+    return new Promise((resolve) => {
+      let interval: any = null;
+      const timeout = setTimeout(() => {
+        clearInterval(interval as NodeJS.Timeout);
+        resolve(this.extensionVersionResponse);
+      }, 5000);
+      interval = setInterval(() => {
+        if (this.extensionVersionResponse != null) {
+          clearInterval(interval as NodeJS.Timeout);
+          clearTimeout(timeout as NodeJS.Timeout);
+          resolve(this.extensionVersionResponse);
+        }
+      }, 200);
+    });
   }
 
   promptServer(prompts: any): Promise<any> {


### PR DESCRIPTION
This change introduces the `hardis:doctor` command to streamline bug reporting and
refactors the `uxLog` utility with new options.

- **`hardis:doctor` command**: Gathers comprehensive local installation details
  (sfdx-hardis, Salesforce CLI, Node.js, OS, plugins, VS Code extension),
  queries npm for latest versions, and generates a pre-filled GitHub issue.
  It supports both interactive and `--agent` modes.
- **`uxLog` options refactor**: The `uxLog` function now accepts an options
  object `{ sensitive?: boolean; alwaysVisible?: boolean }` as its 4th argument.
  - `alwaysVisible`: Keeps the enclosing VS Code UI section expanded, useful for
    displaying summaries before user interaction (e.g., in `hardis:doctor`).
  - Backward compatibility is maintained for the legacy `sensitive: boolean`
    flag, and internal calls are updated to use the new object syntax.
