### PR TITLE
fix(work:save): propose to update the Pull Request when one is already open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - The `className`, `cronExpression` and `jobName` parameters of `schedule-batch` actions are now declared, instead of only being tolerated as extra keys.
 - [hardis:work:save](https://sfdx-hardis.cloudity.com/hardis/work/save/): The end of the command now displays an **Update the Deployment Actions of your Pull Request** button in VS Code, opening the DevOps Pipeline directly on the deployment actions of the Pull Request of your current branch (its draft actions when the Pull Request is not created yet). Requires VS Code extension **sfdx-hardis** v7.19.0 or later.
 - [hardis:work:save](https://sfdx-hardis.cloudity.com/hardis/work/save/): When a Pull Request is already open between your branch and its target branch, the end of the command now proposes to **Update Pull Request** and links to it, instead of proposing to create a new one.
+- Azure DevOps: Fix the links to Pull Requests created or found by sfdx-hardis, which opened the REST API response (raw JSON) instead of the Pull Request page.
 - Fix the Pull Request comment losing its result banner, its status title and its code coverage section when every item of the deployment package was filtered out before the deployment.
 - Pull Request comments now only mention what they actually contain: the scope paragraph names deployment actions and Apex test classes only when the Pull Request carries them, and each status legend lists only the statuses present in the table above it.
 - [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - `commandsPostDeploy` now accepts the `schedule-batch` action type, which was reported as invalid even though scheduling an Apex batch after a deployment is its normal use.
   - The `className`, `cronExpression` and `jobName` parameters of `schedule-batch` actions are now declared, instead of only being tolerated as extra keys.
 - [hardis:work:save](https://sfdx-hardis.cloudity.com/hardis/work/save/): The end of the command now displays an **Update the Deployment Actions of your Pull Request** button in VS Code, opening the DevOps Pipeline directly on the deployment actions of the Pull Request of your current branch (its draft actions when the Pull Request is not created yet). Requires VS Code extension **sfdx-hardis** v7.19.0 or later.
+- [hardis:work:save](https://sfdx-hardis.cloudity.com/hardis/work/save/): When a Pull Request is already open between your branch and its target branch, the end of the command now proposes to **Update Pull Request** and links to it, instead of proposing to create a new one.
 - Fix the Pull Request comment losing its result banner, its status title and its code coverage section when every item of the deployment package was filtered out before the deployment.
 - Pull Request comments now only mention what they actually contain: the scope paragraph names deployment actions and Apex test classes only when the Pull Request carries them, and each status legend lists only the statuses present in the table above it.
 - [hardis:project:deploy:smart](https://sfdx-hardis.cloudity.com/hardis/project/deploy/smart/):

--- a/src/commands/hardis/work/save.ts
+++ b/src/commands/hardis/work/save.ts
@@ -245,17 +245,23 @@ The command's technical implementation involves a series of orchestrated steps:
     await this.manageCommitPush(gitStatusWithConfig, gitStatusAfterDeployPlan);
 
 
-    let mergeRequestUrl = GitProvider.getMergeRequestCreateUrl(this.gitUrl, this.targetBranch || '', this.currentBranch);
+    // If a Pull Request is already open from the current branch to its target branch,
+    // point to it instead of proposing to create a new one
+    const existingPullRequest = await this.findExistingPullRequest();
+    let mergeRequestUrl = existingPullRequest ? existingPullRequest.pullRequestUrl : GitProvider.getMergeRequestCreateUrl(this.gitUrl, this.targetBranch || '', this.currentBranch);
     mergeRequestUrl = mergeRequestUrl || this.gitUrl.replace('.git', '');
+    const mergeRequestLabel = existingPullRequest
+      ? t('updateMergeRequestLabel', { mergeRequestName: GitProvider.getMergeRequestName(this.gitUrl) })
+      : t('createMergeRequestLabel', { mergeRequestName: GitProvider.getMergeRequestName(this.gitUrl) });
 
     // Merge request
     uxLog("action", this, c.cyan(t('ifYourWorkIsCreateOtherwisePush', { completed: c.bold(t('completed')), GitProvider: c.bold(GitProvider.getMergeRequestName(this.gitUrl)), currentBranch: c.green(this.currentBranch) })));
     let summaryMsg = c.grey("");
     if (WebSocketClient.isAliveWithLwcUI()) {
-      WebSocketClient.sendReportFileMessage(mergeRequestUrl, t('createMergeRequestLabel', { mergeRequestName: GitProvider.getMergeRequestName(this.gitUrl) }), 'actionUrl');
+      WebSocketClient.sendReportFileMessage(mergeRequestUrl, mergeRequestLabel, 'actionUrl');
     }
     else {
-      summaryMsg += c.grey(`- New ${GitProvider.getMergeRequestName(this.gitUrl)} URL: ${c.green(mergeRequestUrl)}\n`);
+      summaryMsg += c.grey(`- ${existingPullRequest ? 'Existing' : 'New'} ${GitProvider.getMergeRequestName(this.gitUrl)} URL: ${c.green(mergeRequestUrl)}\n`);
     }
     const mergeRequestDoc = `${CONSTANTS.DOC_URL_ROOT}/salesforce-ci-cd-publish-task/#create-merge-request`;
     summaryMsg += c.grey('- ' + t('repositoryLabel') + ': ' + c.green(this.gitUrl.replace('.git', '')) + '\n');
@@ -299,6 +305,23 @@ The command's technical implementation involves a series of orchestrated steps:
     }
     // Return an object to be displayed with --json
     return { outputString: 'Saved the User Story' };
+  }
+
+  // Returns the Pull Request already open between the current branch and its target branch, if there is one
+  private async findExistingPullRequest(): Promise<{ pullRequestUrl: string; id: any } | null> {
+    if (!this.targetBranch) {
+      return null;
+    }
+    try {
+      const gitProvider = await GitProvider.getInstance();
+      if (gitProvider == null) {
+        return null;
+      }
+      return await gitProvider.findOpenPullRequest(this.currentBranch, this.targetBranch);
+    } catch (e) {
+      uxLog("log", this, c.grey(`Unable to check if a ${GitProvider.getMergeRequestName(this.gitUrl)} is already open: ${(e as Error).message}`));
+      return null;
+    }
   }
 
   // Clean git status

--- a/src/common/gitProvider/azureDevops.ts
+++ b/src/common/gitProvider/azureDevops.ts
@@ -1104,9 +1104,7 @@ ${getBannerMarkdownAndLink()}
       description: request.body,
     };
     const result = await azureGitApi.createPullRequest(prToCreate, repositoryId, teamProject);
-    const pullRequestUrl = result?.url || (result?.pullRequestId
-      ? `${this.serverUrl}${teamProject}/_git/${repositoryId}/pullrequest/${result.pullRequestId}`
-      : null);
+    const pullRequestUrl = result?.pullRequestId ? this.pullRequestWebUrlFromApiResult(result, teamProject, repositoryId) : null;
     return {
       created: !!(result?.pullRequestId),
       pullRequestUrl,
@@ -1126,8 +1124,18 @@ ${getBannerMarkdownAndLink()}
     }, teamProject);
     const pr = prs?.[0];
     if (!pr?.pullRequestId) return null;
-    const pullRequestUrl = pr.url || `${this.serverUrl}${teamProject}/_git/${repositoryId}/pullrequest/${pr.pullRequestId}`;
-    return { pullRequestUrl, id: pr.pullRequestId };
+    return { pullRequestUrl: this.pullRequestWebUrlFromApiResult(pr, teamProject, repositoryId), id: pr.pullRequestId };
+  }
+
+  // Web URL of a Pull Request returned by the API. The `url` property of the API result must not be
+  // used: it is the REST URL of the Pull Request, which displays raw JSON when opened in a browser.
+  private pullRequestWebUrlFromApiResult(pullRequest: GitPullRequest, teamProject: string, repositoryId: string): string {
+    const repositoryWebUrl = pullRequest?.repository?.webUrl;
+    if (repositoryWebUrl) {
+      return `${repositoryWebUrl}/pullrequest/${pullRequest.pullRequestId}`;
+    }
+    // The repository GUID is accepted by the Azure DevOps UI when its name is unknown
+    return `${this.serverUrl}${teamProject}/_git/${repositoryId}/pullrequest/${pullRequest.pullRequestId}`;
   }
 
   public async updatePullRequestDescription(id: any, title: string, body: string): Promise<void> {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -3255,6 +3255,7 @@
   "updateFixScratchOrgUser": "Scratch Org-Benutzer aktualisieren / korrigieren ",
   "updateLocalProjectFilesWithInstalledPackages": "Lokale Projektdateien mit der Liste der installierten Pakete für die Bereitstellung aktualisieren",
   "updateManualActionsFile": "Datei für manuelle Aktionen aktualisieren",
+  "updateMergeRequestLabel": "{{mergeRequestName}} aktualisieren",
   "updateMkdocsAndBuildDeployDocs": "Sie sollten wahrscheinlich mkdocs.yml und build-deploy-docs.yml aktualisieren, um neu generierte Seiten einzuschließen",
   "updated": "Aktualisiert ",
   "updatedApiVersionInFromTo": "API-Version in {{manifestFile}} von {{match}} auf {{candidateApiVersion}} aktualisiert",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3260,6 +3260,7 @@
   "updateFixScratchOrgUser": "Update / fix scratch org user ",
   "updateLocalProjectFilesWithInstalledPackages": "Update your local project files with the list of installed packages for deployment",
   "updateManualActionsFile": "Update Manual Actions file",
+  "updateMergeRequestLabel": "Update {{mergeRequestName}}",
   "updateMkdocsAndBuildDeployDocs": "You should probably update mkdocs.yml and build-deploy-docs.yml to include newly generated pages",
   "updated": "Updated ",
   "updatedApiVersionInFromTo": "Updated API version in {{manifestFile}} from {{match}} to {{candidateApiVersion}}",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -3256,6 +3256,7 @@
   "updateFixScratchOrgUser": "Actualizar / corregir usuario de la Scratch Org",
   "updateLocalProjectFilesWithInstalledPackages": "Actualice sus archivos locales del proyecto con la lista de packages instalados para el despliegue",
   "updateManualActionsFile": "Actualizar el archivo de acciones manuales",
+  "updateMergeRequestLabel": "Actualizar {{mergeRequestName}}",
   "updateMkdocsAndBuildDeployDocs": "Probablemente debería actualizar mkdocs.yml y build-deploy-docs.yml para incluir las páginas recién generadas",
   "updated": "Actualizado ",
   "updatedApiVersionInFromTo": "Versión de API actualizada en {{manifestFile}} de {{match}} a {{candidateApiVersion}}",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -3256,6 +3256,7 @@
   "updateFixScratchOrgUser": "Mise à jour / correction de l'utilisateur de la scratch org ",
   "updateLocalProjectFilesWithInstalledPackages": "Mettre à jour vos fichiers de projet locaux avec la liste des packages installés pour le déploiement",
   "updateManualActionsFile": "Mettre à jour le fichier d'actions manuelles",
+  "updateMergeRequestLabel": "Mettre à jour {{mergeRequestName}}",
   "updateMkdocsAndBuildDeployDocs": "Vous devriez probablement mettre à jour mkdocs.yml et build-deploy-docs.yml pour inclure les pages nouvellement générées",
   "updated": "Mis à jour ",
   "updatedApiVersionInFromTo": "Version API mise à jour dans {{manifestFile}} de {{match}} vers {{candidateApiVersion}}",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -3256,6 +3256,7 @@
   "updateFixScratchOrgUser": "Aggiorna/correggi utente scratch org ",
   "updateLocalProjectFilesWithInstalledPackages": "Aggiorna i file locali del progetto con l'elenco dei pacchetti installati per la distribuzione",
   "updateManualActionsFile": "Aggiorna il file Azioni Manuali",
+  "updateMergeRequestLabel": "Aggiorna {{mergeRequestName}}",
   "updateMkdocsAndBuildDeployDocs": "Dovresti probabilmente aggiornare mkdocs.yml e build-deploy-docs.yml per includere le pagine appena generate",
   "updated": "Aggiornato ",
   "updatedApiVersionInFromTo": "Versione API aggiornata in {{manifestFile}} da {{match}} a {{candidateApiVersion}}",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -3253,6 +3253,7 @@
   "updateFixScratchOrgUser": "スクラッチ組織ユーザーの更新 / 修正",
   "updateLocalProjectFilesWithInstalledPackages": "デプロイ用にインストール済みパッケージのリストでローカルプロジェクトファイルを更新します",
   "updateManualActionsFile": "手動アクションファイルの更新",
+  "updateMergeRequestLabel": "{{mergeRequestName}} を更新する",
   "updateMkdocsAndBuildDeployDocs": "新しく生成されたページを含めるために mkdocs.yml と build-deploy-docs.yml を更新する必要があります",
   "updated": "更新しました",
   "updatedApiVersionInFromTo": "{{manifestFile}} の API バージョンを {{match}} から {{candidateApiVersion}} に更新しました",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -3256,6 +3256,7 @@
   "updateFixScratchOrgUser": "Bijwerken / corrigeren scratch org gebruiker ",
   "updateLocalProjectFilesWithInstalledPackages": "Werk je lokale projectbestanden bij met de lijst van geïnstalleerde pakketten voor implementatie",
   "updateManualActionsFile": "Handmatige acties-bestand bijwerken",
+  "updateMergeRequestLabel": "{{mergeRequestName}} bijwerken",
   "updateMkdocsAndBuildDeployDocs": "Je zou waarschijnlijk mkdocs.yml en build-deploy-docs.yml moeten bijwerken om nieuw gegenereerde pagina's op te nemen",
   "updated": "Bijgewerkt ",
   "updatedApiVersionInFromTo": "API-versie in {{manifestFile}} bijgewerkt van {{match}} naar {{candidateApiVersion}}",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -3256,6 +3256,7 @@
   "updateFixScratchOrgUser": "Zaktualizuj / napraw użytkownika Scratch Org ",
   "updateLocalProjectFilesWithInstalledPackages": "Zaktualizuj lokalne pliki projektu listą zainstalowanych pakietów do wdrożenia",
   "updateManualActionsFile": "Zaktualizuj plik ręcznych działań",
+  "updateMergeRequestLabel": "Zaktualizuj {{mergeRequestName}}",
   "updateMkdocsAndBuildDeployDocs": "Prawdopodobnie należy zaktualizować mkdocs.yml i build-deploy-docs.yml, aby uwzględnić nowo wygenerowane strony",
   "updated": "Zaktualizowano ",
   "updatedApiVersionInFromTo": "Zaktualizowano wersję API w {{manifestFile}} z {{match}} do {{candidateApiVersion}}",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -3237,6 +3237,7 @@
   "updateFixScratchOrgUser": "Atualizar / corrigir usuário da scratch org ",
   "updateLocalProjectFilesWithInstalledPackages": "Atualize os arquivos do seu projeto local com a lista de pacotes instalados para deploy",
   "updateManualActionsFile": "Atualizar arquivo de Ações Manuais",
+  "updateMergeRequestLabel": "Atualizar {{mergeRequestName}}",
   "updateMkdocsAndBuildDeployDocs": "Provavelmente você deve atualizar mkdocs.yml e build-deploy-docs.yml para incluir as páginas recém-geradas",
   "updatesForceIgnore": "Atualiza seu arquivo .forceignore com as melhores práticas mais recentes do sfdx-hardis e remove entradas antigas",
   "updatesGitignore": "Atualiza seu arquivo .gitignore com as melhores práticas mais recentes do sfdx-hardis e remove entradas duplicadas",


### PR DESCRIPTION
## What

At the end of `hardis:work:save`, the button proposing the Pull Request always pointed to the creation form, even when a Pull Request was already open between the current branch and its target branch.

It now looks for an open Pull Request between the two branches:

- when one exists, the button reads **Update Pull Request** (**Update Merge Request** on GitLab) and links directly to it;
- otherwise nothing changes: **Create Pull Request** pointing to the creation form.

## How

Reuses `GitProvider.findOpenPullRequest(sourceBranch, targetBranch)`, the same lookup automated Pull Request creation already relies on, so it is implemented for GitHub, GitLab, Azure DevOps and Bitbucket.

The lookup is skipped when there is no target branch, and it never fails the command: if the git provider is not configured, or does not implement the method, the command falls back to the creation URL as before.

## Notes

- New i18n key `updateMergeRequestLabel`, translated in the 9 supported locales.
- The `--json` output and the non-VS-Code console summary are unchanged apart from the URL they display (`Existing` instead of `New` prefix).
