### PR TITLE
ci: disable Docker Hub publication until OIDC is available

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -389,6 +389,7 @@
     "accordiondoc",
     "accordionenable",
     "accordionextends",
+    "accordionflow",
     "accordiongeneric",
     "accordioninit",
     "dotenv",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,12 +40,11 @@ jobs:
 
   push_alpha_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Docker image to Docker Hub
+    name: Push alpha Docker image to GitHub Container Registry
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -54,11 +53,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -77,7 +71,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis:alpha
             ghcr.io/hardisgroupcom/sfdx-hardis:alpha
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -89,12 +82,11 @@ jobs:
 
   push_alpha_to_registry_sfdx_recommended:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Docker image to Docker Hub (with @salesforce/cli version recommended by hardis)
+    name: Push alpha Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -103,11 +95,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -126,7 +113,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis:alpha-sfdx-recommended
             ghcr.io/hardisgroupcom/sfdx-hardis:alpha-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -138,12 +124,11 @@ jobs:
 
   push_alpha_ubuntu_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Ubuntu Docker image to Docker Hub
+    name: Push alpha Ubuntu Docker image to GitHub Container Registry
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -152,11 +137,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -175,7 +155,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -187,12 +166,11 @@ jobs:
 
   push_alpha_ubuntu_to_registry_sfdx_recommended:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Ubuntu Docker image to Docker Hub (with @salesforce/cli version recommended by hardis)
+    name: Push alpha Ubuntu Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -201,11 +179,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -224,7 +197,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha-sfdx-recommended
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -236,12 +208,11 @@ jobs:
 
   push_alpha_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Docker image with agents to Docker Hub
+    name: Push alpha Docker image with agents to GitHub Container Registry
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -250,11 +221,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -274,17 +240,15 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-with-agents:alpha
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:alpha
 
   push_alpha_ubuntu_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Ubuntu Docker image with agents to Docker Hub
+    name: Push alpha Ubuntu Docker image with agents to GitHub Container Registry
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -293,11 +257,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -317,7 +276,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:alpha
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:alpha
 
   deploy_canary:
@@ -347,12 +305,11 @@ jobs:
 
   push_canary_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
-    name: Push canary Docker image to Docker Hub
+    name: Push canary Docker image to GitHub Container Registry
     needs: deploy_canary
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: canary
     steps:
@@ -361,11 +318,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -384,7 +336,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis:canary
             ghcr.io/hardisgroupcom/sfdx-hardis:canary
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -396,12 +347,11 @@ jobs:
 
   push_canary_ubuntu_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
-    name: Push canary Ubuntu Docker image to Docker Hub
+    name: Push canary Ubuntu Docker image to GitHub Container Registry
     needs: deploy_canary
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: canary
     steps:
@@ -410,11 +360,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -433,7 +378,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:canary
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:canary
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -445,12 +389,11 @@ jobs:
 
   push_canary_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
-    name: Push canary Docker image with agents to Docker Hub
+    name: Push canary Docker image with agents to GitHub Container Registry
     needs: deploy_canary
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: canary
     steps:
@@ -459,11 +402,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -483,17 +421,15 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-with-agents:canary
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:canary
 
   push_canary_ubuntu_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
-    name: Push canary Ubuntu Docker image with agents to Docker Hub
+    name: Push canary Ubuntu Docker image with agents to GitHub Container Registry
     needs: deploy_canary
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: canary
     steps:
@@ -502,11 +438,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -526,7 +457,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:canary
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:canary
 
   deploy_beta:
@@ -556,13 +486,12 @@ jobs:
 
   push_beta_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Docker image to Docker Hub
+    name: Push Beta Docker image to GitHub Container Registry
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
       packages: write
       security-events: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -571,11 +500,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -594,7 +518,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis:beta
             ghcr.io/hardisgroupcom/sfdx-hardis:beta
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -643,12 +566,11 @@ jobs:
 
   push_beta_to_registry_sfdx_recommended:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Docker image to Docker Hub (with @salesforce/cli version recommended by hardis)
+    name: Push Beta Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -657,11 +579,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -680,7 +597,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis:beta-sfdx-recommended
             ghcr.io/hardisgroupcom/sfdx-hardis:beta-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -692,13 +608,12 @@ jobs:
 
   push_beta_ubuntu_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Ubuntu Docker image to Docker Hub
