### PR TITLE
feat: add metadataRetrieverPresets config schema properties

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -379,6 +379,7 @@
     "accordionlangchain",
     "accordionopenai",
     "accordionmerge",
+    "accordionmetadata",
     "accordionmonitoring",
     "accordionms",
     "accordionnew",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New [hardis:org:diagnose:unsecure-permissions](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/unsecure-permissions/): Audit dangerous permissions (Modify All Data, Author Apex, Manage Users, View All Data) granted through Profiles, Permission Sets, and Permission Set Groups, and report which active users hold them.
 - [hardis:org:diagnose:unsecure-permissions](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/unsecure-permissions/) is now listed in the sfdx-hardis monitoring commands UI so you can launch it from there (off by default).
+- Add `metadataRetrieverPresets` and `metadataRetrieverPresetsOverrideDefaults` to the config schema so the VS Code Metadata Retriever presets are validated and autocompleted in `.sfdx-hardis.yml`.
 
 ## [7.21.0] 2026-07-17
 

--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -1985,6 +1985,73 @@
       "title": "Merge target branches",
       "type": "array"
     },
+    "metadataRetrieverPresets": {
+      "$id": "#/properties/metadataRetrieverPresets",
+      "description": "Named groups of Metadata API types used by the Metadata Retriever panel of the VS Code extension to retrieve several metadata types at once instead of one at a time.\nEach preset needs an id, a label and a list of Metadata API types (xmlName). A user preset that declares the same id as a built-in one replaces it.",
+      "examples": [
+        [
+          {
+            "id": "developerMetadata",
+            "label": "Developer Metadata",
+            "description": "Apex, Flows, LWCs and other code metadata",
+            "types": [
+              "ApexClass",
+              "ApexTrigger",
+              "Flow",
+              "LightningComponentBundle"
+            ]
+          }
+        ]
+      ],
+      "items": {
+        "$id": "#/properties/metadataRetrieverPresets/items",
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A Metadata Retriever preset: a named group of Metadata API types.",
+        "required": [
+          "label",
+          "types"
+        ],
+        "properties": {
+          "id": {
+            "$id": "#/properties/metadataRetrieverPresets/items/properties/id",
+            "description": "Unique identifier of the preset. Use the id of a built-in preset to override it. Defaults to the label when omitted.",
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "$id": "#/properties/metadataRetrieverPresets/items/properties/label",
+            "description": "Display label shown in the preset dropdown.",
+            "title": "Label",
+            "type": "string"
+          },
+          "description": {
+            "$id": "#/properties/metadataRetrieverPresets/items/properties/description",
+            "description": "Optional description shown as a tooltip.",
+            "title": "Description",
+            "type": "string"
+          },
+          "types": {
+            "$id": "#/properties/metadataRetrieverPresets/items/properties/types",
+            "description": "List of Metadata API types (xmlName) included in the preset, for example ApexClass, Flow, CustomObject. Unknown types are ignored.",
+            "title": "Metadata types",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "title": "Metadata Retriever presets",
+      "type": "array"
+    },
+    "metadataRetrieverPresetsOverrideDefaults": {
+      "$id": "#/properties/metadataRetrieverPresetsOverrideDefaults",
+      "description": "Set to true to hide the built-in Metadata Retriever presets shipped with the VS Code extension, so only the presets defined in metadataRetrieverPresets are shown.",
+      "title": "Override default Metadata Retriever presets",
+      "type": "boolean",
+      "default": false
+    },
     "monitoringBackupSkipDataCloud": {
       "$id": "#/properties/monitoringBackupSkipDataCloud",
       "description": "Set to true to skip the backup of Data Cloud objects (__dlm and __dll CustomObjects) during hardis:org:monitor:backup. Can also be set via MONITORING_BACKUP_SKIP_DATA_CLOUD env variable.",

--- a/docs/schema/sfdx-hardis-json-schema-parameters.html
+++ b/docs/schema/sfdx-hardis-json-schema-parameters.html
@@ -8012,6 +8012,354 @@ Example: availableTargetBranches: [preprod, integration] and availableTargetBran
         </div>
     </div>
 </div>
+<div class="accordion" id="accordionmetadataRetrieverPresets">
+    <div class="card">
+        <div class="card-header" id="headingmetadataRetrieverPresets">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#metadataRetrieverPresets"
+                        aria-expanded="" aria-controls="metadataRetrieverPresets" onclick="setAnchor('#metadataRetrieverPresets')"><span class="property-name">metadataRetrieverPresets</span></button>
+            </h2>
+        </div>
+
+        <div id="metadataRetrieverPresets"
+             class="collapse property-definition-div" aria-labelledby="headingmetadataRetrieverPresets"
+             data-parent="#accordionmetadataRetrieverPresets">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets" onclick="anchorLink('metadataRetrieverPresets')">metadataRetrieverPresets</a></div><h4>Metadata Retriever presets</h4><span class="badge badge-dark value-type">Type: array of object</span><br/>
+<span class="description"><p>Named groups of Metadata API types used by the Metadata Retriever panel of the VS Code extension to retrieve several metadata types at once instead of one at a time.<br />
+Each preset needs an id, a label and a list of Metadata API types (xmlName). A user preset that declares the same id as a built-in one replaces it.</p>
+</span>
+        
+
+        
+        
+
+         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="metadataRetrieverPresets_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets" onclick="anchorLink('metadataRetrieverPresets')">metadataRetrieverPresets</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items" onclick="anchorLink('metadataRetrieverPresets_items')">metadataRetrieverPresets items</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>A Metadata Retriever preset: a named group of Metadata API types.</p>
+</span> <span class="badge badge-info no-additional">No Additional Properties</span>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionmetadataRetrieverPresets_items_id">
+    <div class="card">
+        <div class="card-header" id="headingmetadataRetrieverPresets_items_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#metadataRetrieverPresets_items_id"
+                        aria-expanded="" aria-controls="metadataRetrieverPresets_items_id" onclick="setAnchor('#metadataRetrieverPresets_items_id')"><span class="property-name">id</span></button>
+            </h2>
+        </div>
+
+        <div id="metadataRetrieverPresets_items_id"
+             class="collapse property-definition-div" aria-labelledby="headingmetadataRetrieverPresets_items_id"
+             data-parent="#accordionmetadataRetrieverPresets_items_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets" onclick="anchorLink('metadataRetrieverPresets')">metadataRetrieverPresets</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items" onclick="anchorLink('metadataRetrieverPresets_items')">metadataRetrieverPresets items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items_id" onclick="anchorLink('metadataRetrieverPresets_items_id')">id</a></div><h4>Id</h4><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>Unique identifier of the preset. Use the id of a built-in preset to override it. Defaults to the label when omitted.</p>
+</span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionmetadataRetrieverPresets_items_label">
+    <div class="card">
+        <div class="card-header" id="headingmetadataRetrieverPresets_items_label">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#metadataRetrieverPresets_items_label"
+                        aria-expanded="" aria-controls="metadataRetrieverPresets_items_label" onclick="setAnchor('#metadataRetrieverPresets_items_label')"><span class="property-name">label</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="metadataRetrieverPresets_items_label"
+             class="collapse property-definition-div" aria-labelledby="headingmetadataRetrieverPresets_items_label"
+             data-parent="#accordionmetadataRetrieverPresets_items_label">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets" onclick="anchorLink('metadataRetrieverPresets')">metadataRetrieverPresets</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items" onclick="anchorLink('metadataRetrieverPresets_items')">metadataRetrieverPresets items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items_label" onclick="anchorLink('metadataRetrieverPresets_items_label')">label</a></div><h4>Label</h4><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>Display label shown in the preset dropdown.</p>
+</span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionmetadataRetrieverPresets_items_description">
+    <div class="card">
+        <div class="card-header" id="headingmetadataRetrieverPresets_items_description">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#metadataRetrieverPresets_items_description"
+                        aria-expanded="" aria-controls="metadataRetrieverPresets_items_description" onclick="setAnchor('#metadataRetrieverPresets_items_description')"><span class="property-name">description</span></button>
+            </h2>
+        </div>
+
+        <div id="metadataRetrieverPresets_items_description"
+             class="collapse property-definition-div" aria-labelledby="headingmetadataRetrieverPresets_items_description"
+             data-parent="#accordionmetadataRetrieverPresets_items_description">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets" onclick="anchorLink('metadataRetrieverPresets')">metadataRetrieverPresets</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items" onclick="anchorLink('metadataRetrieverPresets_items')">metadataRetrieverPresets items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items_description" onclick="anchorLink('metadataRetrieverPresets_items_description')">description</a></div><h4>Description</h4><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>Optional description shown as a tooltip.</p>
+</span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionmetadataRetrieverPresets_items_types">
+    <div class="card">
+        <div class="card-header" id="headingmetadataRetrieverPresets_items_types">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#metadataRetrieverPresets_items_types"
+                        aria-expanded="" aria-controls="metadataRetrieverPresets_items_types" onclick="setAnchor('#metadataRetrieverPresets_items_types')"><span class="property-name">types</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="metadataRetrieverPresets_items_types"
+             class="collapse property-definition-div" aria-labelledby="headingmetadataRetrieverPresets_items_types"
+             data-parent="#accordionmetadataRetrieverPresets_items_types">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets" onclick="anchorLink('metadataRetrieverPresets')">metadataRetrieverPresets</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items" onclick="anchorLink('metadataRetrieverPresets_items')">metadataRetrieverPresets items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items_types" onclick="anchorLink('metadataRetrieverPresets_items_types')">types</a></div><h4>Metadata types</h4><span class="badge badge-dark value-type">Type: array of string</span><br/>
+<span class="description"><p>List of Metadata API types (xmlName) included in the preset, for example ApexClass, Flow, CustomObject. Unknown types are ignored.</p>
+</span>
+        
+
+        
+        
+
+         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="metadataRetrieverPresets_items_types_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets" onclick="anchorLink('metadataRetrieverPresets')">metadataRetrieverPresets</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items" onclick="anchorLink('metadataRetrieverPresets_items')">metadataRetrieverPresets items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items_types" onclick="anchorLink('metadataRetrieverPresets_items_types')">types</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresets_items_types_items" onclick="anchorLink('metadataRetrieverPresets_items_types_items')">types items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        
+
+        
+        </div>
+    </div>
+            </div>
+        </div>
+    </div>
+</div>
+        </div>
+    </div><br/>
+<div class="badge badge-secondary">Example:</div>
+<br/><button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#metadataRetrieverPresets_ex1" aria-controls="metadataRetrieverPresets_ex1"></button><div id="metadataRetrieverPresets_ex1" class="collapse jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span>
+<span class="w">    </span><span class="p">{</span>
+<span class="w">        </span><span class="s2">&quot;id&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;developerMetadata&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;label&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;Developer Metadata&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;description&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;Apex, Flows, LWCs and other code metadata&quot;</span><span class="p">,</span>
+<span class="w">        </span><span class="s2">&quot;types&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">            </span><span class="s2">&quot;ApexClass&quot;</span><span class="p">,</span>
+<span class="w">            </span><span class="s2">&quot;ApexTrigger&quot;</span><span class="p">,</span>
+<span class="w">            </span><span class="s2">&quot;Flow&quot;</span><span class="p">,</span>
+<span class="w">            </span><span class="s2">&quot;LightningComponentBundle&quot;</span>
+<span class="w">        </span><span class="p">]</span>
+<span class="w">    </span><span class="p">}</span>
+<span class="p">]</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionmetadataRetrieverPresetsOverrideDefaults">
+    <div class="card">
+        <div class="card-header" id="headingmetadataRetrieverPresetsOverrideDefaults">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#metadataRetrieverPresetsOverrideDefaults"
+                        aria-expanded="" aria-controls="metadataRetrieverPresetsOverrideDefaults" onclick="setAnchor('#metadataRetrieverPresetsOverrideDefaults')"><span class="property-name">metadataRetrieverPresetsOverrideDefaults</span></button>
+            </h2>
+        </div>
+
+        <div id="metadataRetrieverPresetsOverrideDefaults"
+             class="collapse property-definition-div" aria-labelledby="headingmetadataRetrieverPresetsOverrideDefaults"
+             data-parent="#accordionmetadataRetrieverPresetsOverrideDefaults">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#metadataRetrieverPresetsOverrideDefaults" onclick="anchorLink('metadataRetrieverPresetsOverrideDefaults')">metadataRetrieverPresetsOverrideDefaults</a></div><h4>Override default Metadata Retriever presets</h4><span class="badge badge-dark value-type">Type: boolean</span> <span class="badge badge-success default-value">Default: false</span><br/>
+<span class="description"><p>Set to true to hide the built-in Metadata Retriever presets shipped with the VS Code extension, so only the presets defined in metadataRetrieverPresets are shown.</p>
+</span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
 <div class="accordion" id="accordionmonitoringBackupSkipDataCloud">
     <div class="card">
         <div class="card-header" id="headingmonitoringBackupSkipDataCloud">


### PR DESCRIPTION
## What

Adds two properties to `config/sfdx-hardis.jsonschema.json`:

- **`metadataRetrieverPresets`** - array of named groups of Metadata API types. Each preset has an `id` (optional), `label` (required), `description` (optional), and `types` (required list of Metadata API xmlNames).
- **`metadataRetrieverPresetsOverrideDefaults`** - boolean (default `false`) to hide the built-in presets.

## Why

The new Metadata Retriever presets feature in vscode-sfdx-hardis writes these keys to `.sfdx-hardis.yml`. Adding them to the config schema gives users validation and autocompletion when editing the file, and keeps the CLI schema in sync with what the extension writes.

Keys and shape mirror `vscode-sfdx-hardis/src/utils/metadataPresets.ts` (`METADATA_PRESETS_CONFIG_KEY` / `METADATA_PRESETS_OVERRIDE_KEY` and the `MetadataPreset` interface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)