### PR TITLE
fix(deploy): collect the right Pull Request scope for deployment actions and Apex test classes on every merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - **Behavior change: post-deployment actions are no longer run when the metadata deployment failed.** They are reported as `not run` in the Pull Request comment, no execution state is stored, and the job now fails on the deployment error instead of on a post-deployment action error. The `skipIfError` property is removed, and is ignored if still present in your configuration.<br/>**Check your configuration before upgrading: an action relying on `skipIfError: false` to run after a failed deployment will no longer run.**
 - Deployment actions: a failed action now displays why it failed in the job log and in the Pull Request comment. Actions whose command ends with `--json` used to fail with no output at all.
 - Deployment actions and selected Apex test classes: merging a feature branch now processes only the Pull Request just merged, while merges between major branches and from `retrofit/*` branches keep replaying the whole batch of upstream Pull Requests.
+- Deployment actions and selected Apex test classes now also run on merges into the production branch, scoped to the Pull Requests carried by the go-live merge.
+- Deployment actions of Pull Requests merged upstream (like a hotfix in `main`) are now replayed downstream when a retrofit branch brings their commits to another major branch.
+- Fix deployment actions never running on GitHub push-triggered deployment jobs, caused by incomplete Pull Request detection.
 
 ### CI/CD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - A destructive changes manifest configured through `packageXmlToDelete` / `packageXmlToDeletePreDeploy` that does not exist on disk now logs a warning, instead of being skipped silently.
 - **Behavior change: post-deployment actions are no longer run when the metadata deployment failed.** They are reported as `not run` in the Pull Request comment, no execution state is stored, and the job now fails on the deployment error instead of on a post-deployment action error. The `skipIfError` property is removed, and is ignored if still present in your configuration.<br/>**Check your configuration before upgrading: an action relying on `skipIfError: false` to run after a failed deployment will no longer run.**
 - Deployment actions: a failed action now displays why it failed in the job log and in the Pull Request comment. Actions whose command ends with `--json` used to fail with no output at all.
+- Deployment actions and selected Apex test classes: merging a feature branch now processes only the Pull Request just merged, while merges between major branches and from `retrofit/*` branches keep replaying the whole batch of upstream Pull Requests.
 
 ### CI/CD
 

--- a/docs/hardis/project/deploy/smart.md
+++ b/docs/hardis/project/deploy/smart.md
@@ -161,7 +161,7 @@ You can define command lines to run before or after a deployment, with parameter
 
 Post-deployment actions are never run when the metadata deployment failed: they are reported as `not run` and are proposed again during the next successful deployment.
 
-Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion.
+Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion, and a merge into the production branch keeps those of every Pull Request carried by the go-live merge. Pull Requests merged upstream (ex: a hotfix in main) are included as soon as their commits arrive in the window.
 
 If the deployment job of a feature branch fails, its actions are not picked up by the next merged Pull Request: re-run the failed deployment job, or move the actions to a new Pull Request.
 

--- a/docs/hardis/project/deploy/smart.md
+++ b/docs/hardis/project/deploy/smart.md
@@ -161,6 +161,10 @@ You can define command lines to run before or after a deployment, with parameter
 
 Post-deployment actions are never run when the metadata deployment failed: they are reported as `not run` and are proposed again during the next successful deployment.
 
+Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion.
+
+If the deployment job of a feature branch fails, its actions are not picked up by the next merged Pull Request: re-run the failed deployment job, or move the actions to a new Pull Request.
+
 After every action runs, its result (✅ success, ❌ failed, 👋 manual) is recorded in a dedicated **"Deployment Actions"** PR comment - ordered by org (integration → uat → preprod → prod) - regardless of `runOnlyOnceByOrg`.
 
 If the commands are not the same depending on the target org, you can define them into **config/branches/.sfdx-hardis-BRANCHNAME.yml** instead of root **config/.sfdx-hardis.yml**

--- a/docs/hardis/project/deploy/sources/dx.md
+++ b/docs/hardis/project/deploy/sources/dx.md
@@ -161,7 +161,7 @@ You can define command lines to run before or after a deployment, with parameter
 
 Post-deployment actions are never run when the metadata deployment failed: they are reported as `not run` and are proposed again during the next successful deployment.
 
-Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion.
+Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion, and a merge into the production branch keeps those of every Pull Request carried by the go-live merge. Pull Requests merged upstream (ex: a hotfix in main) are included as soon as their commits arrive in the window.
 
 If the deployment job of a feature branch fails, its actions are not picked up by the next merged Pull Request: re-run the failed deployment job, or move the actions to a new Pull Request.
 

--- a/docs/hardis/project/deploy/sources/dx.md
+++ b/docs/hardis/project/deploy/sources/dx.md
@@ -161,6 +161,10 @@ You can define command lines to run before or after a deployment, with parameter
 
 Post-deployment actions are never run when the metadata deployment failed: they are reported as `not run` and are proposed again during the next successful deployment.
 
+Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion.
+
+If the deployment job of a feature branch fails, its actions are not picked up by the next merged Pull Request: re-run the failed deployment job, or move the actions to a new Pull Request.
+
 After every action runs, its result (✅ success, ❌ failed, 👋 manual) is recorded in a dedicated **"Deployment Actions"** PR comment - ordered by org (integration → uat → preprod → prod) - regardless of `runOnlyOnceByOrg`.
 
 If the commands are not the same depending on the target org, you can define them into **config/branches/.sfdx-hardis-BRANCHNAME.yml** instead of root **config/.sfdx-hardis.yml**

--- a/docs/salesforce-ci-cd-smart-deployment.md
+++ b/docs/salesforce-ci-cd-smart-deployment.md
@@ -373,7 +373,11 @@ Pull Request descriptions can also override config properties using YAML blocks 
 ```mermaid
 %%{init: {"theme": "base", "themeVariables": {"primaryColor": "#eaf5fe", "primaryTextColor": "#032d60", "primaryBorderColor": "#0176d3", "lineColor": "#0176d3", "fontFamily": "Salesforce Sans, Arial, sans-serif"}}}%%
 flowchart TD
-    CMD_START[executePrePostCommands] --> SOURCES[Collect commands from:<br/>1. Branch config<br/>2. Extra commands from PR<br/>3. PR description YAML blocks]
+    CMD_START[executePrePostCommands] --> SCOPE{Merge from a<br/>feature branch?}
+    SCOPE -->|Yes| ONE_PR[Scope: the merged PR only]
+    SCOPE -->|No: major or retrofit branch| BATCH[Scope: all PRs since<br/>the previous merge]
+    ONE_PR --> SOURCES[Collect commands from:<br/>1. Branch config<br/>2. Extra commands from PR<br/>3. PR description YAML blocks]
+    BATCH --> SOURCES
     SOURCES --> DEPLOY_KO{Metadata deployment<br/>failed?}
     DEPLOY_KO -->|Yes| SKIP_ERR[Report every action as<br/>not run and stop]
     DEPLOY_KO -->|No| LOOP{For each command}
@@ -395,8 +399,8 @@ flowchart TD
     classDef sfSuccess fill:#cdefc4,stroke:#2e844a,color:#194e31,stroke-width:1.5px
     classDef sfSkip fill:#f3f3f3,stroke:#706e6b,color:#3e3e3c,stroke-width:1px
 
-    class CMD_START,SOURCES sfAction
-    class LOOP,VALID,DEPLOY_KO,CTX_CHECK,ONCE_CHECK sfDecision
+    class CMD_START,SOURCES,ONE_PR,BATCH sfAction
+    class LOOP,VALID,SCOPE,DEPLOY_KO,CTX_CHECK,ONCE_CHECK sfDecision
     class EXEC sfSuccess
     class SKIP_INVALID,SKIP_ERR,SKIP_CTX,SKIP_ONCE sfSkip
 ```
@@ -415,6 +419,8 @@ flowchart TD
 All action types support the following common properties: `id`, `label`, `context`, `allowFailure`, `runOnlyOnceByOrg`, and `customUsername` (to run the action as a different user).
 
 Post-deployment actions are never run when the metadata deployment failed. They are reported as `not run` in the Pull Request comment, no execution state is stored, and they are proposed again during the next successful deployment.
