### PR TITLE
fix: Keep JWT cert file alive for session-refreshing deployment commands in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [beta] (main)
 
+- Fix deployment command actions that refresh their session mid-run (like `sf agent publish`) crashing in CI because the JWT certificate file was deleted too early.
 - New `remove-packagexml-items` pre-deploy action type removes metadata items from package.xml before deployment.
 - Git delta operations now filter to only package directories when sfdx-project.json exists, preventing unrelated metadata changes from being deployed.
 

--- a/docs/schema/sfdx-hardis-json-schema-parameters.html
+++ b/docs/schema/sfdx-hardis-json-schema-parameters.html
@@ -1942,7 +1942,7 @@ Example: availableTargetBranches: [preprod, integration] and availableTargetBran
 <span class="description"><p>Type of the action</p>
 </span><div class="enum-value" id="commandsPreDeploy_items_type_enum">
             <h4>Must be one of:</h4>
-            <ul class="list-group"><li class="list-group-item enum-item">"command"</li><li class="list-group-item enum-item">"data"</li><li class="list-group-item enum-item">"apex"</li><li class="list-group-item enum-item">"schedule-batch"</li><li class="list-group-item enum-item">"publish-community"</li><li class="list-group-item enum-item">"manual"</li></ul>
+            <ul class="list-group"><li class="list-group-item enum-item">"command"</li><li class="list-group-item enum-item">"data"</li><li class="list-group-item enum-item">"apex"</li><li class="list-group-item enum-item">"schedule-batch"</li><li class="list-group-item enum-item">"publish-community"</li><li class="list-group-item enum-item">"manual"</li><li class="list-group-item enum-item">"remove-packagexml-items"</li></ul>
             </div>
         
 
@@ -1960,6 +1960,8 @@ Example: availableTargetBranches: [preprod, integration] and availableTargetBran
 </div><div id="commandsPreDeploy_items_type_ex4" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;publish-community&quot;</span>
 </pre></div>
 </div><div id="commandsPreDeploy_items_type_ex5" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;manual&quot;</span>
+</pre></div>
+</div><div id="commandsPreDeploy_items_type_ex6" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;remove-packagexml-items&quot;</span>
 </pre></div>
 </div>
             </div>
@@ -2226,6 +2228,119 @@ Example: availableTargetBranches: [preprod, integration] and availableTargetBran
         
 
         
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordioncommandsPreDeploy_items_parameters_packageXmlItems">
+    <div class="card">
+        <div class="card-header" id="headingcommandsPreDeploy_items_parameters_packageXmlItems">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#commandsPreDeploy_items_parameters_packageXmlItems"
+                        aria-expanded="" aria-controls="commandsPreDeploy_items_parameters_packageXmlItems" onclick="setAnchor('#commandsPreDeploy_items_parameters_packageXmlItems')"><span class="property-name">packageXmlItems</span></button>
+            </h2>
+        </div>
+
+        <div id="commandsPreDeploy_items_parameters_packageXmlItems"
+             class="collapse property-definition-div" aria-labelledby="headingcommandsPreDeploy_items_parameters_packageXmlItems"
+             data-parent="#accordioncommandsPreDeploy_items_parameters_packageXmlItems">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy" onclick="anchorLink('commandsPreDeploy')">commandsPreDeploy</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy_items" onclick="anchorLink('commandsPreDeploy_items')">Action</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy_items_parameters" onclick="anchorLink('commandsPreDeploy_items_parameters')">parameters</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy_items_parameters_packageXmlItems" onclick="anchorLink('commandsPreDeploy_items_parameters_packageXmlItems')">packageXmlItems</a></div><span class="badge badge-dark value-type">Type: array of string or string</span><br/>
+<span class="description"><p>List of package.xml items to remove before the metadata deployment for 'remove-packagexml-items' actions. Each entry uses the format TypeName:Member1,Member2 (use * as member to remove the whole type). A single string is also accepted for a single entry.</p>
+</span>
+        
+
+        
+        
+
+         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="commandsPreDeploy_items_parameters_packageXmlItems_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy" onclick="anchorLink('commandsPreDeploy')">commandsPreDeploy</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy_items" onclick="anchorLink('commandsPreDeploy_items')">Action</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy_items_parameters" onclick="anchorLink('commandsPreDeploy_items_parameters')">parameters</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy_items_parameters_packageXmlItems" onclick="anchorLink('commandsPreDeploy_items_parameters_packageXmlItems')">packageXmlItems</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#commandsPreDeploy_items_parameters_packageXmlItems_items" onclick="anchorLink('commandsPreDeploy_items_parameters_packageXmlItems_items')">packageXmlItems items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        
+
+        
+        </div>
+    </div><br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="commandsPreDeploy_items_parameters_packageXmlItems_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span>
+<span class="w">    </span><span class="s2">&quot;ApexClass:MyClass1,MyClass3&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;Layout:MyLayout1,MyLayout2,MyLayout3&quot;</span>
+<span class="p">]</span>
+</pre></div>
+</div><div id="commandsPreDeploy_items_parameters_packageXmlItems_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;AiEvaluationDefinition:My_Eval_Definition&quot;</span>
+</pre></div>
+</div>
             </div>
         </div>
     </div>