+    name: Push Beta Ubuntu Docker image to GitHub Container Registry
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
       packages: write
       security-events: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -707,11 +622,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -730,7 +640,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:beta
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:beta
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -779,12 +688,11 @@ jobs:
 
   push_beta_ubuntu_to_registry_sfdx_recommended:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Ubuntu Docker image to Docker Hub (with @salesforce/cli version recommended by hardis)
+    name: Push Beta Ubuntu Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -793,11 +701,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -816,7 +719,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:beta-sfdx-recommended
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:beta-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -828,12 +730,11 @@ jobs:
 
   push_beta_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Docker image with agents to Docker Hub
+    name: Push Beta Docker image with agents to GitHub Container Registry
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -842,11 +743,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -866,17 +762,15 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-with-agents:beta
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:beta
 
   push_beta_ubuntu_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Ubuntu Docker image with agents to Docker Hub
+    name: Push Beta Ubuntu Docker image with agents to GitHub Container Registry
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -885,11 +779,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -909,7 +798,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:beta
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:beta
 
   deploy_release:
@@ -937,13 +825,12 @@ jobs:
 
   push_release_to_registry:
     if: github.event_name == 'release'
-    name: Push Docker image to Docker Hub
+    name: Push Docker image to GitHub Container Registry
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
       packages: write
       security-events: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -952,11 +839,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -975,8 +857,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis:${{ github.event.release.tag_name }}
-            docker.io/hardisgroupcom/sfdx-hardis:latest
             ghcr.io/hardisgroupcom/sfdx-hardis:${{ github.event.release.tag_name }}
             ghcr.io/hardisgroupcom/sfdx-hardis:latest
       # - uses: aquasecurity/trivy-action@master
@@ -1026,12 +906,11 @@ jobs:
 
   push_release_to_registry_sfdx_recommended:
     if: github.event_name == 'release'
-    name: Push Docker image to Docker Hub (with @salesforce/cli version recommended by hardis)
+    name: Push Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -1040,11 +919,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1063,7 +937,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended
             ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -1075,13 +948,12 @@ jobs:
 
   push_release_ubuntu_to_registry:
     if: github.event_name == 'release'
-    name: Push Ubuntu Docker image to Docker Hub
+    name: Push Ubuntu Docker image to GitHub Container Registry
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
       packages: write
       security-events: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -1090,11 +962,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1113,8 +980,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:${{ github.event.release.tag_name }}
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:${{ github.event.release.tag_name }}
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
       # - uses: aquasecurity/trivy-action@master
@@ -1164,12 +1029,11 @@ jobs:
 
   push_release_ubuntu_to_registry_sfdx_recommended:
     if: github.event_name == 'release'
-    name: Push Ubuntu Docker image to Docker Hub (with @salesforce/cli version recommended by hardis)
+    name: Push Ubuntu Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -1178,11 +1042,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1201,7 +1060,6 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
@@ -1213,12 +1071,11 @@ jobs:
 
   push_release_with_agents_to_registry:
     if: github.event_name == 'release'
-    name: Push Docker image with agents to Docker Hub
+    name: Push Docker image with agents to GitHub Container Registry
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -1227,11 +1084,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1251,19 +1103,16 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-with-agents:${{ github.event.release.tag_name }}
-            docker.io/hardisgroupcom/sfdx-hardis-with-agents:latest
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:${{ github.event.release.tag_name }}
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest
 
   push_release_ubuntu_with_agents_to_registry:
     if: github.event_name == 'release'
-    name: Push Ubuntu Docker image with agents to Docker Hub
+    name: Push Ubuntu Docker image with agents to GitHub Container Registry
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      id-token: write # Required for Docker Hub OIDC login
     environment:
       name: release
     steps:
@@ -1272,11 +1121,6 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.DOCKERHUB_OIDC_CONNECTIONID }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1296,7 +1140,5 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:${{ github.event.release.tag_name }}
-            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:${{ github.event.release.tag_name }}
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## [beta] (main)
 
 - [hardis:org:diagnose:audittrail](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/audittrail/): New `.sfdx-hardis.yml` property **monitoringAllowedUsersActions** to allow specific expected actions for specific users (ex: an integration user whose portal user provisioning automatically creates account roles). Unlike **monitoringExcludeUsernames**, any other action performed by the same user is still flagged as suspect.