+
+A merge from a feature branch only processes the actions and the Apex test classes of the Pull Request that has just been merged. A merge between major branches, or from a retrofit branch (`retrofit/*`), processes those of every Pull Request merged into the source major branch since its last promotion.
 
 Command context options:
 

--- a/docs/salesforce-ci-cd-smart-deployment.md
+++ b/docs/salesforce-ci-cd-smart-deployment.md
@@ -420,7 +420,7 @@ All action types support the following common properties: `id`, `label`, `contex
 
 Post-deployment actions are never run when the metadata deployment failed. They are reported as `not run` in the Pull Request comment, no execution state is stored, and they are proposed again during the next successful deployment.
 
-A merge from a feature branch only processes the actions and the Apex test classes of the Pull Request that has just been merged. A merge between major branches, or from a retrofit branch (`retrofit/*`), processes those of every Pull Request merged into the source major branch since its last promotion.
+A merge from a feature branch only processes the actions and the Apex test classes of the Pull Request that has just been merged. A merge between major branches, or from a retrofit branch (`retrofit/*`), processes those of every Pull Request merged into the source major branch since its last promotion. A merge into the production branch processes those of every Pull Request carried by the go-live merge. Pull Requests merged upstream (ex: a hotfix in `main`) are included as soon as their commits arrive in the window, for example through a retrofit branch.
 
 Command context options:
 

--- a/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
+++ b/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
@@ -89,6 +89,27 @@ Each action is an object with the following required and optional properties.
 
 > Post-deployment actions are never run when the metadata deployment failed. They are reported as `not run` in the Pull Request comment, no execution state is stored for them, and they are proposed again during the next successful deployment.
 
+### Which Pull Requests are in scope
+
+The actions collected for a deployment depend on the branch the merged Pull Request comes from.
+
+| Merge | Scope |
+|-------|-------|
+| From a feature branch (ex: `feature/my-story` -> `integration`) | Only the Pull Request that has just been merged |
+| Between major branches (ex: `integration` -> `uat`) | Every Pull Request merged since the previous merge |
+| From a retrofit branch (ex: `retrofit/from-main` -> `integration`) | Every Pull Request merged since the previous merge |
+
+A feature branch merge carries a single Pull Request, so its notification and its Pull Request comment list only that Pull Request's actions. A major branch or retrofit branch merge carries a batch of Pull Requests, whose actions must be replayed in the target org.
+
+> The batch is built from the Pull Requests merged into the source major branch since its last promotion. Two consequences are worth knowing:
+>
+> - A merge into the production branch processes no Pull Request batch, because the production branch has no merge target to bound the window.
+> - A retrofit merge collects the Pull Requests of the branch it is merged into, not the ones merged upstream into `main`. To replay a specific upstream action during a retrofit, declare it on the retrofit Pull Request itself.
+
+The same scope applies to the Apex test classes selected from Pull Requests when `enableDeploymentApexTestClasses` is active.
+
+> If the deployment job of a feature branch fails, its actions are not picked up by the next merged Pull Request. Re-run the failed deployment job, or open a new Pull Request carrying the actions of the previous one.
+
 ### Deployment Actions PR comment
 
 After every action runs, sfdx-hardis creates or updates a dedicated **"Deployment Actions"** comment on the Pull Request. This gives release managers a consolidated view of what has been executed across every org for the lifetime of the PR.

--- a/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
+++ b/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
@@ -93,10 +93,10 @@ Each action is an object with the following required and optional properties.
 
 The actions collected for a deployment depend on the branch the merged Pull Request comes from.
 
-| Merge | Scope |
-|-------|-------|
-| From a feature branch (ex: `feature/my-story` -> `integration`) | Only the Pull Request that has just been merged |
-| Between major branches (ex: `integration` -> `uat`) | Every Pull Request merged since the previous merge |
+| Merge                                                              | Scope                                              |
+|--------------------------------------------------------------------|----------------------------------------------------|
+| From a feature branch (ex: `feature/my-story` -> `integration`)    | Only the Pull Request that has just been merged    |
+| Between major branches (ex: `integration` -> `uat`)                | Every Pull Request merged since the previous merge |
 | From a retrofit branch (ex: `retrofit/from-main` -> `integration`) | Every Pull Request merged since the previous merge |
 
 A feature branch merge carries a single Pull Request, so its notification and its Pull Request comment list only that Pull Request's actions. A major branch or retrofit branch merge carries a batch of Pull Requests, whose actions must be replayed in the target org.

--- a/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
+++ b/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
@@ -101,10 +101,11 @@ The actions collected for a deployment depend on the branch the merged Pull Requ
 
 A feature branch merge carries a single Pull Request, so its notification and its Pull Request comment list only that Pull Request's actions. A major branch or retrofit branch merge carries a batch of Pull Requests, whose actions must be replayed in the target org.
 
-> The batch is built from the Pull Requests merged into the source major branch since its last promotion. Two consequences are worth knowing:
->
-> - A merge into the production branch processes no Pull Request batch, because the production branch has no merge target to bound the window.
-> - A retrofit merge collects the Pull Requests of the branch it is merged into, not the ones merged upstream into `main`. To replay a specific upstream action during a retrofit, declare it on the retrofit Pull Request itself.
+- Between major branches, the batch is every Pull Request merged into the source major branch since its last promotion.
+- Into the production branch (which has no promotion target), the batch is every Pull Request carried by the go-live merge itself.
+- Pull Requests merged into upstream branches are part of the batch as soon as their commits arrive in the window: a hotfix merged into `main` is collected when a retrofit branch brings it down to `integration`, so its actions run there too.
+
+In every case, `runOnlyOnceByOrg` state tracking ensures each action runs only in the orgs where it has not been performed yet.
 
 The same scope applies to the Apex test classes selected from Pull Requests when `enableDeploymentApexTestClasses` is active.
 

--- a/src/commands/hardis/project/deploy/smart.ts
+++ b/src/commands/hardis/project/deploy/smart.ts
@@ -206,6 +206,10 @@ You can define command lines to run before or after a deployment, with parameter
 
 Post-deployment actions are never run when the metadata deployment failed: they are reported as \`not run\` and are proposed again during the next successful deployment.
 
+Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion.
+
+If the deployment job of a feature branch fails, its actions are not picked up by the next merged Pull Request: re-run the failed deployment job, or move the actions to a new Pull Request.
+
 After every action runs, its result (✅ success, ❌ failed, 👋 manual) is recorded in a dedicated **"Deployment Actions"** PR comment - ordered by org (integration → uat → preprod → prod) - regardless of \`runOnlyOnceByOrg\`.
 
 If the commands are not the same depending on the target org, you can define them into **config/branches/.sfdx-hardis-BRANCHNAME.yml** instead of root **config/.sfdx-hardis.yml**

--- a/src/commands/hardis/project/deploy/smart.ts
+++ b/src/commands/hardis/project/deploy/smart.ts
@@ -206,7 +206,7 @@ You can define command lines to run before or after a deployment, with parameter
 
 Post-deployment actions are never run when the metadata deployment failed: they are reported as \`not run\` and are proposed again during the next successful deployment.
 
-Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion.
+Deployment actions and selected Apex test classes are scoped to the Pull Request that has just been merged when it comes from a feature branch. A merge from a major branch (ex: integration -> uat) or from a retrofit branch (ex: retrofit/from-main -> integration) keeps those of every Pull Request merged into the source major branch since its last promotion, and a merge into the production branch keeps those of every Pull Request carried by the go-live merge. Pull Requests merged upstream (ex: a hotfix in main) are included as soon as their commits arrive in the window.
 
 If the deployment job of a feature branch fails, its actions are not picked up by the next merged Pull Request: re-run the failed deployment job, or move the actions to a new Pull Request.
 

--- a/src/common/gitProvider/github.ts
+++ b/src/common/gitProvider/github.ts
@@ -303,6 +303,13 @@ export class GithubProvider extends GitProviderRoot {
                     body
                     url
                     merged,
+                    headRefName
+                    baseRefName
+                    mergeCommit {
+                      oid
+                    }
+                    createdAt
+                    mergedAt
                     baseRef {
                       id
                       name
@@ -333,7 +340,21 @@ export class GithubProvider extends GitProviderRoot {
         (pr: any) => pr.node.merged === true && pr.node.baseRef.name === currentGitBranch,
       );
       if (candidatePullRequests.length > 0) {
-        return this.completePullRequestInfo(candidatePullRequests[0].node);
+        // The GraphQL node does not have the REST shape completePullRequestInfo reads
+        // (head.ref / base.ref / merge_commit_sha / user.login / html_url), so map it first.
+        // Without this, push-triggered deployments got a Pull Request with empty source and
+        // target branches, and the deployment actions engine could not resolve its scope.
+        const node = candidatePullRequests[0].node;
+        return this.completePullRequestInfo({
+          ...node,
+          head: { ref: node.headRefName || "" },
+          base: { ref: node.baseRefName || node.baseRef?.name || "" },
+          merge_commit_sha: node.mergeCommit?.oid || undefined,
+          created_at: node.createdAt || undefined,
+          merged_at: node.mergedAt || undefined,
+          user: { login: node.author?.login || "" },
+          html_url: node.url || "",
+        });
       }
     }
     uxLog("log", this, c.grey('[GitHub Integration] ' + t('githubUnableToFindPrInfo')));

--- a/src/common/utils/orgConfigUtils.ts
+++ b/src/common/utils/orgConfigUtils.ts
@@ -273,6 +273,19 @@ export function isUatRun(branchName) {
 }
 
 /**
+ * A retrofit branch carries the changes of an upstream major branch down to another one
+ * (ex: main is merged into retrofit/from-main, which is then merged into integration).
+ * Retrofit branches have no org config file, so they never appear in listMajorOrgs():
+ * they are identified by their name, like the other branch kinds above.
+ */
+export function isRetrofit(branchName: string): boolean {
+  // Matches the retrofit/<name> convention produced by hardis:work:new, so an ordinary branch
+  // named retrofit-JIRA-123 or retrofitting-legacy is not mistaken for one.
+  const name = (branchName || "").toLowerCase();
+  return name === "retrofit" || name.startsWith("retrofit/");
+}
+
+/**
  * Get the Chrome/Chromium executable path for Puppeteer
  * This is used by various commands that need browser automation
  * @returns string - Path to Chrome executable, or empty string if not found

--- a/src/common/utils/pullRequestUtils.ts
+++ b/src/common/utils/pullRequestUtils.ts
@@ -4,8 +4,9 @@ import c from "chalk";
 import path from "path";
 import fs from "fs-extra";
 import yaml from "js-yaml";
-import { listMajorOrgs } from "./orgConfigUtils.js";
+import { isRetrofit, listMajorOrgs } from "./orgConfigUtils.js";
 import { SfError } from "@salesforce/core";
+import { t } from "./i18n.js";
 
 let _cachedPullRequests: CommonPullRequestInfo[] | null = null;
 
@@ -58,6 +59,30 @@ function getYamlFromPrDescription(pr: CommonPullRequestInfo): object | null {
   return null;
 }
 
+/**
+ * Tells whether a merge carries only its own Pull Request, or a batch of upstream ones.
+ *
+ * A merge coming from a feature branch carries only its own Pull Request: collecting the other
+ * Pull Requests of the batch would run and report their deployment actions and their Apex test
+ * classes under the Pull Request that has just been merged.
+ *
+ * A merge coming from a major branch (ex: integration -> uat) or from a retrofit branch
+ * (ex: retrofit/from-main -> integration) carries every Pull Request merged upstream since the
+ * previous merge, and their actions and test classes must be replayed in the target org.
+ */
+export function isSinglePullRequestScope(sourceBranch: string, majorBranchNames: string[]): boolean {
+  const branchName = (sourceBranch || "").toLowerCase();
+  // Unknown source branch: keep the previous behavior (whole batch) rather than silently dropping
+  // the actions and test classes of every upstream Pull Request.
+  if (branchName === "") {
+    return false;
+  }
+  // Compared without case, like the other branch classifiers: major branch names come from the
+  // config/branches/.sfdx-hardis.<branch>.yml file names, which may not match the git branch case.
+  const isMajorBranch = majorBranchNames.some((majorBranchName) => (majorBranchName || "").toLowerCase() === branchName);
+  return !isMajorBranch && !isRetrofit(branchName);
+}
+
 export async function listAllPullRequestsForCurrentScope(checkOnly: boolean): Promise<CommonPullRequestInfo[]> {
   if (_cachedPullRequests) {
     return _cachedPullRequests;
@@ -88,20 +113,35 @@ export async function listAllPullRequestsForCurrentScope(checkOnly: boolean): Pr
   else {
     // Find major org config related to the branch of the PR just merged (ex: integration)
     const prTargetOrgDef = majorOrgs.find(o => o.branchName === pullRequestInfo.targetBranch);
-    if (prTargetOrgDef) {
-      if (!prTargetOrgDef.mergeTargets || prTargetOrgDef.mergeTargets.length === 0) {
-        uxLog("warning", this, c.yellow(`[GitProvider] No merge targets defined for target branch ${prTargetOrgDef.branchName}, cannot retrieve pull requests.`));
-        return [];
-      }
-      // ex: integration
-      sourceBranchToUse = prTargetOrgDef.branchName;
-      // ex: uat (multiple merge targets is not used yet so there should always be only one)
-      targetBranchToUse = prTargetOrgDef.mergeTargets[0];
-    }
-    else {
+    if (!prTargetOrgDef) {
       uxLog("warning", this, c.yellow(`[GitProvider] Target branch ${pullRequestInfo.targetBranch} not found in major orgs list, cannot retrieve pull requests.\nPR: ${JSON.stringify(pullRequestInfo, null, 2)}`));
       return [];
     }
+    // Merge from a feature branch: the Pull Request that has just been merged is the whole scope.
+    // No merge window is needed here, so this does not depend on mergeTargets being configured.
+    if (isSinglePullRequestScope(pullRequestInfo.sourceBranch, majorOrgs.map(o => o.branchName))) {
+      uxLog("log", this, c.grey(`[GitProvider] ${t('pullRequestScopeFeatureBranchMerge', {
+        sourceBranch: pullRequestInfo.sourceBranch,
+        pr: pullRequestInfo.idStr,
+      })}`));
+      _cachedPullRequests = [pullRequestInfo];
+      return _cachedPullRequests;
+    }
+    if (!prTargetOrgDef.mergeTargets || prTargetOrgDef.mergeTargets.length === 0) {
+      uxLog("warning", this, c.yellow(`[GitProvider] No merge targets defined for target branch ${prTargetOrgDef.branchName}, cannot retrieve pull requests.`));
+      return [];
+    }
+    // ex: integration
+    sourceBranchToUse = prTargetOrgDef.branchName;
+    // ex: uat (multiple merge targets is not used yet so there should always be only one)
+    targetBranchToUse = prTargetOrgDef.mergeTargets[0];
+    // The window is not the merge that just happened: it is every Pull Request merged into
+    // sourceBranchToUse since it was last promoted to targetBranchToUse.
+    uxLog("log", this, c.grey(`[GitProvider] ${t('pullRequestScopeBatchMerge', {
+      sourceBranch: pullRequestInfo.sourceBranch,
+      windowBranch: sourceBranchToUse,
+      nextBranch: targetBranchToUse,
+    })}`));
   }
   // Recursively find all child branches of the target branch
   // Ex: if targetbranchToUse is uat, we'll retrieve [integration]

--- a/src/common/utils/pullRequestUtils.ts
+++ b/src/common/utils/pullRequestUtils.ts
@@ -83,6 +83,26 @@ export function isSinglePullRequestScope(sourceBranch: string, majorBranchNames:
   return !isMajorBranch && !isRetrofit(branchName);
 }
 
+/**
+ * Build the list of branches whose merged Pull Requests are candidates for a scope window.
+ *
+ * On top of the recursive child branches of the window's target branch, every major branch is
+ * included: matching is bounded by the window's commit SHAs, so a Pull Request merged into an
+ * upstream branch (ex: a hotfix merged into main) is only collected when its merge commit
+ * actually arrived in the window - which is exactly what happens when a retrofit branch brings
+ * main's commits down to integration. Without the upstream branches in the list, those Pull
+ * Requests would never be fetched, and their actions would never be replayed downstream.
+ *
+ * excludeBranch removes the branch the git provider already adds by itself to the search list,
+ * to avoid fetching the same branch's Pull Requests twice.
+ */
+export function buildPrSearchBranches(targetBranch: string, majorOrgs: any[], excludeBranch: string): string[] {
+  const childBranchesNames = recursiveGetChildBranches(targetBranch, majorOrgs);
+  const allBranches = new Set<string>([...childBranchesNames, ...majorOrgs.map((o) => o.branchName)]);
+  allBranches.delete(excludeBranch);
+  return [...allBranches];
+}
+
 export async function listAllPullRequestsForCurrentScope(checkOnly: boolean): Promise<CommonPullRequestInfo[]> {
   if (_cachedPullRequests) {
     return _cachedPullRequests;
@@ -127,9 +147,37 @@ export async function listAllPullRequestsForCurrentScope(checkOnly: boolean): Pr
       _cachedPullRequests = [pullRequestInfo];
       return _cachedPullRequests;
     }
+    // Topmost branch (ex: production): there is no downstream promotion to anchor a window on,
+    // so the scope is the batch of Pull Requests carried by the merge itself (the "go live").
+    // Actions and test classes MUST also be processed on the production deployment, in the orgs
+    // where they have not been performed yet.
     if (!prTargetOrgDef.mergeTargets || prTargetOrgDef.mergeTargets.length === 0) {
-      uxLog("warning", this, c.yellow(`[GitProvider] No merge targets defined for target branch ${prTargetOrgDef.branchName}, cannot retrieve pull requests.`));
-      return [];
+      let goLivePullRequests: CommonPullRequestInfo[] = [];
+      if (pullRequestInfo.mergeCommitSha) {
+        uxLog("log", this, c.grey(`[GitProvider] ${t('pullRequestScopeGoLiveMerge', {
+          sourceBranch: pullRequestInfo.sourceBranch,
+          targetBranch: pullRequestInfo.targetBranch,
+        })}`));
+        const goLiveSearchBranches = buildPrSearchBranches(pullRequestInfo.targetBranch, majorOrgs, pullRequestInfo.targetBranch);
+        goLivePullRequests = await gitProvider.listPullRequestsInGoLive(
+          pullRequestInfo.targetBranch,
+          goLiveSearchBranches,
+          pullRequestInfo.mergeCommitSha,
+        );
+        goLivePullRequests.reverse(); // Oldest PR first
+      }
+      else {
+        uxLog("warning", this, c.yellow(`[GitProvider] ${t('pullRequestScopeGoLiveNoMergeCommit', {
+          targetBranch: pullRequestInfo.targetBranch,
+          pr: pullRequestInfo.idStr,
+        })}`));
+      }
+      // Always keep at least the merged Pull Request itself in the scope
+      if (!goLivePullRequests.some(pr => pr.idStr === pullRequestInfo.idStr)) {
+        goLivePullRequests.push(pullRequestInfo);
+      }
+      _cachedPullRequests = goLivePullRequests;
+      return _cachedPullRequests;
     }
     // ex: integration
     sourceBranchToUse = prTargetOrgDef.branchName;
@@ -143,16 +191,15 @@ export async function listAllPullRequestsForCurrentScope(checkOnly: boolean): Pr
       nextBranch: targetBranchToUse,
     })}`));
   }
-  // Recursively find all child branches of the target branch
-  // Ex: if targetbranchToUse is uat, we'll retrieve [integration]
-  const childBranchesNames = recursiveGetChildBranches(
-    targetBranchToUse,
-    majorOrgs,
-  );
+  // Child branches of the window's target branch, plus every major branch so Pull Requests
+  // merged upstream (ex: hotfixes in main arriving through a retrofit) are collected too.
+  // Ex: if targetBranchToUse is uat and sourceBranchToUse is integration, this returns
+  // [uat, preprod, main] - integration is left out because the provider prepends it itself.
+  const searchBranches = buildPrSearchBranches(targetBranchToUse, majorOrgs, sourceBranchToUse);
   const pullRequests = await gitProvider.listPullRequestsInBranchSinceLastMerge(
     sourceBranchToUse,
     targetBranchToUse,
-    [...childBranchesNames]
+    searchBranches
   );
   pullRequests.reverse(); // Oldest PR first
   // Add current PR if not already present

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -2489,6 +2489,8 @@
   "publishingPagesToConfluence": "{{count}} Seiten werden auf Confluence veröffentlicht...",
   "pullCommandDidNotReturnExpectedResults": "Pull-Befehl hat keine erwarteten Ergebnisse zurückgegeben\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Neueste Änderungen aus der Org abrufen, um Dateien zu stagen und Ihren commit zu erstellen",
+  "pullRequestScopeBatchMerge": "Merge vom Branch {{sourceBranch}}: die Deployment-Aktionen und Apex-Testklassen jedes Pull Requests, der seit dem letzten Merge von {{windowBranch}} nach {{nextBranch}} in {{windowBranch}} gemergt wurde, werden verarbeitet",
+  "pullRequestScopeFeatureBranchMerge": "Merge vom Feature-Branch {{sourceBranch}}: es werden nur die Deployment-Aktionen und Apex-Testklassen verarbeitet, die im Pull Request {{pr}} definiert sind",
   "pullingAllLatestMetadataChangesFromDevOrg": "Alle neuesten Metadaten-Änderungen aus der Entwicklungs-Org werden in lokale Projektdateien abgerufen (einschließlich Änderungen anderer Benutzer)",
   "pullingMetadataChangesFromOrg": "Metadaten-Änderungen aus der Org werden abgerufen: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Neueste Version des Remote-Branches {{mergeBranch}} wird abgerufen...",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -2491,6 +2491,8 @@
   "pullLatestUpdatesFromOrgToStageAndCommit": "Neueste Änderungen aus der Org abrufen, um Dateien zu stagen und Ihren commit zu erstellen",
   "pullRequestScopeBatchMerge": "Merge vom Branch {{sourceBranch}}: die Deployment-Aktionen und Apex-Testklassen jedes Pull Requests, der seit dem letzten Merge von {{windowBranch}} nach {{nextBranch}} in {{windowBranch}} gemergt wurde, werden verarbeitet",
   "pullRequestScopeFeatureBranchMerge": "Merge vom Feature-Branch {{sourceBranch}}: es werden nur die Deployment-Aktionen und Apex-Testklassen verarbeitet, die im Pull Request {{pr}} definiert sind",
+  "pullRequestScopeGoLiveMerge": "Merge vom Branch {{sourceBranch}} in den obersten Branch {{targetBranch}}: die Deployment-Aktionen und Apex-Testklassen jedes von diesem Merge getragenen Pull Requests werden verarbeitet",
+  "pullRequestScopeGoLiveNoMergeCommit": "Kein Merge-Commit für den in {{targetBranch}} gemergten Pull Request {{pr}} gefunden: es werden nur die Deployment-Aktionen und Apex-Testklassen dieses Pull Requests verarbeitet",
   "pullingAllLatestMetadataChangesFromDevOrg": "Alle neuesten Metadaten-Änderungen aus der Entwicklungs-Org werden in lokale Projektdateien abgerufen (einschließlich Änderungen anderer Benutzer)",
   "pullingMetadataChangesFromOrg": "Metadaten-Änderungen aus der Org werden abgerufen: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Neueste Version des Remote-Branches {{mergeBranch}} wird abgerufen...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2496,6 +2496,8 @@
   "pullLatestUpdatesFromOrgToStageAndCommit": "Pull latest updates from org so you can stage files and create your commit",
   "pullRequestScopeBatchMerge": "Merge from branch {{sourceBranch}}: the deployment actions and Apex test classes of every Pull Request merged into {{windowBranch}} since its last merge into {{nextBranch}} will be processed",
   "pullRequestScopeFeatureBranchMerge": "Merge from feature branch {{sourceBranch}}: only the deployment actions and Apex test classes defined on Pull Request {{pr}} will be processed",
+  "pullRequestScopeGoLiveMerge": "Merge from branch {{sourceBranch}} into topmost branch {{targetBranch}}: the deployment actions and Apex test classes of every Pull Request carried by this merge will be processed",
+  "pullRequestScopeGoLiveNoMergeCommit": "No merge commit found for Pull Request {{pr}} merged into {{targetBranch}}: only this Pull Request's deployment actions and Apex test classes will be processed",
   "pullingAllLatestMetadataChangesFromDevOrg": "Pulling all latest metadata changes from dev org to local project files (including changes by other users)",
   "pullingMetadataChangesFromOrg": "Pulling metadata changes from org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Pulling most recent version of remote branch {{mergeBranch}}...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2494,6 +2494,8 @@
   "publishingPagesToConfluence": "Publishing {{count}} pages to Confluence...",
   "pullCommandDidNotReturnExpectedResults": "Pull command did not return expected results\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Pull latest updates from org so you can stage files and create your commit",
+  "pullRequestScopeBatchMerge": "Merge from branch {{sourceBranch}}: the deployment actions and Apex test classes of every Pull Request merged into {{windowBranch}} since its last merge into {{nextBranch}} will be processed",
+  "pullRequestScopeFeatureBranchMerge": "Merge from feature branch {{sourceBranch}}: only the deployment actions and Apex test classes defined on Pull Request {{pr}} will be processed",
   "pullingAllLatestMetadataChangesFromDevOrg": "Pulling all latest metadata changes from dev org to local project files (including changes by other users)",
   "pullingMetadataChangesFromOrg": "Pulling metadata changes from org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Pulling most recent version of remote branch {{mergeBranch}}...",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2492,6 +2492,8 @@
   "pullLatestUpdatesFromOrgToStageAndCommit": "Obtenga las últimas actualizaciones de la org para preparar los archivos (stage) y crear el commit",
   "pullRequestScopeBatchMerge": "Merge desde la branch {{sourceBranch}}: se procesarán las acciones de despliegue y las clases de test Apex de todas las Pull Requests fusionadas en {{windowBranch}} desde su último merge a {{nextBranch}}",
   "pullRequestScopeFeatureBranchMerge": "Merge desde la branch de funcionalidad {{sourceBranch}}: solo se procesarán las acciones de despliegue y las clases de test Apex definidas en la Pull Request {{pr}}",
+  "pullRequestScopeGoLiveMerge": "Merge desde la branch {{sourceBranch}} a la branch final {{targetBranch}}: se procesarán las acciones de despliegue y las clases de test Apex de cada Pull Request incluida en este merge",
+  "pullRequestScopeGoLiveNoMergeCommit": "No se ha encontrado el commit de merge de la Pull Request {{pr}} fusionada en {{targetBranch}}: solo se procesarán las acciones de despliegue y las clases de test Apex de esta Pull Request",
   "pullingAllLatestMetadataChangesFromDevOrg": "Obteniendo los últimos cambios de metadatos desde la org de desarrollo (incluidos cambios de otros usuarios)",
   "pullingMetadataChangesFromOrg": "Obteniendo cambios de metadatos desde la org {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Obteniendo la versión más reciente de la branch remota {{mergeBranch}}...",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2490,6 +2490,8 @@
   "publishingPagesToConfluence": "Publicando {{count}} páginas en Confluence...",
   "pullCommandDidNotReturnExpectedResults": "El comando pull no devolvió los resultados esperados\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Obtenga las últimas actualizaciones de la org para preparar los archivos (stage) y crear el commit",
+  "pullRequestScopeBatchMerge": "Merge desde la branch {{sourceBranch}}: se procesarán las acciones de despliegue y las clases de test Apex de todas las Pull Requests fusionadas en {{windowBranch}} desde su último merge a {{nextBranch}}",
+  "pullRequestScopeFeatureBranchMerge": "Merge desde la branch de funcionalidad {{sourceBranch}}: solo se procesarán las acciones de despliegue y las clases de test Apex definidas en la Pull Request {{pr}}",
   "pullingAllLatestMetadataChangesFromDevOrg": "Obteniendo los últimos cambios de metadatos desde la org de desarrollo (incluidos cambios de otros usuarios)",
   "pullingMetadataChangesFromOrg": "Obteniendo cambios de metadatos desde la org {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Obteniendo la versión más reciente de la branch remota {{mergeBranch}}...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2492,6 +2492,8 @@
   "pullLatestUpdatesFromOrgToStageAndCommit": "Récupérez les dernières mises à jour de l'org pour pouvoir staged les fichiers et créer votre commit",
   "pullRequestScopeBatchMerge": "Merge depuis la branche {{sourceBranch}} : les actions de déploiement et les classes de test Apex de toutes les Pull Requests fusionnées dans {{windowBranch}} depuis son dernier merge vers {{nextBranch}} seront traitées",
   "pullRequestScopeFeatureBranchMerge": "Merge depuis la branche de fonctionnalité {{sourceBranch}} : seules les actions de déploiement et les classes de test Apex définies sur la Pull Request {{pr}} seront traitées",
+  "pullRequestScopeGoLiveMerge": "Merge depuis la branche {{sourceBranch}} vers la branche finale {{targetBranch}} : les actions de déploiement et les classes de test Apex de chaque Pull Request incluse dans ce merge seront traitées",
+  "pullRequestScopeGoLiveNoMergeCommit": "Aucun commit de merge trouvé pour la Pull Request {{pr}} fusionnée dans {{targetBranch}} : seules les actions de déploiement et les classes de test Apex de cette Pull Request seront traitées",
   "pullingAllLatestMetadataChangesFromDevOrg": "Récupération de toutes les dernières modifications de métadonnées depuis l'org de développement (y compris les modifications d'autres utilisateurs)",
   "pullingMetadataChangesFromOrg": "Récupération des changements de métadonnées depuis l'org : {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Récupération de la version la plus récente de la branche distante {{mergeBranch}}...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2490,6 +2490,8 @@
   "publishingPagesToConfluence": "Publication de {{count}} pages sur Confluence...",
   "pullCommandDidNotReturnExpectedResults": "La commande pull n'a pas retourné les résultats attendus\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Récupérez les dernières mises à jour de l'org pour pouvoir staged les fichiers et créer votre commit",
+  "pullRequestScopeBatchMerge": "Merge depuis la branche {{sourceBranch}} : les actions de déploiement et les classes de test Apex de toutes les Pull Requests fusionnées dans {{windowBranch}} depuis son dernier merge vers {{nextBranch}} seront traitées",
+  "pullRequestScopeFeatureBranchMerge": "Merge depuis la branche de fonctionnalité {{sourceBranch}} : seules les actions de déploiement et les classes de test Apex définies sur la Pull Request {{pr}} seront traitées",
   "pullingAllLatestMetadataChangesFromDevOrg": "Récupération de toutes les dernières modifications de métadonnées depuis l'org de développement (y compris les modifications d'autres utilisateurs)",
   "pullingMetadataChangesFromOrg": "Récupération des changements de métadonnées depuis l'org : {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Récupération de la version la plus récente de la branche distante {{mergeBranch}}...",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -2492,6 +2492,8 @@
   "pullLatestUpdatesFromOrgToStageAndCommit": "Recupera gli ultimi aggiornamenti dalla org per poter mettere in stage i file e creare il tuo commit",
   "pullRequestScopeBatchMerge": "Merge dal branch {{sourceBranch}}: verranno elaborate le azioni di distribuzione e le classi di test Apex di ogni Pull Request unita in {{windowBranch}} dall'ultimo merge verso {{nextBranch}}",
   "pullRequestScopeFeatureBranchMerge": "Merge dal branch di funzionalità {{sourceBranch}}: verranno elaborate solo le azioni di distribuzione e le classi di test Apex definite sulla Pull Request {{pr}}",
+  "pullRequestScopeGoLiveMerge": "Merge dal branch {{sourceBranch}} al branch finale {{targetBranch}}: verranno elaborate le azioni di distribuzione e le classi di test Apex di ogni Pull Request inclusa in questo merge",
+  "pullRequestScopeGoLiveNoMergeCommit": "Nessun commit di merge trovato per la Pull Request {{pr}} unita in {{targetBranch}}: verranno elaborate solo le azioni di distribuzione e le classi di test Apex di questa Pull Request",
   "pullingAllLatestMetadataChangesFromDevOrg": "Recupero di tutte le ultime modifiche ai metadati dalla dev org ai file di progetto locali (incluse le modifiche di altri utenti)",
   "pullingMetadataChangesFromOrg": "Recupero modifiche ai metadati dalla org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Recupero della versione più recente del branch remoto {{mergeBranch}}...",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -2490,6 +2490,8 @@
   "publishingPagesToConfluence": "Pubblicazione di {{count}} pagine su Confluence...",
   "pullCommandDidNotReturnExpectedResults": "Il comando pull non ha restituito i risultati attesi\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Recupera gli ultimi aggiornamenti dalla org per poter mettere in stage i file e creare il tuo commit",
+  "pullRequestScopeBatchMerge": "Merge dal branch {{sourceBranch}}: verranno elaborate le azioni di distribuzione e le classi di test Apex di ogni Pull Request unita in {{windowBranch}} dall'ultimo merge verso {{nextBranch}}",
+  "pullRequestScopeFeatureBranchMerge": "Merge dal branch di funzionalità {{sourceBranch}}: verranno elaborate solo le azioni di distribuzione e le classi di test Apex definite sulla Pull Request {{pr}}",
   "pullingAllLatestMetadataChangesFromDevOrg": "Recupero di tutte le ultime modifiche ai metadati dalla dev org ai file di progetto locali (incluse le modifiche di altri utenti)",
   "pullingMetadataChangesFromOrg": "Recupero modifiche ai metadati dalla org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Recupero della versione più recente del branch remoto {{mergeBranch}}...",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -2490,6 +2490,8 @@
   "pullLatestUpdatesFromOrgToStageAndCommit": "組織から最新の更新をpullして、ファイルをステージしてcommitを作成してください",
   "pullRequestScopeBatchMerge": "branch {{sourceBranch}} からの merge です。{{windowBranch}} から {{nextBranch}} への前回の merge 以降に {{windowBranch}} にマージされたすべての Pull Request のデプロイアクションと Apex テストクラスが処理されます",
   "pullRequestScopeFeatureBranchMerge": "機能 branch {{sourceBranch}} からの merge です。Pull Request {{pr}} で定義されたデプロイアクションと Apex テストクラスのみが処理されます",
+  "pullRequestScopeGoLiveMerge": "branch {{sourceBranch}} から最上位 branch {{targetBranch}} への merge です。この merge に含まれるすべての Pull Request のデプロイアクションと Apex テストクラスが処理されます",
+  "pullRequestScopeGoLiveNoMergeCommit": "{{targetBranch}} にマージされた Pull Request {{pr}} の merge コミットが見つかりません。この Pull Request のデプロイアクションと Apex テストクラスのみが処理されます",
   "pullingAllLatestMetadataChangesFromDevOrg": "開発組織からローカルプロジェクトファイルへすべての最新メタデータ変更をpullしています（他のユーザーによる変更を含む）",
   "pullingMetadataChangesFromOrg": "組織からメタデータの変更をpullしています：{{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "リモートbranch {{mergeBranch}} の最新バージョンをpullしています...",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -2488,6 +2488,8 @@
   "publishingPagesToConfluence": "{{count}} ページを Confluence に公開しています...",
   "pullCommandDidNotReturnExpectedResults": "pullコマンドが期待された結果を返しませんでした\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "組織から最新の更新をpullして、ファイルをステージしてcommitを作成してください",
+  "pullRequestScopeBatchMerge": "branch {{sourceBranch}} からの merge です。{{windowBranch}} から {{nextBranch}} への前回の merge 以降に {{windowBranch}} にマージされたすべての Pull Request のデプロイアクションと Apex テストクラスが処理されます",
+  "pullRequestScopeFeatureBranchMerge": "機能 branch {{sourceBranch}} からの merge です。Pull Request {{pr}} で定義されたデプロイアクションと Apex テストクラスのみが処理されます",
   "pullingAllLatestMetadataChangesFromDevOrg": "開発組織からローカルプロジェクトファイルへすべての最新メタデータ変更をpullしています（他のユーザーによる変更を含む）",
   "pullingMetadataChangesFromOrg": "組織からメタデータの変更をpullしています：{{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "リモートbranch {{mergeBranch}} の最新バージョンをpullしています...",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -2490,6 +2490,8 @@
   "publishingPagesToConfluence": "{{count}} pagina's worden gepubliceerd naar Confluence...",
   "pullCommandDidNotReturnExpectedResults": "Pull-commando heeft geen verwachte resultaten teruggegeven\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Haal de nieuwste updates op uit de org zodat je bestanden kunt stagen en je commit kunt aanmaken",
+  "pullRequestScopeBatchMerge": "Merge vanaf branch {{sourceBranch}}: de deploy-acties en Apex-testklassen van elke Pull Request die sinds de laatste merge van {{windowBranch}} naar {{nextBranch}} in {{windowBranch}} is gemerged worden verwerkt",
+  "pullRequestScopeFeatureBranchMerge": "Merge vanaf feature branch {{sourceBranch}}: alleen de deploy-acties en Apex-testklassen die op Pull Request {{pr}} zijn gedefinieerd worden verwerkt",
   "pullingAllLatestMetadataChangesFromDevOrg": "Alle nieuwste metadatawijzigingen worden opgehaald van de dev-org naar lokale projectbestanden (inclusief wijzigingen door andere gebruikers)",
   "pullingMetadataChangesFromOrg": "Metadatawijzigingen worden opgehaald van org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Meest recente versie van remote branch {{mergeBranch}} wordt opgehaald...",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -2492,6 +2492,8 @@
   "pullLatestUpdatesFromOrgToStageAndCommit": "Haal de nieuwste updates op uit de org zodat je bestanden kunt stagen en je commit kunt aanmaken",
   "pullRequestScopeBatchMerge": "Merge vanaf branch {{sourceBranch}}: de deploy-acties en Apex-testklassen van elke Pull Request die sinds de laatste merge van {{windowBranch}} naar {{nextBranch}} in {{windowBranch}} is gemerged worden verwerkt",
   "pullRequestScopeFeatureBranchMerge": "Merge vanaf feature branch {{sourceBranch}}: alleen de deploy-acties en Apex-testklassen die op Pull Request {{pr}} zijn gedefinieerd worden verwerkt",
+  "pullRequestScopeGoLiveMerge": "Merge vanaf branch {{sourceBranch}} naar de hoogste branch {{targetBranch}}: de deploy-acties en Apex-testklassen van elke Pull Request in deze merge worden verwerkt",
+  "pullRequestScopeGoLiveNoMergeCommit": "Geen merge-commit gevonden voor Pull Request {{pr}} gemerged in {{targetBranch}}: alleen de deploy-acties en Apex-testklassen van deze Pull Request worden verwerkt",
   "pullingAllLatestMetadataChangesFromDevOrg": "Alle nieuwste metadatawijzigingen worden opgehaald van de dev-org naar lokale projectbestanden (inclusief wijzigingen door andere gebruikers)",
   "pullingMetadataChangesFromOrg": "Metadatawijzigingen worden opgehaald van org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Meest recente versie van remote branch {{mergeBranch}} wordt opgehaald...",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -2490,6 +2490,8 @@
   "publishingPagesToConfluence": "Publikowanie {{count}} stron w Confluence...",
   "pullCommandDidNotReturnExpectedResults": "Polecenie pull nie zwróciło oczekiwanych wyników\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Pobierz najnowsze aktualizacje z org, aby móc przygotować pliki i utworzyć commit",
+  "pullRequestScopeBatchMerge": "Merge z branch {{sourceBranch}}: przetworzone zostaną akcje wdrożeniowe i klasy testowe Apex każdego Pull Requesta scalonego do {{windowBranch}} od jego ostatniego merge do {{nextBranch}}",
+  "pullRequestScopeFeatureBranchMerge": "Merge z branch funkcjonalności {{sourceBranch}}: przetworzone zostaną wyłącznie akcje wdrożeniowe i klasy testowe Apex zdefiniowane w Pull Request {{pr}}",
   "pullingAllLatestMetadataChangesFromDevOrg": "Pobieranie wszystkich najnowszych zmian metadanych z dev org do lokalnych plików projektu (w tym zmian innych użytkowników)",
   "pullingMetadataChangesFromOrg": "Pobieranie zmian metadanych z org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Pobieranie najnowszej wersji zdalnej gałęzi {{mergeBranch}}...",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -2492,6 +2492,8 @@
   "pullLatestUpdatesFromOrgToStageAndCommit": "Pobierz najnowsze aktualizacje z org, aby móc przygotować pliki i utworzyć commit",
   "pullRequestScopeBatchMerge": "Merge z branch {{sourceBranch}}: przetworzone zostaną akcje wdrożeniowe i klasy testowe Apex każdego Pull Requesta scalonego do {{windowBranch}} od jego ostatniego merge do {{nextBranch}}",
   "pullRequestScopeFeatureBranchMerge": "Merge z branch funkcjonalności {{sourceBranch}}: przetworzone zostaną wyłącznie akcje wdrożeniowe i klasy testowe Apex zdefiniowane w Pull Request {{pr}}",
+  "pullRequestScopeGoLiveMerge": "Merge z branch {{sourceBranch}} do najwyższego branch {{targetBranch}}: przetworzone zostaną akcje wdrożeniowe i klasy testowe Apex każdego Pull Requesta objętego tym merge",
+  "pullRequestScopeGoLiveNoMergeCommit": "Nie znaleziono commita merge dla Pull Requesta {{pr}} scalonego do {{targetBranch}}: przetworzone zostaną wyłącznie akcje wdrożeniowe i klasy testowe Apex tego Pull Requesta",
   "pullingAllLatestMetadataChangesFromDevOrg": "Pobieranie wszystkich najnowszych zmian metadanych z dev org do lokalnych plików projektu (w tym zmian innych użytkowników)",
   "pullingMetadataChangesFromOrg": "Pobieranie zmian metadanych z org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Pobieranie najnowszej wersji zdalnej gałęzi {{mergeBranch}}...",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -2457,6 +2457,8 @@
   "prStatusOpen": "Aberto",
   "publishingPagesToConfluence": "Publicando {{count}} páginas no Confluence...",
   "pullCommandDidNotReturnExpectedResults": "O comando pull não retornou os resultados esperados\n{{JSON}}",
+  "pullRequestScopeBatchMerge": "Merge a partir da branch {{sourceBranch}}: as ações de deploy e as classes de teste Apex de cada Pull Request mesclado em {{windowBranch}} desde o seu último merge para {{nextBranch}} serão processadas",
+  "pullRequestScopeFeatureBranchMerge": "Merge a partir da branch de funcionalidade {{sourceBranch}}: somente as ações de deploy e as classes de teste Apex definidas no Pull Request {{pr}} serão processadas",
   "pullingAllLatestMetadataChangesFromDevOrg": "Obtendo todas as últimas alterações de metadados da org de desenvolvimento para os arquivos do projeto local (incluindo alterações de outros usuários)",
   "pullingMetadataChangesFromOrg": "Obtendo alterações de metadados da org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Obtendo a versão mais recente da branch remota {{mergeBranch}}...",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -2459,6 +2459,8 @@
   "pullCommandDidNotReturnExpectedResults": "O comando pull não retornou os resultados esperados\n{{JSON}}",
   "pullRequestScopeBatchMerge": "Merge a partir da branch {{sourceBranch}}: as ações de deploy e as classes de teste Apex de cada Pull Request mesclado em {{windowBranch}} desde o seu último merge para {{nextBranch}} serão processadas",
   "pullRequestScopeFeatureBranchMerge": "Merge a partir da branch de funcionalidade {{sourceBranch}}: somente as ações de deploy e as classes de teste Apex definidas no Pull Request {{pr}} serão processadas",
+  "pullRequestScopeGoLiveMerge": "Merge a partir da branch {{sourceBranch}} para a branch final {{targetBranch}}: as ações de deploy e as classes de teste Apex de cada Pull Request incluído neste merge serão processadas",
+  "pullRequestScopeGoLiveNoMergeCommit": "Nenhum commit de merge encontrado para o Pull Request {{pr}} mesclado em {{targetBranch}}: somente as ações de deploy e as classes de teste Apex deste Pull Request serão processadas",
   "pullingAllLatestMetadataChangesFromDevOrg": "Obtendo todas as últimas alterações de metadados da org de desenvolvimento para os arquivos do projeto local (incluindo alterações de outros usuários)",
   "pullingMetadataChangesFromOrg": "Obtendo alterações de metadados da org: {{targetUsername}}",
   "pullingMostRecentVersionOfRemoteBranch": "Obtendo a versão mais recente da branch remota {{mergeBranch}}...",

--- a/test/common/utils/pullRequestScope.test.ts
+++ b/test/common/utils/pullRequestScope.test.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import { expect } from 'chai';
+import { isRetrofit } from '../../../src/common/utils/orgConfigUtils.js';
+import { isSinglePullRequestScope } from '../../../src/common/utils/pullRequestUtils.js';
+
+const MAJOR_BRANCHES = ['main', 'preprod', 'uat', 'integration'];
+
+describe('isRetrofit()', () => {
+  it('recognizes a retrofit branch', () => {
+    expect(isRetrofit('retrofit/from-main')).to.equal(true);
+    expect(isRetrofit('retrofit')).to.equal(true);
+  });
+
+  it('is case insensitive, like the other branch classifiers', () => {
+    expect(isRetrofit('Retrofit/From-Main')).to.equal(true);
+    expect(isRetrofit('RETROFIT/from-main')).to.equal(true);
+  });
+
+  it('only matches the retrofit/<name> convention', () => {
+    expect(isRetrofit('feature/retrofit-the-thing')).to.equal(false);
+    expect(isRetrofit('integration')).to.equal(false);
+    // An ordinary branch that merely starts with the word must not take the batch scope
+    expect(isRetrofit('retrofit-JIRA-123')).to.equal(false);
+    expect(isRetrofit('retrofitting-legacy')).to.equal(false);
+  });
+
+  it('handles an empty branch name', () => {
+    expect(isRetrofit('')).to.equal(false);
+  });
+});
+
+describe('isSinglePullRequestScope()', () => {
+  it('scopes a feature branch merge to the merged Pull Request', () => {
+    expect(isSinglePullRequestScope('feature/my-feature', MAJOR_BRANCHES)).to.equal(true);
+    expect(isSinglePullRequestScope('fix/my-fix', MAJOR_BRANCHES)).to.equal(true);
+    expect(isSinglePullRequestScope('hotfix/urgent', MAJOR_BRANCHES)).to.equal(true);
+  });
+
+  // A major branch merge carries every Pull Request merged upstream since the previous merge.
+  it('keeps the whole batch for a merge between major branches', () => {
+    expect(isSinglePullRequestScope('integration', MAJOR_BRANCHES)).to.equal(false);
+    expect(isSinglePullRequestScope('uat', MAJOR_BRANCHES)).to.equal(false);
+    expect(isSinglePullRequestScope('main', MAJOR_BRANCHES)).to.equal(false);
+  });
+
+  // Retrofitting main down to integration must replay what already ran in main.
+  it('keeps the whole batch for a merge from a retrofit branch', () => {
+    expect(isSinglePullRequestScope('retrofit/from-main', MAJOR_BRANCHES)).to.equal(false);
+    expect(isSinglePullRequestScope('retrofit/from-preprod', MAJOR_BRANCHES)).to.equal(false);
+  });
+
+  it('does not treat a feature branch named after a major branch as major', () => {
+    expect(isSinglePullRequestScope('feature/integration-tests', MAJOR_BRANCHES)).to.equal(true);
+  });
+
+  // Some providers do not expose the source branch on a push-triggered deployment. Narrowing the
+  // scope there would silently drop every upstream Pull Request, so keep the previous behavior.
+  it('keeps the whole batch when the source branch is unknown', () => {
+    expect(isSinglePullRequestScope('', MAJOR_BRANCHES)).to.equal(false);
+  });
+
+  it('matches major branch names without case, like the other branch classifiers', () => {
+    expect(isSinglePullRequestScope('Integration', MAJOR_BRANCHES)).to.equal(false);
+    expect(isSinglePullRequestScope('integration', ['Integration', 'UAT'])).to.equal(false);
+  });
+
+  it('treats every named branch as a feature branch when no major branch is configured', () => {
+    expect(isSinglePullRequestScope('integration', [])).to.equal(true);
+    expect(isSinglePullRequestScope('retrofit/from-main', [])).to.equal(false);
+  });
+});

--- a/test/common/utils/pullRequestScope.test.ts
+++ b/test/common/utils/pullRequestScope.test.ts
@@ -1,9 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { expect } from 'chai';
 import { isRetrofit } from '../../../src/common/utils/orgConfigUtils.js';
-import { isSinglePullRequestScope } from '../../../src/common/utils/pullRequestUtils.js';
+import { buildPrSearchBranches, isSinglePullRequestScope } from '../../../src/common/utils/pullRequestUtils.js';
 
 const MAJOR_BRANCHES = ['main', 'preprod', 'uat', 'integration'];
+
+const MAJOR_ORGS = [
+  { branchName: 'integration', mergeTargets: ['uat'] },
+  { branchName: 'uat', mergeTargets: ['preprod'] },
+  { branchName: 'preprod', mergeTargets: ['main'] },
+  { branchName: 'main', mergeTargets: [] },
+];
 
 describe('isRetrofit()', () => {
   it('recognizes a retrofit branch', () => {
@@ -67,5 +74,30 @@ describe('isSinglePullRequestScope()', () => {
   it('treats every named branch as a feature branch when no major branch is configured', () => {
     expect(isSinglePullRequestScope('integration', [])).to.equal(true);
     expect(isSinglePullRequestScope('retrofit/from-main', [])).to.equal(false);
+  });
+});
+
+describe('buildPrSearchBranches()', () => {
+  // Upstream branches must be searched too: a hotfix Pull Request merged into main can only be
+  // collected after a retrofit if main is part of the search list.
+  it('includes every major branch, not just the children of the window target', () => {
+    const branches = buildPrSearchBranches('uat', MAJOR_ORGS, 'integration');
+    expect(branches).to.have.members(['uat', 'preprod', 'main']);
+  });
+
+  it('excludes the branch the git provider already searches by itself', () => {
+    const branches = buildPrSearchBranches('preprod', MAJOR_ORGS, 'uat');
+    expect(branches).to.not.include('uat');
+    expect(branches).to.have.members(['integration', 'preprod', 'main']);
+  });
+
+  it('covers the go-live case: all major branches below and above the production branch', () => {
+    const branches = buildPrSearchBranches('main', MAJOR_ORGS, 'main');
+    expect(branches).to.have.members(['integration', 'uat', 'preprod']);
+  });
+
+  it('returns no duplicates when children and major branches overlap', () => {
+    const branches = buildPrSearchBranches('main', MAJOR_ORGS, 'preprod');
+    expect(branches).to.deep.equal([...new Set(branches)]);
   });
 });


### PR DESCRIPTION
## Goal

In every use case, on every platform, deployment actions and selected Apex test classes must be collected by check-deploy and process-deploy jobs, so they run in each major org where they have not been performed yet - production included.

> This PR also contains the commits of #2055, which was merged into this branch.

## Problem

`listAllPullRequestsForCurrentScope` (`src/common/utils/pullRequestUtils.ts`) discards the merged Pull Request in deployment mode and re-derives the scope from the branch strategy. Merging `feature/x -> integration` collected every Pull Request merged into `integration` since the last `integration -> uat` promotion: one feature merge could run an action belonging to another Pull Request and attribute it to the wrong one in the Slack notification and in the Pull Request comment.

An audit of the whole scope-collection engine then found three more holes:

| # | Use case | Check deploy | Process deploy |
|---|---|---|---|
| 1 | `feature/x -> integration` | ok | **wrong scope: whole batch** |
| 2 | `integration -> uat`, `uat -> preprod` | ok | ok |
| 3 | `preprod -> main` (go-live) | ok | **broken: empty scope** |
| 4 | `hotfix/x -> main` direct | ok | **broken: empty scope** |
| 5 | `retrofit/from-main -> integration` | **upstream PRs missing** | **upstream PRs missing** |
| 6 | any process deploy on GitHub (push-triggered) | n/a | **engine never engages** |

The `runOnlyOnceByOrg` state tracking itself is sound: once a Pull Request is in scope, its actions run only in the orgs where they have not yet. All defects were in scope collection.

## Fixes

**Feature merges are scoped to the merged Pull Request.** When the merged Pull Request's source branch is neither a major branch (has a `config/branches/.sfdx-hardis.<branch>.yml`, compared without case) nor a `retrofit/*` branch, the scope is that Pull Request alone. Merges between major branches keep the batch. The decision lives at collection time, so actions, test classes, the deployment notification, the Pull Request comment and the per-PR "Deployment Actions" state comment all follow it with no filter of their own.

**Go-live merges collect the batch they carry.** A production branch has no `mergeTargets` to anchor a window on, so a `preprod -> main` merge used to return an empty scope: nothing ran on the go-live deployment. The scope is now the batch of Pull Requests carried by the merge itself, through the existing `listPullRequestsInGoLive` provider method (implemented identically by all 4 providers), bounded by the merge commit's first parent so hotfixes merged at other times are excluded. When the merge commit is unknown, the scope falls back to the merged Pull Request alone, never to nothing. Direct `hotfix/x -> main` merges are covered by the feature-merge scoping.

**Upstream Pull Requests are collected when their commits arrive.** The window collectors only fetched Pull Requests whose base is the window branch or one of its children, so a hotfix merged into `main` was invisible to a `retrofit/from-main -> integration` merge. Every major branch is now part of the search list (`buildPrSearchBranches`), in check and deploy modes and in the go-live path. Safe by construction: a Pull Request only matches when its merge commit is inside the window's commit SHAs. Its actions then replay in each downstream org as promotions propagate, deduplicated per org by the state tracking.

**GitHub push-triggered deployments resolve their Pull Request.** Without a Pull Request number, the GraphQL commit lookup selected neither the head and base ref names nor the merge commit, so the resolved Pull Request had empty source and target branches and scope resolution bailed out immediately: on GitHub, PR-scoped actions only ever ran in check jobs, never in process jobs. The query now selects those fields and maps them to the shape `completePullRequestInfo` reads, which also fixes the empty author name and web URL. GitLab, Azure DevOps and Bitbucket deploy-mode lookups were verified complete.

Two log lines state which scoping rule fired, so the decision is visible in every job log.

## Side effects worth noting

- The single Pull Request scope no longer depends on `mergeTargets` being configured: a feature merge into a major branch without merge targets used to collect nothing at all.
- If the deployment job of a feature branch fails, its actions are not picked up by the next merged Pull Request: re-run the failed job, or move the actions to a new Pull Request. Documented in the command description.

## Reviews

An initial code review caught four defects fixed before pushing (unknown-source-branch fallback, case-sensitive branch matching, over-broad retrofit prefix, misleading batch log). An ultrareview of the engine fixes found a single comment nit, also fixed.

## Tests

New `test/common/utils/pullRequestScope.test.ts`: `isRetrofit`, `isSinglePullRequestScope` and `buildPrSearchBranches` (feature / major / retrofit / go-live cases, case insensitivity, unknown source branch, upstream inclusion, dedup). `1084 passing`, lint and compile clean. Four new i18n keys in all 9 locales. Docs updated: scope table, mermaid flow, command descriptions.