@@ -2558,6 +2673,19 @@ Example: availableTargetBranches: [preprod, integration] and availableTargetBran
 <span class="w">            </span><span class="s2">&quot;sfdmuProject&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;EmailTemplate&quot;</span>
 <span class="w">        </span><span class="p">},</span>
 <span class="w">        </span><span class="s2">&quot;context&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;process-deployment-only&quot;</span>
+<span class="w">    </span><span class="p">},</span>
+<span class="w">    </span><span class="p">{</span>
+<span class="w">        </span><span class="s2">&quot;id&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;removeLegacyItems&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;label&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;Remove legacy items from deployment package.xml&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;type&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;remove-packagexml-items&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;parameters&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">{</span>
+<span class="w">            </span><span class="s2">&quot;packageXmlItems&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">                </span><span class="s2">&quot;ApexClass:MyClass1,MyClass3&quot;</span><span class="p">,</span>
+<span class="w">                </span><span class="s2">&quot;Layout:MyLayout1,MyLayout2,MyLayout3&quot;</span>
+<span class="w">            </span><span class="p">]</span>
+<span class="w">        </span><span class="p">},</span>
+<span class="w">        </span><span class="s2">&quot;context&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;all&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;runOnlyOnceByOrg&quot;</span><span class="o">:</span><span class="w"> </span><span class="kc">false</span>
 <span class="w">    </span><span class="p">}</span>
 <span class="p">]</span>
 </pre></div>

--- a/src/common/actionsProvider/commandAction.ts
+++ b/src/common/actionsProvider/commandAction.ts
@@ -1,6 +1,20 @@
 import { ActionsProvider, ActionResult, PrePostCommand } from './actionsProvider.js';
-import { execCommand, uxLog } from '../utils/index.js';
+import { execCommand, getCurrentGitBranch, isCI, uxLog } from '../utils/index.js';
+import { AuthOrgOptions, authOrg, safeDeleteAuthTempFile } from '../utils/authUtils.js';
+import { GitProvider } from '../gitProvider/index.js';
+import { t } from '../utils/i18n.js';
 import c from 'chalk';
