### PR TITLE
docs(changelog): group beta entries by category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,40 @@
 
 ## [beta] (main)
 
-- Reduce the npm dependency tree by ~20% (14 packages removed, among which axios, xml2js, openai, cloudflare and md-to-pdf) to shrink the supply-chain attack surface, with no functional change.
-- [hardis:org:diagnose:audittrail](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/audittrail/): New `.sfdx-hardis.yml` property **monitoringAllowedUsersActions** to allow specific expected actions for specific users (ex: an integration user whose portal user provisioning automatically creates account roles). Unlike **monitoringExcludeUsernames**, any other action performed by the same user is still flagged as suspect.
-- [hardis:org:user:unlink-security-key](https://sfdx-hardis.cloudity.com/hardis/org/user/unlink-security-key/): Notifications and reports now show who triggered the run.
+### Org Monitoring & Grafana
+
 - New [hardis:org:diagnose:usage-entitlements](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/usage-entitlements/): Monitor usage-based entitlements like Einstein Requests, Flex Credits, Data 360 credits and API calls, and warn when consumption is on track to exceed the allowance before the billing period ends.
 - New [hardis:org:diagnose:consumption-alerts](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/consumption-alerts/): Report the consumption and license utilization alerts Salesforce raises on the org.
 - New [hardis:org:diagnose:ai-usage](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/ai-usage/): Break down Agentforce and Data 360 credit consumption by agent and action (requires Data 360).
 - New "08 - Usage & Cost" Grafana v2 dashboard for entitlement consumption, projected overage, utilization alerts and AI credit usage.
 - Estimate usage costs in your own currency: declare your contracted rates in `usageCost` and monitoring reports entitlement overage and Agentforce credits in money alongside the percentages.
+- [hardis:org:diagnose:audittrail](https://sfdx-hardis.cloudity.com/hardis/org/diagnose/audittrail/): New `.sfdx-hardis.yml` property **monitoringAllowedUsersActions** to allow specific expected actions for specific users (ex: an integration user whose portal user provisioning automatically creates account roles). Unlike **monitoringExcludeUsernames**, any other action performed by the same user is still flagged as suspect.
+- [hardis:org:user:unlink-security-key](https://sfdx-hardis.cloudity.com/hardis/org/user/unlink-security-key/): Notifications and reports now show who triggered the run.
+
+### Deployment
+
 - [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/):
   - Delete Flows listed in destructive changes. Flow members are removed from the manifest sent to the org and deleted through the Tooling API after the deployment (deactivate, then delete every version), because a Flow deletion can neither be validated by a `--check` deployment nor survive a quick deploy. A `--check` reports the deletion plan in the Pull Request comment and fails if Flow Interviews block a deletion.
   - New `FLOW_DELETE_INTERVIEWS` Pull Request keyword / env variable and `flowDeleteInterviews` config property, to authorize deleting the Flow Interviews that block a Flow deletion.<br/>**Caution: deleting Flow Interviews is irreversible and destroys in-flight process state.**
   - New `flowDeleteMaxAttempts` and `flowDeleteRetryDelayMs` config properties (and their `FLOW_DELETE_MAX_ATTEMPTS` and `FLOW_DELETE_RETRY_DELAY_MS` env variables) to tune how many times a Flow version deletion is retried when a Flow Interview still blocks it, and how long to wait between attempts.
   - **Behavior change: a Flow listed in destructive changes is no longer deleted inside the deployment transaction.** Its deactivation and its deletion are committed on their own, before the deployment for `preDestructiveChanges.xml` and after it otherwise, so a deployment that fails leaves the Flow deactivated or deleted instead of rolling it back. Every step is re-runnable, so retrying the pipeline converges.
   - **Behavior change: `--check` no longer validates Flow destructive members against the org.** A Flow member that does not exist in the target org, a typo included, is now reported as `FLOW_DELETE_NOOP` and passes, because the same destructive changes are replayed along the promotion chain and can already have been applied.
+  - CI logs now display a readable deployment summary instead of the complete deployment JSON, which is written in hardis-report and published as a CI job artifact.
+  - New SFDX_HARDIS_DEPLOY_CHECK_ID env variable to force the Quick Deploy job id instead of reading it from Pull Request comments.
 - [hardis:org:purge:flow](https://sfdx-hardis.cloudity.com/hardis/org/purge/flow/): Flow version deletion is now significantly faster with far fewer API calls.
-- Fix `packageXmlToDeploy`, `packageXmlToDelete` and `packageXmlToDeletePreDeploy` config properties (and their `PACKAGE_XML_TO_DEPLOY`, `PACKAGE_XML_TO_DELETE`, `PACKAGE_XML_TO_DELETE_PRE_DEPLOY` env variables) being ignored: an operator precedence issue made the default `manifest/` and `config/` paths always win. Worst case, a project pointing to a custom destructive manifest deleted nothing at all and still exited with success. The `--packagexml` flag of [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/) was discarded the same way.<br/>**Check your configuration before upgrading: a project that sets one of these properties and also has a `manifest/package.xml` or `manifest/destructiveChanges.xml` on disk now deploys and deletes what its configuration says, which can be a different set of metadata than in previous runs.**
+- Fix `packageXmlToDeploy`, `packageXmlToDelete` and `packageXmlToDeletePreDeploy` config properties (and their `PACKAGE_XML_TO_DEPLOY`, `PACKAGE_XML_TO_DELETE`, `PACKAGE_XML_TO_DELETE_PRE_DEPLOY` env variables) being ignored: an operator precedence issue made the default `manifest/` and `config/` paths always win. Worst case, a project pointing to a custom destructive manifest deleted nothing at all and still exited with success. The `--packagexml` flag of hardis:project:deploy:smart was discarded the same way.<br/>**Check your configuration before upgrading: a project that sets one of these properties and also has a `manifest/package.xml` or `manifest/destructiveChanges.xml` on disk now deploys and deletes what its configuration says, which can be a different set of metadata than in previous runs.**
 - A destructive changes manifest configured through `packageXmlToDelete` / `packageXmlToDeletePreDeploy` that does not exist on disk now logs a warning, instead of being skipped silently.
+
+### CI/CD
+
+- Upgrade MegaLinter to v10 (repository lint config, CI/CD template workflow and mega-linter-runner dependency).
+- New Docker images are published only to GitHub Container Registry (`ghcr.io/hardisgroupcom/sfdx-hardis`): publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization.
+
+### Core
+
+- Reduce the npm dependency tree by ~20% (14 packages removed, among which axios, xml2js, openai, cloudflare and md-to-pdf) to shrink the supply-chain attack surface, with no functional change.
 - CSV and XLSX reports of the Bulk API helpers (`bulkUpdate`, `bulkDelete`) are now written in the reports directory, like every other report, instead of a relative file named after the object and the action.
 - Plugin API: `bulkDeleteTooling` now always returns `{ results: [{ Id, success, errors }] }`. Deletions go through the Tooling composite endpoint, with a one-by-one fallback.
-- [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/): CI logs now display a readable deployment summary instead of the complete deployment JSON, which is written in hardis-report and published as a CI job artifact.
-- [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/): New SFDX_HARDIS_DEPLOY_CHECK_ID env variable to force the Quick Deploy job id instead of reading it from Pull Request comments.
-- Upgrade MegaLinter to v10 (repository lint config, CI/CD template workflow and mega-linter-runner dependency).
 
 ## [7.23.0] 2026-07-26
 


### PR DESCRIPTION
## What

- Reorganize the `[beta] (main)` CHANGELOG section into categories (Org Monitoring & Grafana, Deployment, CI/CD, Core), following the structure introduced in 7.23.0.
- Merge the three separate `hardis:project:deploy:smart` entries into a single grouped entry with nested bullets.
- Add a missing entry for #2040: new Docker images are published only to ghcr.io while Docker Hub publication is paused pending OIDC availability.

## Why

All PRs merged since v7.23.0 were cross-checked against the changelog: everything user-visible was already covered except #2040. Dependency bumps and internal CI/docs commits are left out, as usual.