-- Docker images are published to Docker Hub again, using OIDC authentication instead of password secrets.
 - [hardis:org:user:unlink-security-key](https://sfdx-hardis.cloudity.com/hardis/org/user/unlink-security-key/): Notifications and reports now show who triggered the run.
 - New [hardis:org:diagnose:usage-entitlements](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/usage-entitlements/): Monitor usage-based entitlements like Einstein Requests, Flex Credits, Data 360 credits and API calls, and warn when consumption is on track to exceed the allowance before the billing period ends.
 - New [hardis:org:diagnose:consumption-alerts](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/consumption-alerts/): Report the consumption and license utilization alerts Salesforce raises on the org.

--- a/docs/schema/sfdx-hardis-json-schema-parameters.html
+++ b/docs/schema/sfdx-hardis-json-schema-parameters.html
@@ -899,6 +899,119 @@
         </div>
     </div>
 </div>
+<div class="accordion" id="accordionflowDeleteInterviews">
+    <div class="card">
+        <div class="card-header" id="headingflowDeleteInterviews">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#flowDeleteInterviews"
+                        aria-expanded="" aria-controls="flowDeleteInterviews" onclick="setAnchor('#flowDeleteInterviews')"><span class="property-name">flowDeleteInterviews</span></button>
+            </h2>
+        </div>
+
+        <div id="flowDeleteInterviews"
+             class="collapse property-definition-div" aria-labelledby="headingflowDeleteInterviews"
+             data-parent="#accordionflowDeleteInterviews">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#flowDeleteInterviews" onclick="anchorLink('flowDeleteInterviews')">flowDeleteInterviews</a></div><h4>Delete Flow Interviews blocking a Flow deletion</h4><span class="badge badge-dark value-type">Type: boolean</span> <span class="badge badge-success default-value">Default: false</span><br/>
+<div class="description collapse" id="collapseDescription_flowDeleteInterviews">
+            <p>When deleting a Flow listed in destructive changes, authorizes sfdx-hardis to delete the Flow Interviews that block the deletion.<br />
+Caution: deleting Flow Interviews is irreversible and destroys in-flight process state.<br />
+Can also be set with the FLOW<em>DELETE</em>INTERVIEWS env variable or an affirmative, standalone FLOW<em>DELETE</em>INTERVIEWS directive in the Pull Request description.</p>
+
+        </div>
+        <div>
+            <a class="collapse-description-link collapsed" data-toggle="collapse" href="#collapseDescription_flowDeleteInterviews"
+               aria-expanded="false" aria-controls="collapseDescriptionflowDeleteInterviews"
+            ></a>
+        </div>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionflowDeleteMaxAttempts">
+    <div class="card">
+        <div class="card-header" id="headingflowDeleteMaxAttempts">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#flowDeleteMaxAttempts"
+                        aria-expanded="" aria-controls="flowDeleteMaxAttempts" onclick="setAnchor('#flowDeleteMaxAttempts')"><span class="property-name">flowDeleteMaxAttempts</span></button>
+            </h2>
+        </div>
+
+        <div id="flowDeleteMaxAttempts"
+             class="collapse property-definition-div" aria-labelledby="headingflowDeleteMaxAttempts"
+             data-parent="#accordionflowDeleteMaxAttempts">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#flowDeleteMaxAttempts" onclick="anchorLink('flowDeleteMaxAttempts')">flowDeleteMaxAttempts</a></div><h4>Flow deletion max attempts</h4><span class="badge badge-dark value-type">Type: integer</span> <span class="badge badge-success default-value">Default: 3</span><br/>
+<span class="description"><p>Number of attempts to delete the versions of a Flow listed in destructive changes. Only used when the deletion of blocking Flow Interviews is authorized, to retry a version that a paused interview still blocks.<br />
+Can also be set with the FLOW<em>DELETE</em>MAX_ATTEMPTS env variable, which takes priority. A value below 1 or not an integer is ignored, with a warning.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction numeric-restriction" id="flowDeleteMaxAttempts_number">Value must be greater or equal to <code>1</code></span></p>
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionflowDeleteRetryDelayMs">
+    <div class="card">
+        <div class="card-header" id="headingflowDeleteRetryDelayMs">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#flowDeleteRetryDelayMs"
+                        aria-expanded="" aria-controls="flowDeleteRetryDelayMs" onclick="setAnchor('#flowDeleteRetryDelayMs')"><span class="property-name">flowDeleteRetryDelayMs</span></button>
+            </h2>
+        </div>
+
+        <div id="flowDeleteRetryDelayMs"
+             class="collapse property-definition-div" aria-labelledby="headingflowDeleteRetryDelayMs"
+             data-parent="#accordionflowDeleteRetryDelayMs">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#flowDeleteRetryDelayMs" onclick="anchorLink('flowDeleteRetryDelayMs')">flowDeleteRetryDelayMs</a></div><h4>Flow deletion retry delay (ms)</h4><span class="badge badge-dark value-type">Type: integer</span> <span class="badge badge-success default-value">Default: 10000</span><br/>
+<span class="description"><p>Delay in milliseconds between two attempts to delete the versions of a Flow listed in destructive changes.<br />
+Can also be set with the FLOW<em>DELETE</em>RETRY<em>DELAY</em>MS env variable, which takes priority. A negative value or a value that is not an integer is ignored, with a warning.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction numeric-restriction" id="flowDeleteRetryDelayMs_number">Value must be greater or equal to <code>0</code></span></p>
+
+        
+            </div>
+        </div>
+    </div>
+</div>
 <div class="accordion" id="accordionallowedOrgTypes">
     <div class="card">
         <div class="card-header" id="headingallowedOrgTypes">
@@ -10902,6 +11015,123 @@ User entries are merged by 'key' onto the built-in defaults: provide only the fi
         
 
         
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionmonitoringAllowedUsersActions">
+    <div class="card">
+        <div class="card-header" id="headingmonitoringAllowedUsersActions">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#monitoringAllowedUsersActions"
+                        aria-expanded="" aria-controls="monitoringAllowedUsersActions" onclick="setAnchor('#monitoringAllowedUsersActions')"><span class="property-name">monitoringAllowedUsersActions</span></button>
+            </h2>
+        </div>
+
+        <div id="monitoringAllowedUsersActions"
+             class="collapse property-definition-div" aria-labelledby="headingmonitoringAllowedUsersActions"
+             data-parent="#accordionmonitoringAllowedUsersActions">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#monitoringAllowedUsersActions" onclick="anchorLink('monitoringAllowedUsersActions')">monitoringAllowedUsersActions</a></div><h4>Monitoring Allowed Users Actions</h4><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>Map of username to the list of Setup Audit Trail actions that won't be considered as suspect when performed by this user. Unlike monitoringExcludeUsernames, any other action from the same user is still flagged. An empty list ignores all actions from the user.</p>
+</span>
+        
+
+        
+        
+
+        <br/>
+<div class="badge badge-secondary">Example:</div>
+<br/><div id="monitoringAllowedUsersActions_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span>
+<span class="w">    </span><span class="s2">&quot;provisioning-user@cloudity.com&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span>
+<span class="w">        </span><span class="s2">&quot;createdrole&quot;</span>
+<span class="w">    </span><span class="p">]</span>
+<span class="p">}</span>
+</pre></div>
+</div>
+<div class="accordion" id="accordionmonitoringAllowedUsersActions_additionalProperties">
+    <div class="card">
+        <div class="card-header" id="headingmonitoringAllowedUsersActions_additionalProperties">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#monitoringAllowedUsersActions_additionalProperties"
+                        aria-expanded="" aria-controls="monitoringAllowedUsersActions_additionalProperties" onclick="setAnchor('#monitoringAllowedUsersActions_additionalProperties')"><em><span class="property-name">Additional Properties</span></em></button>
+            </h2>
+        </div>
+
+        <div id="monitoringAllowedUsersActions_additionalProperties"
+             class="collapse property-definition-div" aria-labelledby="headingmonitoringAllowedUsersActions_additionalProperties"
+             data-parent="#accordionmonitoringAllowedUsersActions_additionalProperties">
+            <div class="card-body pl-5"><p class="additional-properties">Each additional property must conform to the following schema</p>
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#monitoringAllowedUsersActions" onclick="anchorLink('monitoringAllowedUsersActions')">monitoringAllowedUsersActions</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#monitoringAllowedUsersActions_additionalProperties" onclick="anchorLink('monitoringAllowedUsersActions_additionalProperties')">additionalProperties</a></div><span class="badge badge-dark value-type">Type: array of string</span><br/>
+
+        
+
+        
+        
+
+         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="monitoringAllowedUsersActions_additionalProperties_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#monitoringAllowedUsersActions" onclick="anchorLink('monitoringAllowedUsersActions')">monitoringAllowedUsersActions</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#monitoringAllowedUsersActions_additionalProperties" onclick="anchorLink('monitoringAllowedUsersActions_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#monitoringAllowedUsersActions_additionalProperties_items" onclick="anchorLink('monitoringAllowedUsersActions_additionalProperties_items')">additionalProperties items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        
+
+        
+        </div>
+    </div>
             </div>
         </div>
     </div>

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -35,3 +35,22 @@ reason = "serialize-javascript 6.0.2 is brought by mocha from @salesforce/dev-sc
 [[IgnoredVulns]]
 id = "GHSA-mh99-v99m-4gvg"
 reason = "brace-expansion 1.1.16 and 2.1.2 are pinned by minimatch 3.x/5.x/9.x in upstream tooling; only 5.0.8 is patched and 5.x is API-breaking for those consumers. Our 5.x branch is upgraded to 5.0.8. DoS only, on patterns that never come from untrusted input."