+
+// Commands that refresh their Salesforce session mid-run using the JWT bearer flow, which
+// re-reads the certificate key file whose path the SF CLI stored at login. For these we must
+// re-authenticate keeping the certificate file available during execution, then delete it.
+// Matched with a substring "contains" check so chained commands are also detected
+// (for example "sf agent publish ... && sf agent activate ...").
+export const COMMANDS_REQUIRING_CERT_KEEP_ALIVE = ['sf agent'];
+
+export function commandNeedsCertKeepAlive(command: string): boolean {
+  return !!command && COMMANDS_REQUIRING_CERT_KEEP_ALIVE.some((pattern) => command.includes(pattern));
+}
 
 export class CommandAction extends ActionsProvider {
   public getLabel(): string {
@@ -21,10 +35,46 @@ export class CommandAction extends ActionsProvider {
     const validity = await this.checkValidityIssues(cmd);
     if (validity) return validity;
     cmd.command = cmd.command + (this.customUsernameToUse ? ` --target-org ${this.customUsernameToUse}` : '');
-    const res = await execCommand(cmd.command, null, { fail: false, output: true });
-    if (res.status === 0) {
-      return { statusCode: 'success', output: (res.stdout || '') + '\n' + (res.stderr || '') };
+
+    // For cert-dependent commands in CI, re-authenticate keeping the JWT certificate file
+    // available during execution, then delete it whatever the command outcome.
+    const keptCertFilePath =
+      isCI && commandNeedsCertKeepAlive(cmd.command) ? await this.reauthKeepingCertFile() : null;
+    try {
+      const res = await execCommand(cmd.command, null, { fail: false, output: true });
+      const output = (res.stdout || '') + '\n' + (res.stderr || '');
+      return { statusCode: res.status === 0 ? 'success' : 'failed', output };
+    } finally {
+      if (keptCertFilePath) {
+        await safeDeleteAuthTempFile(keptCertFilePath);
+        uxLog('other', this, c.grey(`[DeploymentActions] Deleted temporary certificate file ${keptCertFilePath}`));
+      }
     }
-    return { statusCode: 'failed', output: (res.stdout || '') + '\n' + (res.stderr || '') };
+  }
+
+  private async resolveReauthOrgAlias(): Promise<string> {
+    const prInfo = await GitProvider.getPullRequestInfo({ useCache: true });
+    return prInfo?.targetBranch || (await getCurrentGitBranch({ formatted: true })) || '';
+  }
+
+  // Best-effort re-authentication that keeps the certificate file. Returns the kept certificate
+  // file path (even if login threw, so a partially created file is still cleaned up), or null.
+  private async reauthKeepingCertFile(): Promise<string | null> {
+    const authOptions: AuthOrgOptions = { checkAuth: true, keepCertFile: true, setDefault: false };
+    if (this.customUsernameToUse) {
+      authOptions.forceUsername = this.customUsernameToUse;
+    }
+    try {
+      const orgAlias = await this.resolveReauthOrgAlias();
+      uxLog('log', this, c.grey('[DeploymentActions] ' + t('reauthenticatingBeforeCommandAction')));
+      await authOrg(orgAlias, authOptions);
+    } catch (e) {
+      uxLog(
+        'warning',
+        this,
+        c.yellow('[DeploymentActions] ' + t('reauthBeforeCommandActionFailed', { error: (e as Error).message }))
+      );
+    }
+    return authOptions.keptCertFilePath || null;
   }
 }

--- a/src/common/utils/authUtils.ts
+++ b/src/common/utils/authUtils.ts
@@ -32,6 +32,12 @@ export interface AuthOrgOptions {
   setDefault?: boolean;
   forceUsername?: string;
   encryptedCertContent?: string;
+  // When true, do not delete the JWT certificate temp file after login (the caller is
+  // responsible for deleting it later using safeDeleteAuthTempFile). Used by deployment
+  // command actions that refresh their session mid-run (for example "sf agent ...").
+  keepCertFile?: boolean;
+  // Output: when keepCertFile is true, authOrg writes the kept certificate file path here.
+  keptCertFilePath?: string;
   Command?: {
     flags?: Record<string, any>;
     id?: string;
@@ -258,7 +264,13 @@ export async function authOrg(orgAlias: string, options: AuthOrgOptions): Promis
         uxLog("error", this, c.red(`JWT login failed for org ${orgAlias}. Error: ${(e as Error).message}`));
       }
       finally {
-        await safeDeleteAuthTempFile(crtKeyfile);
+        if (options.keepCertFile) {
+          // Keep the certificate file so the caller (for example a deployment command action)
+          // can use it while its command runs, then delete it afterwards.
+          options.keptCertFilePath = crtKeyfile;
+        } else {
+          await safeDeleteAuthTempFile(crtKeyfile);
+        }
       }
     } else if (!isCI && !isAgentMode()) {
       // Login with web auth
@@ -393,7 +405,7 @@ export async function authOrg(orgAlias: string, options: AuthOrgOptions): Promis
   return false;
 }
 
-async function safeDeleteAuthTempFile(filePath?: string | null): Promise<void> {
+export async function safeDeleteAuthTempFile(filePath?: string | null): Promise<void> {
   if (!filePath) {
     return;
   }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -2345,6 +2345,8 @@
   "readmeDocumentationLink": "Automatisch generierte Dokumentation des SFDX-Projekts lesen",
   "readyToRefreshSandboxOrg": "Sie können Ihre Sandbox-Org jetzt aktualisieren. Fahren Sie jetzt mit der Org-Aktualisierung fort.",
   "readyToWorkInBranch": "Bereit zur Arbeit in Branch {{branchName}}",
+  "reauthBeforeCommandActionFailed": "Vor der Befehlsaktion konnte keine erneute Authentifizierung durchgeführt werden. Es wird mit der bestehenden Sitzung fortgefahren: {{error}}",
+  "reauthenticatingBeforeCommandAction": "Erneute Authentifizierung vor der Befehlsaktion, um die Zertifikatsdatei während der Ausführung verfügbar zu halten...",
   "rebuildFullDocDescription": "Wenn ja, wird die gesamte Dokumentation neu generiert (langsamer). Wenn nein, werden nur die beim letzten Backup geänderten Dateien aktualisiert.",
   "recommended": "empfohlen",
   "recommendedToUseMkdocsMaterialToRead": "Es wird empfohlen, mkdocs-material zur korrekten Anzeige zu verwenden (siehe Dokumentation)",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2350,6 +2350,8 @@
   "readmeDocumentationLink": "Read auto-generated documentation of the SFDX project",
   "readyToRefreshSandboxOrg": "You are now ready to refresh your sandbox org. Proceed with the org refresh now.",
   "readyToWorkInBranch": "Ready to work in branch {{branchName}}",
+  "reauthBeforeCommandActionFailed": "Could not re-authenticate before command action, running with the existing session: {{error}}",
+  "reauthenticatingBeforeCommandAction": "Re-authenticating before command action to keep the certificate file available during execution...",
   "rebuildFullDocDescription": "If yes, the whole documentation will be regenerated (slower). If no, only files changed in the last backup will be updated.",
   "recommended": "recommended",
   "recommendedToUseMkdocsMaterialToRead": "It is recommended to use mkdocs-material to read it correctly (see documentation)",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2346,6 +2346,8 @@
   "readmeDocumentationLink": "Leer la documentación autogenerada del proyecto SFDX",
   "readyToRefreshSandboxOrg": "Todo listo para actualizar su Sandbox. Proceda ahora con la actualización de la org.",
   "readyToWorkInBranch": "Listo para trabajar en la branch {{branchName}}",
+  "reauthBeforeCommandActionFailed": "No se ha podido volver a autenticar antes de la acción del comando, se continúa con la sesión existente: {{error}}",
+  "reauthenticatingBeforeCommandAction": "Volviendo a autenticar antes de la acción del comando para mantener el archivo de certificado disponible durante la ejecución...",
   "rebuildFullDocDescription": "Si acepta, se regenerará toda la documentación (más lento). Si no, solo se actualizarán los archivos modificados en el último backup.",
   "recommended": "recomendado",
   "recommendedToUseMkdocsMaterialToRead": "Se recomienda usar mkdocs-material para visualizarlo correctamente (consulte la documentación)",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2346,6 +2346,8 @@
   "readmeDocumentationLink": "Lire la documentation auto-générée du projet SFDX",
   "readyToRefreshSandboxOrg": "Vous êtes prêt à rafraîchir votre org sandbox. Procédez au rafraîchissement de l'org maintenant.",
   "readyToWorkInBranch": "Prêt à travailler dans la branche {{branchName}}",
+  "reauthBeforeCommandActionFailed": "Impossible de se réauthentifier avant l'action de la commande, poursuite avec la session existante : {{error}}",
+  "reauthenticatingBeforeCommandAction": "Réauthentification avant l'action de la commande pour garder le fichier de certificat disponible pendant l'exécution...",
   "rebuildFullDocDescription": "Si oui, toute la documentation sera régénérée (plus lent). Si non, seuls les fichiers modifiés lors du dernier backup seront mis à jour.",
   "recommended": "recommande",
   "recommendedToUseMkdocsMaterialToRead": "Il est recommandé d'utiliser mkdocs-material pour le lire correctement (voir la documentation)",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -2346,6 +2346,8 @@
   "readmeDocumentationLink": "Leggi la documentazione generata automaticamente del progetto SFDX",
   "readyToRefreshSandboxOrg": "Sei ora pronto per aggiornare la tua sandbox org. Procedi ora con l'aggiornamento della org.",
   "readyToWorkInBranch": "Pronto per lavorare nel branch {{branchName}}",
+  "reauthBeforeCommandActionFailed": "Impossibile ri-autenticarsi prima dell'azione del comando, si continua con la sessione esistente: {{error}}",
+  "reauthenticatingBeforeCommandAction": "Ri-autenticazione prima dell'azione del comando per mantenere il file certificato disponibile durante l'esecuzione...",
   "rebuildFullDocDescription": "Se sì, tutta la documentazione verrà rigenerata (più lento). Se no, verranno aggiornati solo i file modificati nell'ultimo backup.",
   "recommended": "consigliato",
   "recommendedToUseMkdocsMaterialToRead": "Si consiglia di utilizzare mkdocs-material per leggerla correttamente (vedi documentazione)",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -2344,6 +2344,8 @@
   "readmeDocumentationLink": "SFDXプロジェクトの自動生成ドキュメントを読む",
   "readyToRefreshSandboxOrg": "Sandbox組織をリフレッシュする準備ができました。今すぐ組織のリフレッシュを実行してください。",
   "readyToWorkInBranch": "branch {{branchName}} で作業する準備ができました",
+  "reauthBeforeCommandActionFailed": "コマンドアクションの前に再認証できませんでした。既存のセッションで実行を続けます: {{error}}",
+  "reauthenticatingBeforeCommandAction": "実行中に証明書ファイルを利用可能な状態に保つため、コマンドアクションの前に再認証しています...",
   "rebuildFullDocDescription": "はいの場合、すべてのドキュメントが再生成されます（時間がかかります）。いいえの場合、前回のバックアップで変更されたファイルのみが更新されます。",
   "recommended": "推奨",
   "recommendedToUseMkdocsMaterialToRead": "正しく表示するにはmkdocs-materialの使用を推奨します（ドキュメントを参照）",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -2346,6 +2346,8 @@
   "readmeDocumentationLink": "Lees de automatisch gegenereerde documentatie van het SFDX-project",
   "readyToRefreshSandboxOrg": "Je bent nu klaar om je sandbox-org te vernieuwen. Ga nu verder met het vernieuwen van de org.",
   "readyToWorkInBranch": "Klaar om te werken in branch {{branchName}}",
+  "reauthBeforeCommandActionFailed": "Kon niet opnieuw authenticeren voor de command action, wordt uitgevoerd met de bestaande sessie: {{error}}",
+  "reauthenticatingBeforeCommandAction": "Opnieuw authenticeren voor de command action om het certificaatbestand beschikbaar te houden tijdens de uitvoering...",
   "rebuildFullDocDescription": "Als ja, wordt alle documentatie opnieuw gegenereerd (langzamer). Als nee, worden alleen de bestanden bijgewerkt die zijn gewijzigd in de laatste backup.",
   "recommended": "aanbevolen",
   "recommendedToUseMkdocsMaterialToRead": "Het wordt aanbevolen om mkdocs-material te gebruiken om het correct te lezen (zie documentatie)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -2346,6 +2346,8 @@
   "readmeDocumentationLink": "Przeczytaj automatycznie wygenerowaną dokumentację projektu SFDX",
   "readyToRefreshSandboxOrg": "Jesteś teraz gotowy do odświeżenia swojego sandbox org. Przejdź do odświeżenia org teraz.",
   "readyToWorkInBranch": "Gotowy do pracy w gałęzi {{branchName}}",
+  "reauthBeforeCommandActionFailed": "Nie udało się ponownie uwierzytelnić przed command action, kontynuowanie z istniejącą sesją: {{error}}",
+  "reauthenticatingBeforeCommandAction": "Ponowne uwierzytelnianie przed command action, aby plik certyfikatu pozostał dostępny podczas wykonywania...",
   "rebuildFullDocDescription": "Jeśli tak, cała dokumentacja zostanie wygenerowana od nowa (wolniej). Jeśli nie, zaktualizowane zostaną tylko pliki zmienione podczas ostatniego backupu.",
   "recommended": "zalecane",
   "recommendedToUseMkdocsMaterialToRead": "Zaleca się użycie mkdocs-material do poprawnego odczytu (patrz dokumentacja)",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -2314,6 +2314,8 @@
   "readmeDocumentationLink": "Leia a documentação gerada automaticamente do projeto SFDX",
   "readyToRefreshSandboxOrg": "Você está pronto para atualizar sua org sandbox. Prossiga com a atualização da org agora.",
   "readyToWorkInBranch": "Pronto para trabalhar na branch {{branchName}}",
+  "reauthBeforeCommandActionFailed": "Não foi possível reautenticar antes da command action, continuando com a sessão existente: {{error}}",
+  "reauthenticatingBeforeCommandAction": "Reautenticando antes da command action para manter o arquivo de certificado disponível durante a execução...",
   "recommended": "recomendado",
   "recommendedToUseMkdocsMaterialToRead": "Recomenda-se usar mkdocs-material para lê-la corretamente (consulte a documentação)",
   "reconnectingToOrg": "Reconectando a org {{org}}...",

--- a/test/common/actionsProvider/commandAction.test.ts
+++ b/test/common/actionsProvider/commandAction.test.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { commandNeedsCertKeepAlive } from '../../../src/common/actionsProvider/commandAction.js';
+
+describe('commandNeedsCertKeepAlive', () => {
+  it('matches a simple sf agent command', () => {
+    expect(commandNeedsCertKeepAlive('sf agent publish authoring-bundle --api-name Referral_Assistant')).to.equal(true);
+  });
+
+  it('matches chained sf agent commands', () => {
+    expect(
+      commandNeedsCertKeepAlive('sf agent publish authoring-bundle --api-name X && sf agent activate --api-name X')
+    ).to.equal(true);
+  });
+
+  it('matches when sf agent appears mid-string', () => {
+    expect(commandNeedsCertKeepAlive('echo start && sf agent activate --api-name X')).to.equal(true);
+  });
+
+  it('does not match unrelated commands', () => {
+    expect(commandNeedsCertKeepAlive('sf project deploy start')).to.equal(false);
+  });
+
+  it('does not match an empty command', () => {
+    expect(commandNeedsCertKeepAlive('')).to.equal(false);
+  });
+});


### PR DESCRIPTION
Salesforce CLI commands like `sf agent publish` can refresh their session
mid-run. In CI environments using JWT authentication, the temporary
certificate key file required for these operations was being deleted
immediately after initial authentication, causing subsequent session
refreshes within the command to fail.

This change identifies commands requiring persistent certificate access
(currently 'sf agent' commands) and, when detected in a CI environment:
- Re-authenticates to the target org.
- Explicitly keeps the JWT certificate file available for the duration
  of the command's execution.
- Ensures the certificate file is safely deleted after the command
  completes, regardless of its outcome.
```
