### PR TITLE
fix: Flow git diff not working when project does not use force-app package directory

### DIFF
--- a/src/common/gitProvider/utilsMarkdown.ts
+++ b/src/common/gitProvider/utilsMarkdown.ts
@@ -111,6 +111,10 @@ export async function flowDiffToMarkdownForPullRequest(flowNames: string[], from
   for (const flowName of flowNames) {
     flowDiffFilesSummary += `- [${flowName}](#${flowName})\n`;
     const fileMetadata = await MetadataUtils.findMetaFileFromTypeAndName("Flow", flowName);
+    if (fileMetadata == null) {
+      uxLog("warning", this, c.yellow('[FlowGitDiff] ' + t('flowGitDiffFlowFileNotFound', { flowName })));
+      continue;
+    }
     try {
       // Markdown with pure MermaidJS
       if (supportsMermaidInPrMarkdown) {

--- a/src/common/metadata-utils/index.ts
+++ b/src/common/metadata-utils/index.ts
@@ -20,7 +20,7 @@ import { PACKAGE_ROOT_DIR } from '../../settings.js';
 import { getCache, setCache } from '../cache/index.js';
 import { buildOrgManifest } from '../utils/deployUtils.js';
 import { listMajorOrgs } from '../utils/orgConfigUtils.js';
-import { GLOB_IGNORE_PATTERNS, METADATA_DOC_GLOB_IGNORE_PATTERNS, isSfdxProject } from '../utils/projectUtils.js';
+import { GLOB_IGNORE_PATTERNS, METADATA_DOC_GLOB_IGNORE_PATTERNS, getSfdxProjectPackageDirectories, isSfdxProject } from '../utils/projectUtils.js';
 import { prompts } from '../utils/prompts.js';
 import { parsePackageXmlFile } from '../utils/xmlUtils.js';
 import { listMetadataTypes } from './metadataList.js';
@@ -454,14 +454,9 @@ Issue tracking: https://github.com/forcedotcom/cli/issues/2426`)
   }
 
   public static async findMetaFileFromTypeAndName(packageXmlType: string, packageXmlName: string, packageDirectories: any[] = []) {
-    // Handle default package directory if not provided as input
+    // Handle package directories declared in sfdx-project.json if not provided as input
     if (packageDirectories.length === 0) {
-      packageDirectories = [
-        {
-          fullPath: path.join(process.cwd(), "force-app"),
-          path: "force-app"
-        }
-      ]
+      packageDirectories = await getSfdxProjectPackageDirectories();
     }
     // Find metadata type from packageXmlName
     const metadataList = listMetadataTypes();

--- a/src/common/utils/projectUtils.ts
+++ b/src/common/utils/projectUtils.ts
@@ -27,6 +27,30 @@ export function isSfdxProject(cwd = process.cwd()) {
   return fs.existsSync(path.join(cwd, 'sfdx-project.json'));
 }
 
+// List package directories declared in sfdx-project.json, with fallback to default force-app
+export async function getSfdxProjectPackageDirectories(cwd = process.cwd()): Promise<{ path: string; fullPath: string }[]> {
+  const defaultPackageDirectories = [{ path: 'force-app', fullPath: path.join(cwd, 'force-app') }];
+  const sfdxProjectFile = path.join(cwd, 'sfdx-project.json');
+  if (!(await fs.pathExists(sfdxProjectFile))) {
+    return defaultPackageDirectories;
+  }
+  try {
+    const sfdxProject = await fs.readJson(sfdxProjectFile);
+    const packageDirectories = (sfdxProject?.packageDirectories || [])
+      .filter((packageDirectory) => packageDirectory?.path)
+      .map((packageDirectory) => ({
+        path: packageDirectory.path,
+        fullPath: path.join(cwd, packageDirectory.path),
+      }));
+    if (packageDirectories.length > 0) {
+      return packageDirectories;
+    }
+  } catch (e: any) {
+    uxLog("warning", this, c.yellow(t('warningUnableToReadPackageDirectoriesFrom', { error: e.message })));
+  }
+  return defaultPackageDirectories;
+}
+
 export async function createBlankSfdxProject(cwd = process.cwd(), debug = false) {
   uxLog("log", this, c.cyan(t('creatingBlankSfdxProject')));
   const projectCreateCommand = 'sf project generate --name "sfdx-hardis-blank-project"';

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1388,6 +1388,7 @@
   "flowDocAfter": "FLOW DOC AFTER:\n",
   "flowDocBefore": "FLOW DOC BEFORE:\n",
   "flowErrorsFound": "{{count}} Flow-Fehler in den letzten {{days}} Tag(en) gefunden.",
+  "flowGitDiffFlowFileNotFound": "Flow-Datei für {{flowName}} wurde in den Paketverzeichnissen nicht gefunden: Flow-Diff wird nicht generiert",
   "flowGitDiffUnableToGenerate": "Flow-Diff für {{flowName}} konnte nicht generiert werden: {{message}}",
   "flowVersionsDeletionResultsReportTitle": "Ergebnisse der Flow-Versionen-Löschung",
   "flowVersionsToDeleteReportTitle": "Zu löschende Flow-Versionen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1393,6 +1393,7 @@
   "flowDocAfter": "FLOW DOC AFTER:\n",
   "flowDocBefore": "FLOW DOC BEFORE:\n",
   "flowErrorsFound": "{{count}} Flow error(s) found in the last {{days}} day(s).",
+  "flowGitDiffFlowFileNotFound": "Unable to find Flow file for {{flowName}} in package directories: Flow diff will not be generated",
   "flowGitDiffUnableToGenerate": "Unable to generate Flow diff for {{flowName}}: {{message}}",
   "flowVersionsDeletionResultsReportTitle": "Flow Versions Deletion Results",
   "flowVersionsToDeleteReportTitle": "Flow Versions to Delete",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1389,6 +1389,7 @@
   "flowDocAfter": "DOC DE FLOW DESPUÉS:\n",
   "flowDocBefore": "DOC DE FLOW ANTES:\n",
   "flowErrorsFound": "Se encontraron {{count}} error(es) de Flow en los últimos {{days}} día(s).",
+  "flowGitDiffFlowFileNotFound": "No se encuentra el archivo del Flow {{flowName}} en los directorios de packages: no se generará el diff del Flow",
   "flowGitDiffUnableToGenerate": "No se puede generar el diff del Flow para {{flowName}}: {{message}}",
   "flowVersionsDeletionResultsReportTitle": "Resultados de eliminación de versiones de Flow",
   "flowVersionsToDeleteReportTitle": "Versiones de Flow a eliminar",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1389,6 +1389,7 @@
   "flowDocAfter": "DOC FLUX APRÈS :\n",
   "flowDocBefore": "DOC FLUX AVANT :\n",
   "flowErrorsFound": "{{count}} erreur(s) de Flux trouvée(s) sur les {{days}} dernier(s) jour(s).",
+  "flowGitDiffFlowFileNotFound": "Impossible de trouver le fichier du Flux {{flowName}} dans les répertoires de packages : le diff de Flux ne sera pas généré",
   "flowGitDiffUnableToGenerate": "Impossible de générer le diff de Flux pour {{flowName}} : {{message}}",
   "flowVersionsDeletionResultsReportTitle": "Résultats de la suppression des versions de Flow",
   "flowVersionsToDeleteReportTitle": "Versions de Flow à supprimer",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1389,6 +1389,7 @@
   "flowDocAfter": "FLOW DOC DOPO:\n",
   "flowDocBefore": "FLOW DOC PRIMA:\n",
   "flowErrorsFound": "{{count}} errore/i nel Flow trovato/i negli ultimi {{days}} giorno/i.",
+  "flowGitDiffFlowFileNotFound": "Impossibile trovare il file del Flow {{flowName}} nelle directory dei package: il diff del Flow non sarà generato",
   "flowGitDiffUnableToGenerate": "Impossibile generare il diff del Flow per {{flowName}}: {{message}}",
   "flowVersionsDeletionResultsReportTitle": "Risultati eliminazione versioni Flow",
   "flowVersionsToDeleteReportTitle": "Versioni Flow da eliminare",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -1387,6 +1387,7 @@
   "flowDocAfter": "フロードキュメント（変更後）:\n",
   "flowDocBefore": "フロードキュメント（変更前）:\n",
   "flowErrorsFound": "過去 {{days}} 日間にフロー エラーが {{count}} 件見つかりました。",
+  "flowGitDiffFlowFileNotFound": "パッケージディレクトリ内にフロー{{flowName}}のファイルが見つかりません: フロー差分は生成されません",
   "flowGitDiffUnableToGenerate": "フロー{{flowName}}の差分を生成できません: {{message}}",
   "flowVersionsDeletionResultsReportTitle": "フローバージョン削除結果",
   "flowVersionsToDeleteReportTitle": "削除するフローバージョン",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -1389,6 +1389,7 @@
   "flowDocAfter": "FLOW DOC NA:\n",
   "flowDocBefore": "FLOW DOC VOOR:\n",
   "flowErrorsFound": "{{count}} Flow-fout(en) gevonden in de laatste {{days}} dag(en).",
+  "flowGitDiffFlowFileNotFound": "Flow-bestand voor {{flowName}} niet gevonden in de pakketmappen: Flow-diff wordt niet gegenereerd",
   "flowGitDiffUnableToGenerate": "Kan geen Flow-diff genereren voor {{flowName}}: {{message}}",
   "flowVersionsDeletionResultsReportTitle": "Resultaten van verwijdering van Flow-versies",
   "flowVersionsToDeleteReportTitle": "Te verwijderen Flow-versies",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1389,6 +1389,7 @@
   "flowDocAfter": "DOKUMENTACJA FLOW PO:\n",
   "flowDocBefore": "DOKUMENTACJA FLOW PRZED:\n",
   "flowErrorsFound": "Znaleziono {{count}} błąd(y) Flow w ciągu ostatnich {{days}} dnia/dni.",
+  "flowGitDiffFlowFileNotFound": "Nie znaleziono pliku Flow {{flowName}} w katalogach pakietów: różnica Flow nie zostanie wygenerowana",
   "flowGitDiffUnableToGenerate": "Nie można wygenerować różnicy Flow dla {{flowName}}: {{message}}",
   "flowVersionsDeletionResultsReportTitle": "Wyniki usuwania wersji Flow",
   "flowVersionsToDeleteReportTitle": "Wersje Flow do usunięcia",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -1365,6 +1365,7 @@
   "flowDocAfter": "DOC DO FLUXO DEPOIS:\n",
   "flowDocBefore": "DOC DO FLUXO ANTES:\n",
   "flowErrorsFound": "{{count}} erro(s) de Fluxo encontrado(s) nos últimos {{days}} dia(s).",
+  "flowGitDiffFlowFileNotFound": "Não foi possível encontrar o arquivo do Fluxo {{flowName}} nos diretórios de pacote: o diff de Fluxo não será gerado",
   "flowGitDiffUnableToGenerate": "Não foi possível gerar o diff de Fluxo para {{flowName}}: {{message}}",
   "flowVersionsDeletionResultsReportTitle": "Resultados da Exclusão de Versões de Fluxo",
   "flowVersionsToDeleteReportTitle": "Versões de Fluxo a Excluir",

--- a/test/common/utils/projectUtils.test.ts
+++ b/test/common/utils/projectUtils.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { listApexFiles, listFlowFiles, listPageFiles } from '../../../src/common/utils/projectUtils.js';
+import { getSfdxProjectPackageDirectories, listApexFiles, listFlowFiles, listPageFiles } from '../../../src/common/utils/projectUtils.js';
 
 describe('projectUtils', () => {
   let tmpDir: string;
@@ -14,6 +14,35 @@ describe('projectUtils', () => {
 
   afterEach(async () => {
     await fs.remove(tmpDir);
+  });
+
+  describe('getSfdxProjectPackageDirectories()', () => {
+    it('returns package directories declared in sfdx-project.json', async () => {
+      await fs.writeJson(path.join(tmpDir, 'sfdx-project.json'), {
+        packageDirectories: [{ path: 'src-dx', default: true }, { path: 'src-extra' }],
+      });
+
+      const packageDirectories = await getSfdxProjectPackageDirectories(tmpDir);
+
+      expect(packageDirectories).to.deep.equal([
+        { path: 'src-dx', fullPath: path.join(tmpDir, 'src-dx') },
+        { path: 'src-extra', fullPath: path.join(tmpDir, 'src-extra') },
+      ]);
+    });
+
+    it('falls back to force-app when sfdx-project.json is missing', async () => {
+      const packageDirectories = await getSfdxProjectPackageDirectories(tmpDir);
+
+      expect(packageDirectories).to.deep.equal([{ path: 'force-app', fullPath: path.join(tmpDir, 'force-app') }]);
+    });
+
+    it('falls back to force-app when sfdx-project.json has no package directories', async () => {
+      await fs.writeJson(path.join(tmpDir, 'sfdx-project.json'), { name: 'empty-project' });
+
+      const packageDirectories = await getSfdxProjectPackageDirectories(tmpDir);
+
+      expect(packageDirectories).to.deep.equal([{ path: 'force-app', fullPath: path.join(tmpDir, 'force-app') }]);
+    });
   });
 
   describe('listFlowFiles()', () => {


### PR DESCRIPTION
`MetadataUtils.findMetaFileFromTypeAndName` looks for metadata files only in a hardcoded `force-app` folder. On projects using custom package directories (e.g. `src-dx`), the Flow file lookup always returns null and the PR flow diff crashes with:

```
[FlowGitDiff] Unable to generate Flow diff for X: The "path" argument must be of type string. Received null
```

Changes:
- read `packageDirectories` from `sfdx-project.json` (fallback to `force-app` when missing/empty)
- skip the flow diff with a warning when the flow file cannot be found, instead of throwing on a null path
- new i18n key in all locales + unit tests

Tested on a real GitLab CI project with a `src-dx` package directory - the MR now gets the mermaid flow diff comment. Projects using `force-app` behave exactly as before.