+
+# https://github.com/advisories/GHSA-5p2g-fcmc-qvqq (CVE-2025-71329)
+# https://github.com/advisories/GHSA-w3rx-r6r6-pgpr (CVE-2025-71330)
+# image-size: the JXL/HEIF box parser and the ICNS entry parser never advance the read offset when a
+# size field is 0, so a crafted image spins the event loop forever (DoS, availability only).
+# No patched release exists: OSV marks every version up to and including 2.0.2 as affected, and
+# 2.0.2 is the current latest on npm (1.2.1 is the `legacy` tag). There is nothing to upgrade to.
+# image-size 1.2.1 reaches us only through pptxgenjs 4.0.1 (`image-size "^1.2.1"`), used by
+# src/common/utils/monitoringPptxReport.ts to build the monitoring PPTX report. That report is
+# text and tables only: it never calls addImage, so the vulnerable parsers are never reached, and
+# no image bytes from an untrusted source are ever handed to the library. Remove once image-size
+# ships a fix and pptxgenjs picks it up. Added 2026-08-07.
+[[IgnoredVulns]]
+id = "GHSA-5p2g-fcmc-qvqq"
+reason = "image-size 1.2.1 is a transitive dependency of pptxgenjs 4.0.1; no patched version exists (all releases up to the latest 2.0.2 are affected). Our PPTX report generates text and tables only and never decodes images, so the vulnerable JXL/HEIF parser is unreachable."
+
+[[IgnoredVulns]]
+id = "GHSA-w3rx-r6r6-pgpr"
+reason = "image-size 1.2.1 is a transitive dependency of pptxgenjs 4.0.1; no patched version exists (all releases up to the latest 2.0.2 are affected). Our PPTX report generates text and tables only and never decodes images, so the vulnerable ICNS parser is unreachable."


### PR DESCRIPTION
The previous change reactivated Docker Hub publication through docker/login-action v4 OIDC, but the required OIDC connection cannot be set up on the hardisgroupcom Docker Hub org for now.

This removes from all Docker push jobs in deploy.yml:

- the Docker Hub login step (DOCKER_USERNAME / DOCKERHUB_OIDC_CONNECTIONID)
- the docker.io push tags
- the id-token: write permissions added for the Docker Hub login

Images keep being published to ghcr.io, and the npm publish OIDC permissions are untouched. Job names are updated to say GitHub Container Registry. The unreleased CHANGELOG line announcing Docker Hub publication is removed.

Docker Hub publication can be restored by reverting this commit once the OIDC connection is available.