### PR TITLE
fix: Ensure correct default org setting during re-authentication

### DIFF
--- a/src/common/actionsProvider/commandAction.ts
+++ b/src/common/actionsProvider/commandAction.ts
@@ -60,9 +60,16 @@ export class CommandAction extends ActionsProvider {
   // Best-effort re-authentication that keeps the certificate file. Returns the kept certificate
   // file path (even if login threw, so a partially created file is still cleaned up), or null.
   private async reauthKeepingCertFile(): Promise<string | null> {
-    const authOptions: AuthOrgOptions = { checkAuth: true, keepCertFile: true, setDefault: false };
+    const authOptions: AuthOrgOptions = { checkAuth: true, keepCertFile: true };
     if (this.customUsernameToUse) {
+      // The command already targets this user via an explicit --target-org, so keep the
+      // existing default org untouched.
       authOptions.forceUsername = this.customUsernameToUse;
+      authOptions.setDefault = false;
+    } else {
+      // No explicit target org on the command: re-authenticate as the default org so the
+      // command (for example "sf agent ...") finds it.
+      authOptions.setDefault = true;
     }
     try {
       const orgAlias = await this.resolveReauthOrgAlias();


### PR DESCRIPTION
Previously, the `setDefault` option was hardcoded to `false` during
re-authentication, regardless of the command's context.

This could lead to issues where:
- Commands *without* an explicit target org (e.g., `sf agent publish`)
  would re-authenticate but fail to set the re-authenticated org as the
  default, causing subsequent calls expecting a default to fail.
- Commands *with* an explicit target org (via `--target-org`) would
  undesirably change the global default org after re-authentication.

This change introduces conditional logic to `setDefault`:
- If an explicit `customUsernameToUse` is present, `setDefault` remains
  `false` to avoid altering the existing default org.
- Otherwise, `setDefault` is set to `true` to establish the re-
  authenticated org as the new default, aligning with expectations
  for commands that operate on the default.
