### PR TITLE
ci(templates): always run default workflows in sfdx-hardis docker images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
   push_alpha_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Docker image to GitHub Container Registry
+    name: Push alpha Docker image to GitHub Container Registry & Docker Hub
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
@@ -53,6 +53,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -72,6 +77,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis:alpha
+            docker.io/hardisgroupcom/sfdx-hardis:alpha
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis:alpha
@@ -82,7 +88,7 @@ jobs:
 
   push_alpha_to_registry_sfdx_recommended:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
+    name: Push alpha Docker image to GitHub Container Registry & Docker Hub (with @salesforce/cli version recommended by hardis)
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
@@ -95,6 +101,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -114,6 +125,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis:alpha-sfdx-recommended
+            docker.io/hardisgroupcom/sfdx-hardis:alpha-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis:alpha-sfdx-recommended
@@ -124,7 +136,7 @@ jobs:
 
   push_alpha_ubuntu_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Ubuntu Docker image to GitHub Container Registry
+    name: Push alpha Ubuntu Docker image to GitHub Container Registry & Docker Hub
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
@@ -137,6 +149,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -156,6 +173,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha
@@ -166,7 +184,7 @@ jobs:
 
   push_alpha_ubuntu_to_registry_sfdx_recommended:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Ubuntu Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
+    name: Push alpha Ubuntu Docker image to GitHub Container Registry & Docker Hub (with @salesforce/cli version recommended by hardis)
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
@@ -179,6 +197,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -198,6 +221,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha-sfdx-recommended
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis-ubuntu:alpha-sfdx-recommended
@@ -208,7 +232,7 @@ jobs:
 
   push_alpha_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Docker image with agents to GitHub Container Registry
+    name: Push alpha Docker image with agents to GitHub Container Registry & Docker Hub
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
@@ -221,6 +245,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -241,10 +270,11 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:alpha
+            docker.io/hardisgroupcom/sfdx-hardis-with-agents:alpha
 
   push_alpha_ubuntu_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
-    name: Push alpha Ubuntu Docker image with agents to GitHub Container Registry
+    name: Push alpha Ubuntu Docker image with agents to GitHub Container Registry & Docker Hub
     needs: deploy_alpha
     runs-on: ubuntu-latest
     permissions:
@@ -257,6 +287,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -277,6 +312,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:alpha
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:alpha
 
   deploy_canary:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
@@ -305,7 +341,7 @@ jobs:
 
   push_canary_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
-    name: Push canary Docker image to GitHub Container Registry
+    name: Push canary Docker image to GitHub Container Registry & Docker Hub
     needs: deploy_canary
     runs-on: ubuntu-latest
     permissions:
@@ -318,6 +354,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -337,6 +378,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis:canary
+            docker.io/hardisgroupcom/sfdx-hardis:canary
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis:canary
@@ -347,7 +389,7 @@ jobs:
 
   push_canary_ubuntu_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
-    name: Push canary Ubuntu Docker image to GitHub Container Registry
+    name: Push canary Ubuntu Docker image to GitHub Container Registry & Docker Hub
     needs: deploy_canary
     runs-on: ubuntu-latest
     permissions:
@@ -360,6 +402,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -379,6 +426,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:canary
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:canary
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis-ubuntu:canary
@@ -389,7 +437,7 @@ jobs:
 
   push_canary_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
-    name: Push canary Docker image with agents to GitHub Container Registry
+    name: Push canary Docker image with agents to GitHub Container Registry & Docker Hub
     needs: deploy_canary
     runs-on: ubuntu-latest
     permissions:
@@ -402,6 +450,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -422,10 +475,11 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:canary
+            docker.io/hardisgroupcom/sfdx-hardis-with-agents:canary
 
   push_canary_ubuntu_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/canary'
-    name: Push canary Ubuntu Docker image with agents to GitHub Container Registry
+    name: Push canary Ubuntu Docker image with agents to GitHub Container Registry & Docker Hub
     needs: deploy_canary
     runs-on: ubuntu-latest
     permissions:
@@ -438,6 +492,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -458,6 +517,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:canary
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:canary
 
   deploy_beta:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -486,7 +546,7 @@ jobs:
 
   push_beta_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Docker image to GitHub Container Registry
+    name: Push Beta Docker image to GitHub Container Registry & Docker Hub
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
@@ -500,6 +560,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -519,6 +584,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis:beta
+            docker.io/hardisgroupcom/sfdx-hardis:beta
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: ghcr.io/hardisgroupcom/sfdx-hardis:beta
@@ -566,7 +632,7 @@ jobs:
 
   push_beta_to_registry_sfdx_recommended:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
+    name: Push Beta Docker image to GitHub Container Registry & Docker Hub (with @salesforce/cli version recommended by hardis)
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
@@ -579,6 +645,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -598,6 +669,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis:beta-sfdx-recommended
+            docker.io/hardisgroupcom/sfdx-hardis:beta-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis:beta-sfdx-recommended
@@ -608,7 +680,7 @@ jobs:
 
   push_beta_ubuntu_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Ubuntu Docker image to GitHub Container Registry
+    name: Push Beta Ubuntu Docker image to GitHub Container Registry & Docker Hub
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
@@ -622,6 +694,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -641,6 +718,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:beta
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:beta
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:beta
@@ -688,7 +766,7 @@ jobs:
 
   push_beta_ubuntu_to_registry_sfdx_recommended:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Ubuntu Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
+    name: Push Beta Ubuntu Docker image to GitHub Container Registry & Docker Hub (with @salesforce/cli version recommended by hardis)
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
@@ -701,6 +779,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -720,6 +803,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:beta-sfdx-recommended
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:beta-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis-ubuntu:beta-sfdx-recommended
@@ -730,7 +814,7 @@ jobs:
 
   push_beta_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Docker image with agents to GitHub Container Registry
+    name: Push Beta Docker image with agents to GitHub Container Registry & Docker Hub
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
@@ -743,6 +827,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -763,10 +852,11 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:beta
+            docker.io/hardisgroupcom/sfdx-hardis-with-agents:beta
 
   push_beta_ubuntu_with_agents_to_registry:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Push Beta Ubuntu Docker image with agents to GitHub Container Registry
+    name: Push Beta Ubuntu Docker image with agents to GitHub Container Registry & Docker Hub
     needs: deploy_beta
     runs-on: ubuntu-latest
     permissions:
@@ -779,6 +869,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -799,6 +894,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:beta
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:beta
 
   deploy_release:
     if: github.event_name == 'release'
@@ -825,7 +921,7 @@ jobs:
 
   push_release_to_registry:
     if: github.event_name == 'release'
-    name: Push Docker image to GitHub Container Registry
+    name: Push Docker image to GitHub Container Registry & Docker Hub
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
@@ -839,6 +935,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -859,6 +960,8 @@ jobs:
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis:${{ github.event.release.tag_name }}
             ghcr.io/hardisgroupcom/sfdx-hardis:latest
+            docker.io/hardisgroupcom/sfdx-hardis:latest
+            docker.io/hardisgroupcom/sfdx-hardis:${{ github.event.release.tag_name }}
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: ghcr.io/hardisgroupcom/sfdx-hardis:${{ github.event.release.tag_name }}
@@ -906,7 +1009,7 @@ jobs:
 
   push_release_to_registry_sfdx_recommended:
     if: github.event_name == 'release'
-    name: Push Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
+    name: Push Docker image to GitHub Container Registry & Docker Hub (with @salesforce/cli version recommended by hardis)
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
@@ -919,6 +1022,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -938,6 +1046,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended
+            docker.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended
@@ -948,7 +1057,7 @@ jobs:
 
   push_release_ubuntu_to_registry:
     if: github.event_name == 'release'
-    name: Push Ubuntu Docker image to GitHub Container Registry
+    name: Push Ubuntu Docker image to GitHub Container Registry & Docker Hub
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
@@ -962,6 +1071,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -982,6 +1096,8 @@ jobs:
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:${{ github.event.release.tag_name }}
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:${{ github.event.release.tag_name }}
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:${{ github.event.release.tag_name }}
@@ -1029,7 +1145,7 @@ jobs:
 
   push_release_ubuntu_to_registry_sfdx_recommended:
     if: github.event_name == 'release'
-    name: Push Ubuntu Docker image to GitHub Container Registry (with @salesforce/cli version recommended by hardis)
+    name: Push Ubuntu Docker image to GitHub Container Registry & Docker Hub (with @salesforce/cli version recommended by hardis)
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
@@ -1042,6 +1158,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1061,6 +1182,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended
       # - uses: aquasecurity/trivy-action@master
       #   with:
       #     image-ref: docker.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended
@@ -1071,7 +1193,7 @@ jobs:
 
   push_release_with_agents_to_registry:
     if: github.event_name == 'release'
-    name: Push Docker image with agents to GitHub Container Registry
+    name: Push Docker image with agents to GitHub Container Registry & Docker Hub
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
@@ -1084,6 +1206,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1105,10 +1232,12 @@ jobs:
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:${{ github.event.release.tag_name }}
             ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest
+            docker.io/hardisgroupcom/sfdx-hardis-with-agents:latest
+            docker.io/hardisgroupcom/sfdx-hardis-with-agents:${{ github.event.release.tag_name }}
 
   push_release_ubuntu_with_agents_to_registry:
     if: github.event_name == 'release'
-    name: Push Ubuntu Docker image with agents to GitHub Container Registry
+    name: Push Ubuntu Docker image with agents to GitHub Container Registry & Docker Hub
     needs: deploy_release
     runs-on: ubuntu-latest
     permissions:
@@ -1121,6 +1250,11 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # Docker Hub login (secondary registry: ghcr.io is the primary & recommended one)
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1142,3 +1276,5 @@ jobs:
           tags: |
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:${{ github.event.release.tag_name }}
             ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+            docker.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:${{ github.event.release.tag_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,10 +76,10 @@
   - To let the pipeline auto-fix deployment errors with coding agents, switch to the `ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest` image instead of uncommenting npm install lines.
   - The ubuntu images now include `sudo`, so custom steps added to Azure Pipelines container jobs (which run as a non-root user) can still elevate privileges when they need to.
   - Existing pipelines keep working: the templates are only applied when initializing a new project or monitoring repository (or, for GitLab monitoring repositories, when automatic updates are opted-in with `AUTO_UPDATE_GITLAB_CI_YML`).
-- The default GitLab CI workflows now pull the sfdx-hardis image from GitHub Container Registry (`ghcr.io/hardisgroupcom/sfdx-hardis:latest`), since the Docker Hub image is not updated anymore.
+- The default GitLab CI workflows now pull the sfdx-hardis image from GitHub Container Registry (`ghcr.io/hardisgroupcom/sfdx-hardis:latest`), the recommended registry; templates mention the Docker Hub mirror for infrastructures that can only pull from `docker.io`.
 - New [CI/CD Setup Checklist](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-checklist/) documentation page, to verify that a CI/CD setup is complete: what to do before the initialization merge request, what to check after it, and all the integrations grouped by platform.
 - Upgrade MegaLinter to v10 (repository lint config, CI/CD template workflow and mega-linter-runner dependency).
-- New Docker images are published only to GitHub Container Registry (`ghcr.io/hardisgroupcom/sfdx-hardis`): publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization.
+- Docker images are published to both GitHub Container Registry (`ghcr.io/hardisgroupcom/sfdx-hardis`) and Docker Hub. The ghcr.io images are the default and recommended ones, because their publication does not rely on any long-lived token, making their supply chain more secure; the Docker Hub images are kept as a mirror.
 
 ### Core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@
 
 ### CI/CD
 
+- The default GitHub Actions, Azure Pipelines and Bitbucket Pipelines workflows (CI/CD and Org Monitoring) now run in the ubuntu-based sfdx-hardis Docker image (`ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest`), like GitLab always did with the alpine-based image:
+  - Jobs no longer install Node.js, Salesforce CLI and its plugins at every run, so they start faster and can no longer be broken by a bad release of a dependency.
+  - To let the pipeline auto-fix deployment errors with coding agents, switch to the `ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest` image instead of uncommenting npm install lines.
+  - The ubuntu images now include `sudo`, so custom steps added to Azure Pipelines container jobs (which run as a non-root user) can still elevate privileges when they need to.
+  - Existing pipelines keep working: the templates are only applied when initializing a new project or monitoring repository (or, for GitLab monitoring repositories, when automatic updates are opted-in with `AUTO_UPDATE_GITLAB_CI_YML`).
+- The default GitLab CI workflows now pull the sfdx-hardis image from GitHub Container Registry (`ghcr.io/hardisgroupcom/sfdx-hardis:latest`), since the Docker Hub image is not updated anymore.
 - New [CI/CD Setup Checklist](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-checklist/) documentation page, to verify that a CI/CD setup is complete: what to do before the initialization merge request, what to check after it, and all the integrations grouped by platform.
 - Upgrade MegaLinter to v10 (repository lint config, CI/CD template workflow and mega-linter-runner dependency).
 - New Docker images are published only to GitHub Container Registry (`ghcr.io/hardisgroupcom/sfdx-hardis`): publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization.

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     gnupg \
+    # Required for Azure Pipelines container jobs (steps run as a non-root user that needs sudo to elevate)
+    sudo \
     # Required for Python
     python3 \
     python3-pip \

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can use sfdx-hardis docker images to run in CI.
 
 > All our Docker images are checked for security issues with [MegaLinter by OX Security](https://megalinter.io/latest/)
 
-> Images are published on **GitHub Container Registry (ghcr.io)**. Publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization, so do not use the `hub.docker.com` images: they are not updated anymore.
+> Images are published on both **GitHub Container Registry (ghcr.io)** and **Docker Hub**. Prefer the **ghcr.io** images: their publication does not rely on any long-lived token (it is secured with the workflow's ephemeral credentials), so they have the most secure supply chain. Use the Docker Hub mirror images when your infrastructure can only pull from `docker.io`.
 
 Two image flavors are available:
 
@@ -130,15 +130,29 @@ Two image flavors are available:
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - GitHub Container Registry (recommended)
+
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+
+  - Docker Hub (mirror)
+
+    - [**hardisgroupcom/sfdx-hardis:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with latest @salesforce/cli version)
+    - [**hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - GitHub Container Registry (recommended)
+
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+
+  - Docker Hub (mirror)
+
+    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 
@@ -152,13 +166,15 @@ These images include Claude Code, OpenAI Codex, Gemini CLI, and GitHub Copilot p
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - GitHub Container Registry (recommended): [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - Docker Hub (mirror): [**hardisgroupcom/sfdx-hardis-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-with-agents)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket - recommended for coding agents)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - GitHub Container Registry (recommended): [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - Docker Hub (mirror): [**hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu-with-agents)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ You can use sfdx-hardis docker images to run in CI.
 
 > All our Docker images are checked for security issues with [MegaLinter by OX Security](https://megalinter.io/latest/)
 
+> Images are published on **GitHub Container Registry (ghcr.io)**. Publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization, so do not use the `hub.docker.com` images: they are not updated anymore.
+
 Two image flavors are available:
 
 - **Standard images** (`sfdx-hardis`, `sfdx-hardis-ubuntu`): Salesforce CI/CD tooling without coding agent CLIs. Use these for standard deployments.
@@ -128,29 +130,15 @@ Two image flavors are available:
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - Docker Hub
-
-    - [**hardisgroupcom/sfdx-hardis:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with latest @salesforce/cli version)
-    - [**hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
-
-  - GitHub Packages (ghcr.io)
-
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket)
 
-  - Docker Hub
-
-    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
-
-  - GitHub Packages (ghcr.io)
-
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 
@@ -164,15 +152,13 @@ These images include Claude Code, OpenAI Codex, Gemini CLI, and GitHub Copilot p
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - Docker Hub: [**hardisgroupcom/sfdx-hardis-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-with-agents)
-  - GitHub Packages: [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket - recommended for coding agents)
 
-  - Docker Hub: [**hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu-with-agents)
-  - GitHub Packages: [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 

--- a/defaults/ci/.github/workflows/check-deploy.yml
+++ b/defaults/ci/.github/workflows/check-deploy.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
     # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
     # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Simulate Deployment to Major Org

--- a/defaults/ci/.github/workflows/check-deploy.yml
+++ b/defaults/ci/.github/workflows/check-deploy.yml
@@ -29,9 +29,11 @@ jobs:
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Simulate Deployment to Major Org
     permissions:
-      pull-requests: write
-      contents: write
+      pull-requests: write # Allows sfdx-hardis to post deployment status comments on the Pull Request
       issues: write
+      contents: read
+      # To allow coding agents to push auto-fix branches and create Pull Requests,
+      # replace "contents: read" above by "contents: write"
     steps:
       # Checkout repo
       - name: Checkout code
@@ -60,7 +62,9 @@ jobs:
           ORG_ALIAS: ${{ github.event.pull_request.base.ref }} # Defines the target branch of the PR
           CONFIG_BRANCH: ${{ github.event.pull_request.base.ref }} # Defines the target branch of the PR
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CI_SFDX_HARDIS_GITHUB_PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Uncomment to allow coding agents to push auto-fix branches and create Pull Requests
+          # (also requires "contents: write" in the permissions above, the sfdx-hardis-ubuntu-with-agents image, and an AI API key below)
+          # CI_SFDX_HARDIS_GITHUB_PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SLACK_CHANNEL_ID_INTEGRATION: ${{ secrets.SLACK_CHANNEL_ID_INTEGRATION }}

--- a/defaults/ci/.github/workflows/check-deploy.yml
+++ b/defaults/ci/.github/workflows/check-deploy.yml
@@ -22,6 +22,10 @@ concurrency:
 jobs:
   check_deployment:
     runs-on: ubuntu-latest
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Simulate Deployment to Major Org
     permissions:
       pull-requests: write
@@ -35,24 +39,6 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # Fetch all branches
-      # Setup node
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      # SFDX & plugins
-      - name: Install SFDX and plugins
-        run: |
-          npm install --no-cache @salesforce/cli --global
-          sf plugins install @salesforce/plugin-packaging
-          echo 'y' | sf plugins install sfdx-hardis
-          echo 'y' | sf plugins install sfdx-git-delta
-          sf version --verbose --json
-          # Uncomment the coding agent CLIs you want to use for auto-fix of deployment errors
-          # npm install --no-cache @anthropic-ai/claude-code@latest --global && claude --version
-          # npm install --no-cache @openai/codex@latest --global && codex --version
-          # npm install --no-cache @google/gemini-cli@latest --global && gemini --version
-          # npm install --no-cache @github/copilot@latest --global && copilot --version
       # Login & check deploy with test classes & code coverage
       - name: Login & Simulate deployment
         if: ${{ !startsWith(github.head_ref, 'auto-fix/') &&

--- a/defaults/ci/.github/workflows/process-deploy.yml
+++ b/defaults/ci/.github/workflows/process-deploy.yml
@@ -22,6 +22,10 @@ jobs:
   process_deployment:
     name: Process Deployment to Major Org
     runs-on: ubuntu-latest
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     permissions:
       pull-requests: write
       contents: write
@@ -34,25 +38,6 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      # Setup node
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      # SFDX & plugins
-      - name: Install SFDX and plugins
-        run: |
-          npm install @salesforce/cli --global
-          sf plugins install @salesforce/plugin-packaging
-          echo 'y' | sf plugins install sfdx-hardis
-          # echo 'y' | sf plugins install sfdmu # Disabled while it does not play well with @salesforce/cli
-          echo 'y' | sf plugins install sfdx-git-delta
-            sf version --verbose --json
-          # Uncomment the coding agent CLIs you want to use for auto-fix of deployment errors
-          # npm install --no-cache @anthropic-ai/claude-code@latest --global && claude --version
-          # npm install --no-cache @openai/codex@latest --global && codex --version
-          # npm install --no-cache @google/gemini-cli@latest --global && gemini --version
-          # npm install --no-cache @github/copilot@latest --global && copilot --version
       # Set env branch variable (github.ref_name seems to not work)
       - name: Set env.BRANCH
         run: echo "BRANCH=$(echo "$GITHUB_REF" | cut -d'/' -f 3)" >> "$GITHUB_ENV"

--- a/defaults/ci/.github/workflows/process-deploy.yml
+++ b/defaults/ci/.github/workflows/process-deploy.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
     # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
     # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     permissions:

--- a/defaults/ci/.github/workflows/process-deploy.yml
+++ b/defaults/ci/.github/workflows/process-deploy.yml
@@ -28,9 +28,11 @@ jobs:
     # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     permissions:
-      pull-requests: write
-      contents: write
+      pull-requests: write # Allows sfdx-hardis to post deployment status comments on the Pull Request
       issues: write
+      contents: read
+      # To allow coding agents to push auto-fix branches and create Pull Requests,
+      # replace "contents: read" above by "contents: write"
     steps:
       # Git Checkout
       - name: Checkout Code
@@ -61,7 +63,9 @@ jobs:
           ORG_ALIAS: ${{ env.BRANCH }} # Defines the target branch of the PR
           CONFIG_BRANCH: ${{ env.BRANCH }} # Defines the target branch of the PR
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CI_SFDX_HARDIS_GITHUB_PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Uncomment to allow coding agents to push auto-fix branches and create Pull Requests
+          # (also requires "contents: write" in the permissions above, the sfdx-hardis-ubuntu-with-agents image, and an AI API key below)
+          # CI_SFDX_HARDIS_GITHUB_PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           NOTIF_EMAIL_ADDRESS: ${{ secrets.NOTIF_EMAIL_ADDRESS }}

--- a/defaults/ci/.gitlab-ci.yml
+++ b/defaults/ci/.gitlab-ci.yml
@@ -94,15 +94,16 @@ check_deploy_to_target_branch_org:
         echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch $CI_COMMIT_REF_NAME"
         exit 0
       fi
-    - |
-      if [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ]; then
-        git config user.email "sfdx-hardis-bot@cloudity.com"
-        git config user.name "sfdx-hardis Bot"
-        git remote set-url origin "https://oauth2:${CI_SFDX_HARDIS_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
-        echo "[sfdx-hardis] GitLab push/MR auth enabled for coding agents"
-      else
-        echo "[sfdx-hardis] Skipping coding-agent GitLab auth setup: CI_SFDX_HARDIS_GITLAB_TOKEN is not set"
-      fi
+    # Uncomment the lines below to allow coding agents to push auto-fix branches and create Merge Requests
+    # (also requires the sfdx-hardis-ubuntu-with-agents image, an AI API key,
+    # and a CI_SFDX_HARDIS_GITLAB_TOKEN CI/CD variable with api + write_repository scopes)
+    # - |
+    #   if [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ]; then
+    #     git config user.email "sfdx-hardis-bot@cloudity.com"
+    #     git config user.name "sfdx-hardis Bot"
+    #     git remote set-url origin "https://oauth2:${CI_SFDX_HARDIS_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+    #     echo "[sfdx-hardis] GitLab push/MR auth enabled for coding agents"
+    #   fi
     - sf hardis:auth:login
     - sf hardis:project:deploy:smart --check
   artifacts:
@@ -263,15 +264,16 @@ check_deploy_to_current_branch_org:
         echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch $CI_COMMIT_REF_NAME"
         exit 0
       fi
-    - |
-      if [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ]; then
-        git config user.email "sfdx-hardis-bot@cloudity.com"
-        git config user.name "sfdx-hardis Bot"
-        git remote set-url origin "https://oauth2:${CI_SFDX_HARDIS_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
-        echo "[sfdx-hardis] GitLab push/MR auth enabled for coding agents"
-      else
-        echo "[sfdx-hardis] Skipping coding-agent GitLab auth setup: CI_SFDX_HARDIS_GITLAB_TOKEN is not set"
-      fi
+    # Uncomment the lines below to allow coding agents to push auto-fix branches and create Merge Requests
+    # (also requires the sfdx-hardis-ubuntu-with-agents image, an AI API key,
+    # and a CI_SFDX_HARDIS_GITLAB_TOKEN CI/CD variable with api + write_repository scopes)
+    # - |
+    #   if [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ]; then
+    #     git config user.email "sfdx-hardis-bot@cloudity.com"
+    #     git config user.name "sfdx-hardis Bot"
+    #     git remote set-url origin "https://oauth2:${CI_SFDX_HARDIS_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+    #     echo "[sfdx-hardis] GitLab push/MR auth enabled for coding agents"
+    #   fi
     - sf hardis:auth:login
     - sf hardis:project:deploy:smart --check
   artifacts:
@@ -301,15 +303,16 @@ deploy_to_org:
         echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch $CI_COMMIT_REF_NAME"
         exit 0
       fi
-    - |
-      if [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ]; then
-        git config user.email "sfdx-hardis-bot@cloudity.com"
-        git config user.name "sfdx-hardis Bot"
-        git remote set-url origin "https://oauth2:${CI_SFDX_HARDIS_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
-        echo "[sfdx-hardis] GitLab push/MR auth enabled for coding agents"
-      else
-        echo "[sfdx-hardis] Skipping coding-agent GitLab auth setup: CI_SFDX_HARDIS_GITLAB_TOKEN is not set"
-      fi
+    # Uncomment the lines below to allow coding agents to push auto-fix branches and create Merge Requests
+    # (also requires the sfdx-hardis-ubuntu-with-agents image, an AI API key,
+    # and a CI_SFDX_HARDIS_GITLAB_TOKEN CI/CD variable with api + write_repository scopes)
+    # - |
+    #   if [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ]; then
+    #     git config user.email "sfdx-hardis-bot@cloudity.com"
+    #     git config user.name "sfdx-hardis Bot"
+    #     git remote set-url origin "https://oauth2:${CI_SFDX_HARDIS_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+    #     echo "[sfdx-hardis] GitLab push/MR auth enabled for coding agents"
+    #   fi
     - sf hardis:auth:login
     - sf hardis:project:deploy:smart
   artifacts:

--- a/defaults/ci/.gitlab-ci.yml
+++ b/defaults/ci/.gitlab-ci.yml
@@ -20,6 +20,7 @@ stages:
 
 # Jobs are run on sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
 # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+# Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis:latest
 # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest (some agents may crash on the alpine-based images)
 # An ubuntu-based variant is also available: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest (bigger, but includes Chrome for mermaid diagrams generation)
 image: ghcr.io/hardisgroupcom/sfdx-hardis:latest

--- a/defaults/ci/.gitlab-ci.yml
+++ b/defaults/ci/.gitlab-ci.yml
@@ -18,9 +18,11 @@ stages:
   - check_deploy # Simulate deployment to target branch
   - deploy # After a merge, automatically deploys the new commit state into the related Salesforce org
 
-# Jobs are run on sfdx-hardis image, that includes all required dependencies.
-# You can use latest, beta or latest-recommended
-image: hardisgroupcom/sfdx-hardis:latest # If rate limits reached, use ghcr.io/hardisgroupcom/sfdx-hardis:latest
+# Jobs are run on sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+# You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+# To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest (some agents may crash on the alpine-based images)
+# An ubuntu-based variant is also available: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest (bigger, but includes Chrome for mermaid diagrams generation)
+image: ghcr.io/hardisgroupcom/sfdx-hardis:latest
 
 # Force color for output logs for better readability
 variables:

--- a/defaults/ci/Jenkinsfile
+++ b/defaults/ci/Jenkinsfile
@@ -153,15 +153,15 @@ pipeline {
                                     string(credentialsId: 'CI_SFDX_HARDIS_BITBUCKET_TOKEN',       variable: 'CI_SFDX_HARDIS_BITBUCKET_TOKEN',       optional: true),
                                     string(credentialsId: 'CI_SFDX_HARDIS_AZURE_TOKEN',           variable: 'CI_SFDX_HARDIS_AZURE_TOKEN',           optional: true),
                                 ]) {
-                                    sh '''
-                                        if [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_BITBUCKET_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_AZURE_TOKEN:-}" ]; then
-                                            git config user.email "sfdx-hardis-bot@cloudity.com"
-                                            git config user.name "sfdx-hardis Bot"
-                                            echo "[sfdx-hardis] Coding-agent git auth prerequisites found"
-                                        else
-                                            echo "[sfdx-hardis] Skipping coding-agent git auth setup: no provider token variable is set"
-                                        fi
-                                    '''
+                                    // Uncomment the lines below to allow coding agents to push auto-fix branches and create PRs
+                                    // (also requires an AI API key credential and a git provider token credential above)
+                                    // sh '''
+                                    //     if [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_BITBUCKET_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_AZURE_TOKEN:-}" ]; then
+                                    //         git config user.email "sfdx-hardis-bot@cloudity.com"
+                                    //         git config user.name "sfdx-hardis Bot"
+                                    //         echo "[sfdx-hardis] Coding-agent git auth prerequisites found"
+                                    //     fi
+                                    // '''
                                     sh 'sf hardis:auth:login'
                                     sh 'sf hardis:project:deploy:smart --check'
                                 }
@@ -230,15 +230,15 @@ pipeline {
                             string(credentialsId: 'CI_SFDX_HARDIS_BITBUCKET_TOKEN',       variable: 'CI_SFDX_HARDIS_BITBUCKET_TOKEN',       optional: true),
                             string(credentialsId: 'CI_SFDX_HARDIS_AZURE_TOKEN',           variable: 'CI_SFDX_HARDIS_AZURE_TOKEN',           optional: true),
                         ]) {
-                            sh '''
-                                if [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_BITBUCKET_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_AZURE_TOKEN:-}" ]; then
-                                    git config user.email "sfdx-hardis-bot@cloudity.com"
-                                    git config user.name "sfdx-hardis Bot"
-                                    echo "[sfdx-hardis] Coding-agent git auth prerequisites found"
-                                else
-                                    echo "[sfdx-hardis] Skipping coding-agent git auth setup: no provider token variable is set"
-                                fi
-                            '''
+                            // Uncomment the lines below to allow coding agents to push auto-fix branches and create PRs
+                            // (also requires an AI API key credential and a git provider token credential above)
+                            // sh '''
+                            //     if [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_GITLAB_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_BITBUCKET_TOKEN:-}" ] || [ -n "${CI_SFDX_HARDIS_AZURE_TOKEN:-}" ]; then
+                            //         git config user.email "sfdx-hardis-bot@cloudity.com"
+                            //         git config user.name "sfdx-hardis Bot"
+                            //         echo "[sfdx-hardis] Coding-agent git auth prerequisites found"
+                            //     fi
+                            // '''
                             sh 'sf hardis:auth:login'
                             sh 'sf hardis:project:deploy:smart'
                         }

--- a/defaults/ci/Jenkinsfile
+++ b/defaults/ci/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
     agent {
         docker {
             // Use sfdx-hardis image - no install step needed. If not working on Jenkins, use ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
+            // Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis:latest
             image 'ghcr.io/hardisgroupcom/sfdx-hardis:latest'
             // Mount Docker socket so MegaLinter can run as a sibling container
             args '-v /var/run/docker.sock:/var/run/docker.sock --user root'

--- a/defaults/ci/Jenkinsfile
+++ b/defaults/ci/Jenkinsfile
@@ -20,7 +20,7 @@
 //    Missing optional credentials are silently ignored - the pipeline will NOT crash.
 //
 // 3. The Docker agent requires Docker to be available on the Jenkins node.
-//    The main agent uses hardisgroupcom/sfdx-hardis:latest.
+//    The main agent uses ghcr.io/hardisgroupcom/sfdx-hardis:latest.
 //    MegaLinter runs via `docker run` inside that agent (Docker socket must be mounted).
 //
 // Doc & support: https://sfdx-hardis.cloudity.com/salesforce-ci-cd-setup-integration-jenkins/
@@ -37,9 +37,8 @@ pipeline {
 
     agent {
         docker {
-            // Use sfdx-hardis image - no install step needed
-            // If rate limits are reached, use: ghcr.io/hardisgroupcom/sfdx-hardis:latest
-            image 'hardisgroupcom/sfdx-hardis:latest'
+            // Use sfdx-hardis image - no install step needed. If not working on Jenkins, use ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
+            image 'ghcr.io/hardisgroupcom/sfdx-hardis:latest'
             // Mount Docker socket so MegaLinter can run as a sibling container
             args '-v /var/run/docker.sock:/var/run/docker.sock --user root'
         }

--- a/defaults/ci/azure-pipelines-checks.yml
+++ b/defaults/ci/azure-pipelines-checks.yml
@@ -58,13 +58,14 @@ jobs:
             echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch ${CURRENT_BRANCH_NAME}"
             exit 0
           fi
-          if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-            git config user.email "sfdx-hardis-bot@cloudity.com"
-            git config user.name "sfdx-hardis Bot"
-            echo "[sfdx-hardis] Azure push/PR auth enabled for coding agents via SYSTEM_ACCESSTOKEN"
-          else
-            echo "[sfdx-hardis] Skipping coding-agent Azure auth setup: SYSTEM_ACCESSTOKEN is not set"
-          fi
+          # Uncomment the lines below to allow coding agents to push auto-fix branches and create Pull Requests
+          # (also requires the sfdx-hardis-ubuntu-with-agents image, an AI API key in the variables below,
+          # and "Contribute" + "Create branch" permissions for the Build Service user on the repository)
+          # if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+          #   git config user.email "sfdx-hardis-bot@cloudity.com"
+          #   git config user.name "sfdx-hardis Bot"
+          #   echo "[sfdx-hardis] Azure push/PR auth enabled for coding agents via SYSTEM_ACCESSTOKEN"
+          # fi
           sf hardis:auth:login
           sf hardis:project:deploy:smart --check
         env:

--- a/defaults/ci/azure-pipelines-checks.yml
+++ b/defaults/ci/azure-pipelines-checks.yml
@@ -40,32 +40,16 @@ jobs:
     timeoutInMinutes: 150
     pool:
       vmImage: ubuntu-latest
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     steps:
       # Checkout repo
       - checkout: self
         fetchDepth: 0
         persistCredentials: true
         displayName: Git Checkout
-
-      # Setup Node.js
-      - task: UseNode@1
-        inputs:
-          version: ">=24.0.0"
-        displayName: "Use Node.js"
-
-      # Install SFDX & Dependencies
-      - script: |
-          npm install @salesforce/cli --global
-          sf plugins install @salesforce/plugin-packaging
-          echo 'y' | sf plugins install sfdx-hardis
-          echo 'y' | sf plugins install sfdx-git-delta
-          sf version --verbose --json
-          # Uncomment the coding agent CLIs you want to use for auto-fix of deployment errors
-          # npm install --no-cache @anthropic-ai/claude-code@latest --global && claude --version
-          # npm install --no-cache @openai/codex@latest --global && codex --version
-          # npm install --no-cache @google/gemini-cli@latest --global && gemini --version
-          # npm install --no-cache @github/copilot@latest --global && copilot --version
-        displayName: "Install SFDX & plugins"
 
       # Login & check deployment to PR target branch related org (configuration: https://hardisgroupcom.github.io/sfdx-hardis/salesforce-ci-cd-setup-auth/ )
       - script: |

--- a/defaults/ci/azure-pipelines-checks.yml
+++ b/defaults/ci/azure-pipelines-checks.yml
@@ -42,6 +42,7 @@ jobs:
       vmImage: ubuntu-latest
     # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
     # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
     # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     steps:

--- a/defaults/ci/azure-pipelines-checks.yml
+++ b/defaults/ci/azure-pipelines-checks.yml
@@ -54,8 +54,8 @@ jobs:
 
       # Login & check deployment to PR target branch related org (configuration: https://hardisgroupcom.github.io/sfdx-hardis/salesforce-ci-cd-setup-auth/ )
       - script: |
-          if [ "$(CURRENT_BRANCH_NAME#auto-fix/)" != "$(CURRENT_BRANCH_NAME)" ]; then
-            echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch $(CURRENT_BRANCH_NAME)"
+          if [ "${CURRENT_BRANCH_NAME#auto-fix/}" != "${CURRENT_BRANCH_NAME}" ]; then
+            echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch ${CURRENT_BRANCH_NAME}"
             exit 0
           fi
           if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then

--- a/defaults/ci/azure-pipelines-deployment.yml
+++ b/defaults/ci/azure-pipelines-deployment.yml
@@ -47,8 +47,8 @@ jobs:
 
       # Login & Deploy sfdx sources to related org (configuration: https://hardisgroupcom.github.io/sfdx-hardis/salesforce-ci-cd-setup-auth/ )
       - script: |
-          if [ "$(BRANCH_NAME#auto-fix/)" != "$(BRANCH_NAME)" ]; then
-            echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch $(BRANCH_NAME)"
+          if [ "${BRANCH_NAME#auto-fix/}" != "${BRANCH_NAME}" ]; then
+            echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch ${BRANCH_NAME}"
             exit 0
           fi
           if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then

--- a/defaults/ci/azure-pipelines-deployment.yml
+++ b/defaults/ci/azure-pipelines-deployment.yml
@@ -33,33 +33,16 @@ jobs:
     timeoutInMinutes: 150
     pool:
       vmImage: ubuntu-latest
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     steps:
       # Checkout repo
       - checkout: self
         fetchDepth: 0
         persistCredentials: true
         displayName: Git Checkout
-
-      # Setup Node.js
-      - task: UseNode@1
-        inputs:
-          version: ">=24.0.0"
-        displayName: "Setup Node.js"
-
-      # Install SFDX & Dependencies
-      - script: |
-          npm install @salesforce/cli --global
-          sf plugins install @salesforce/plugin-packaging
-          echo 'y' | sf plugins install sfdx-hardis
-          echo 'y' | sf plugins install sfdmu
-          echo 'y' | sf plugins install sfdx-git-delta
-          sf version --verbose --json
-          # Uncomment the coding agent CLIs you want to use for auto-fix of deployment errors
-          # npm install --no-cache @anthropic-ai/claude-code@latest --global && claude --version
-          # npm install --no-cache @openai/codex@latest --global && codex --version
-          # npm install --no-cache @google/gemini-cli@latest --global && gemini --version
-          # npm install --no-cache @github/copilot@latest --global && copilot --version
-        displayName: "Install SFDX & plugins"
 
       # Login & Deploy sfdx sources to related org (configuration: https://hardisgroupcom.github.io/sfdx-hardis/salesforce-ci-cd-setup-auth/ )
       - script: |

--- a/defaults/ci/azure-pipelines-deployment.yml
+++ b/defaults/ci/azure-pipelines-deployment.yml
@@ -35,6 +35,7 @@ jobs:
       vmImage: ubuntu-latest
     # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
     # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
     # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     steps:

--- a/defaults/ci/azure-pipelines-deployment.yml
+++ b/defaults/ci/azure-pipelines-deployment.yml
@@ -51,13 +51,14 @@ jobs:
             echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch ${BRANCH_NAME}"
             exit 0
           fi
-          if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-            git config user.email "sfdx-hardis-bot@cloudity.com"
-            git config user.name "sfdx-hardis Bot"
-            echo "[sfdx-hardis] Azure push/PR auth enabled for coding agents via SYSTEM_ACCESSTOKEN"
-          else
-            echo "[sfdx-hardis] Skipping coding-agent Azure auth setup: SYSTEM_ACCESSTOKEN is not set"
-          fi
+          # Uncomment the lines below to allow coding agents to push auto-fix branches and create Pull Requests
+          # (also requires the sfdx-hardis-ubuntu-with-agents image, an AI API key in the variables below,
+          # and "Contribute" + "Create branch" permissions for the Build Service user on the repository)
+          # if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+          #   git config user.email "sfdx-hardis-bot@cloudity.com"
+          #   git config user.name "sfdx-hardis Bot"
+          #   echo "[sfdx-hardis] Azure push/PR auth enabled for coding agents via SYSTEM_ACCESSTOKEN"
+          # fi
           sf hardis:auth:login
           sf hardis:project:deploy:smart
         env:

--- a/defaults/ci/bitbucket-pipelines.yml
+++ b/defaults/ci/bitbucket-pipelines.yml
@@ -1,5 +1,9 @@
 # You might add new branch names in pipeline "branches"
-image: node:24
+
+# Steps run in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+# You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+# To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+image: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
 definitions:
   services:
     docker:
@@ -25,16 +29,6 @@ pipelines:
               clone:
                 depth: full
               script:
-                - npm install --no-cache @salesforce/cli --global
-                - sf plugins install @salesforce/plugin-packaging
-                - echo 'y' | sf plugins install sfdx-hardis
-                - echo 'y' | sf plugins install sfdx-git-delta
-                - sf version --verbose --json
-                # Uncomment the coding agent CLIs you want to use for auto-fix of deployment errors
-                # - npm install --no-cache @anthropic-ai/claude-code@latest --global && claude --version
-                # - npm install --no-cache @openai/codex@latest --global && codex --version
-                # - npm install --no-cache @google/gemini-cli@latest --global && gemini --version
-                # - npm install --no-cache @github/copilot@latest --global && copilot --version
                 - export BRANCH_NAME=$(echo "$BITBUCKET_PR_DESTINATION_BRANCH" |
                   sed 's/refs\/heads\///')
                 - export CI_COMMIT_REF_NAME=$BRANCH_NAME
@@ -72,16 +66,6 @@ pipelines:
           clone:
             depth: full
           script:
-            - npm install --no-cache @salesforce/cli --global
-            - sf plugins install @salesforce/plugin-packaging
-            - echo 'y' | sf plugins install sfdx-hardis
-            - echo 'y' | sf plugins install sfdx-git-delta
-            - sf version --verbose --json
-            # Uncomment the coding agent CLIs you want to use for auto-fix of deployment errors
-            # - npm install --no-cache @anthropic-ai/claude-code@latest --global && claude --version
-            # - npm install --no-cache @openai/codex@latest --global && codex --version
-            # - npm install --no-cache @google/gemini-cli@latest --global && gemini --version
-            # - npm install --no-cache @github/copilot@latest --global && copilot --version
             - export BRANCH_NAME=$(echo "$BITBUCKET_BRANCH" | sed
               's/refs\/heads\///')
             - export CI_COMMIT_REF_NAME=$BRANCH_NAME

--- a/defaults/ci/bitbucket-pipelines.yml
+++ b/defaults/ci/bitbucket-pipelines.yml
@@ -2,6 +2,7 @@
 
 # Steps run in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
 # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+# Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
 # To use coding agents for auto-fix of deployment errors, use image ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
 image: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
 definitions:

--- a/defaults/ci/bitbucket-pipelines.yml
+++ b/defaults/ci/bitbucket-pipelines.yml
@@ -44,16 +44,17 @@ pipelines:
                     echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch $CURRENT_BRANCH_NAME"
                     exit 0
                   fi
-                - |
-                  if [ -n "${CI_SFDX_HARDIS_BITBUCKET_TOKEN:-}" ]; then
-                    git config user.email "sfdx-hardis-bot@cloudity.com"
-                    git config user.name "sfdx-hardis Bot"
-                    ORIGIN_PATH=$(git remote get-url origin | sed -E 's#^https?://##; s#^git@([^:]+):#\1/#; s#^ssh://git@([^/]+)/#\1/#; s#\.git$##')
-                    git remote set-url origin "https://x-token-auth:${CI_SFDX_HARDIS_BITBUCKET_TOKEN}@${ORIGIN_PATH}.git"
-                    echo "[sfdx-hardis] Bitbucket push/PR auth enabled for coding agents"
-                  else
-                    echo "[sfdx-hardis] Skipping coding-agent Bitbucket auth setup: CI_SFDX_HARDIS_BITBUCKET_TOKEN is not set"
-                  fi
+                # Uncomment the lines below to allow coding agents to push auto-fix branches and create Pull Requests
+                # (also requires the sfdx-hardis-ubuntu-with-agents image, an AI API key,
+                # and a CI_SFDX_HARDIS_BITBUCKET_TOKEN repository variable with repository:write + pullrequest:write scopes)
+                # - |
+                #   if [ -n "${CI_SFDX_HARDIS_BITBUCKET_TOKEN:-}" ]; then
+                #     git config user.email "sfdx-hardis-bot@cloudity.com"
+                #     git config user.name "sfdx-hardis Bot"
+                #     ORIGIN_PATH=$(git remote get-url origin | sed -E 's#^https?://##; s#^git@([^:]+):#\1/#; s#^ssh://git@([^/]+)/#\1/#; s#\.git$##')
+                #     git remote set-url origin "https://x-token-auth:${CI_SFDX_HARDIS_BITBUCKET_TOKEN}@${ORIGIN_PATH}.git"
+                #     echo "[sfdx-hardis] Bitbucket push/PR auth enabled for coding agents"
+                #   fi
                 - sf hardis:auth:login
                 - sf hardis:project:deploy:smart --check
               artifacts:
@@ -79,16 +80,17 @@ pipelines:
                 echo "[sfdx-hardis] Skipping sf hardis commands on auto-fix branch $CURRENT_BRANCH_NAME"
                 exit 0
               fi
-            - |
-              if [ -n "${CI_SFDX_HARDIS_BITBUCKET_TOKEN:-}" ]; then
-                git config user.email "sfdx-hardis-bot@cloudity.com"
-                git config user.name "sfdx-hardis Bot"
-                ORIGIN_PATH=$(git remote get-url origin | sed -E 's#^https?://##; s#^git@([^:]+):#\1/#; s#^ssh://git@([^/]+)/#\1/#; s#\.git$##')
-                git remote set-url origin "https://x-token-auth:${CI_SFDX_HARDIS_BITBUCKET_TOKEN}@${ORIGIN_PATH}.git"
-                echo "[sfdx-hardis] Bitbucket push/PR auth enabled for coding agents"
-              else
-                echo "[sfdx-hardis] Skipping coding-agent Bitbucket auth setup: CI_SFDX_HARDIS_BITBUCKET_TOKEN is not set"
-              fi
+            # Uncomment the lines below to allow coding agents to push auto-fix branches and create Pull Requests
+            # (also requires the sfdx-hardis-ubuntu-with-agents image, an AI API key,
+            # and a CI_SFDX_HARDIS_BITBUCKET_TOKEN repository variable with repository:write + pullrequest:write scopes)
+            # - |
+            #   if [ -n "${CI_SFDX_HARDIS_BITBUCKET_TOKEN:-}" ]; then
+            #     git config user.email "sfdx-hardis-bot@cloudity.com"
+            #     git config user.name "sfdx-hardis Bot"
+            #     ORIGIN_PATH=$(git remote get-url origin | sed -E 's#^https?://##; s#^git@([^:]+):#\1/#; s#^ssh://git@([^/]+)/#\1/#; s#\.git$##')
+            #     git remote set-url origin "https://x-token-auth:${CI_SFDX_HARDIS_BITBUCKET_TOKEN}@${ORIGIN_PATH}.git"
+            #     echo "[sfdx-hardis] Bitbucket push/PR auth enabled for coding agents"
+            #   fi
             - sf hardis:auth:login
             - sf hardis:project:deploy:smart
           artifacts:

--- a/defaults/lintonly/.gitlab-ci.yml
+++ b/defaults/lintonly/.gitlab-ci.yml
@@ -5,9 +5,9 @@
 stages:
   - check # Controle de qualité des sources
 
-# On execute les jobs sur l'image hardisgroupcom/sfdx-hardis qui contient les applications necessaires
+# On execute les jobs sur l'image sfdx-hardis qui contient les applications necessaires
 # Version latest recommandée, cependant beta et alpha peuvent être utilisées pour les tests
-image: hardisgroupcom/sfdx-hardis:latest # If rate limits reached, use ghcr.io/hardisgroupcom/sfdx-hardis:latest
+image: ghcr.io/hardisgroupcom/sfdx-hardis:latest
 
 # Variables globales aux jobs
 variables:

--- a/defaults/lintonly/.gitlab-ci.yml
+++ b/defaults/lintonly/.gitlab-ci.yml
@@ -7,6 +7,7 @@ stages:
 
 # On execute les jobs sur l'image sfdx-hardis qui contient les applications necessaires
 # Version latest recommandée, cependant beta et alpha peuvent être utilisées pour les tests
+# Les images sont aussi disponibles en miroir sur Docker Hub si votre infrastructure ne peut télécharger que depuis docker.io: hardisgroupcom/sfdx-hardis:latest
 image: ghcr.io/hardisgroupcom/sfdx-hardis:latest
 
 # Variables globales aux jobs

--- a/defaults/monitoring/.github/workflows/org-monitoring.yml
+++ b/defaults/monitoring/.github/workflows/org-monitoring.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
     # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Backup metadatas
     permissions: write-all

--- a/defaults/monitoring/.github/workflows/org-monitoring.yml
+++ b/defaults/monitoring/.github/workflows/org-monitoring.yml
@@ -37,12 +37,15 @@ jobs:
   ##############################################
   backup:
     runs-on: ubuntu-latest
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Backup metadatas
     permissions: write-all
     timeout-minutes: 360
     strategy:
       fail-fast: false
-      max-parallel: 10 # Set to 1 if you have issues with command npm install --no-cache @salesforce/cli --global
+      max-parallel: 10 # Set to 1 if you have issues with race conditions
       matrix:
         # MANUAL: Add your monitored git branches here
         branch:
@@ -55,22 +58,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Faster code checkout fetching only latest commit
+          fetch-depth: 0 # Fetch all branches & git history (required to generate Flow history documentation)
           ref: ${{ matrix.branch }}
           persist-credentials: true
-      # Setup node
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      # SFDX & plugins
-      - name: Install SFDX and plugins
-        run: |
-          npm install --no-cache @salesforce/cli --global
-          sf plugins install --force @salesforce/plugin-packaging
-          echo 'y' | sf plugins install --force sfdx-hardis
-          echo 'y' | sf plugins install --force sfdx-git-delta
-          sf version --verbose --json
       # Login & check deploy with test classes & code coverage
       - name: Login & Retrieve Metadata
         env:
@@ -131,13 +121,15 @@ jobs:
   ######################
   apex_tests:
     runs-on: ubuntu-latest
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Apex tests
     needs: backup
     permissions: write-all
     timeout-minutes: 360
     strategy:
       fail-fast: false
-      max-parallel: 10 # Set to 1 if you have issues with command npm install --no-cache @salesforce/cli --global
+      max-parallel: 10 # Set to 1 if you have issues with race conditions
       matrix:
         # MANUAL: Add your monitored git branches here
         branch:
@@ -150,22 +142,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Faster code checkout fetching only latest commit
+          fetch-depth: 0 # Fetch all branches & git history (required to generate Flow history documentation)
           ref: ${{ matrix.branch }}
           persist-credentials: true
-      # Setup node
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      # SFDX & plugins
-      - name: Install SFDX and plugins
-        run: |
-          npm install --no-cache @salesforce/cli --global
-          sf plugins install --force @salesforce/plugin-packaging
-          echo 'y' | sf plugins install --force sfdx-hardis
-          echo 'y' | sf plugins install --force sfdx-git-delta
-          sf version --verbose --json
       # Login & check deploy with test classes & code coverage
       - name: Login & Run apex tests
         env:
@@ -231,7 +210,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Faster code checkout fetching only latest commit
+          fetch-depth: 0 # Fetch all branches & git history (required to generate Flow history documentation)
           ref: ${{ matrix.branch }}
           persist-credentials: true
 
@@ -272,13 +251,15 @@ jobs:
   # Monitoring additional checks job
   monitoring:
     runs-on: ubuntu-latest
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Monitoring
     needs: backup
     permissions: read-all
     timeout-minutes: 360
     strategy:
       fail-fast: false
-      max-parallel: 10 # Set to 1 if you have issues with command npm install --no-cache @salesforce/cli --global
+      max-parallel: 10 # Set to 1 if you have issues with race conditions
       matrix:
         # MANUAL: Add your monitored git branches here
         branch:
@@ -294,19 +275,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ matrix.branch }}
           persist-credentials: true
-      # Setup node
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      # SFDX & plugins
-      - name: Install SFDX and plugins
-        run: |
-          npm install --no-cache @salesforce/cli --global
-          sf plugins install --force @salesforce/plugin-packaging
-          echo 'y' | sf plugins install --force sfdx-hardis
-          echo 'y' | sf plugins install --force sfdx-git-delta
-          sf version --verbose --json
       # Login & check deploy with test classes & code coverage
       - name: Login & Run monitoring checks
         env:

--- a/defaults/monitoring/.github/workflows/org-monitoring.yml
+++ b/defaults/monitoring/.github/workflows/org-monitoring.yml
@@ -42,7 +42,8 @@ jobs:
     # Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Backup metadatas
-    permissions: write-all
+    permissions:
+      contents: write # Allows the job to push the commit containing the retrieved metadata
     timeout-minutes: 360
     strategy:
       fail-fast: false
@@ -126,7 +127,7 @@ jobs:
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     name: Apex tests
     needs: backup
-    permissions: write-all
+    permissions: read-all
     timeout-minutes: 360
     strategy:
       fail-fast: false

--- a/defaults/monitoring/.gitlab-ci.yml
+++ b/defaults/monitoring/.gitlab-ci.yml
@@ -16,7 +16,8 @@ stages:
   - monitor
 
 # Use sfdx-hardis docker image to always be up to date with latest version
-image: hardisgroupcom/sfdx-hardis:latest # If rate limits reached, use ghcr.io/hardisgroupcom/sfdx-hardis:latest
+# An ubuntu-based variant is also available: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest (bigger, but includes Chrome for mermaid diagrams generation)
+image: ghcr.io/hardisgroupcom/sfdx-hardis:latest
 
 ##############################################
 ### Sfdx Sources Backup + Push new commit ####

--- a/defaults/monitoring/.gitlab-ci.yml
+++ b/defaults/monitoring/.gitlab-ci.yml
@@ -16,6 +16,7 @@ stages:
   - monitor
 
 # Use sfdx-hardis docker image to always be up to date with latest version
+# Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis:latest
 # An ubuntu-based variant is also available: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest (bigger, but includes Chrome for mermaid diagrams generation)
 image: ghcr.io/hardisgroupcom/sfdx-hardis:latest
 

--- a/defaults/monitoring/Jenkinsfile
+++ b/defaults/monitoring/Jenkinsfile
@@ -16,7 +16,7 @@
 //    Missing optional credentials are silently ignored - the pipeline will NOT crash.
 //
 // 3. The Docker agent requires Docker to be available on the Jenkins node.
-//    The main agent uses hardisgroupcom/sfdx-hardis:latest.
+//    The main agent uses ghcr.io/hardisgroupcom/sfdx-hardis:latest.
 //    MegaLinter runs via `docker run` inside that agent (Docker socket is mounted).
 //
 // Doc & support: https://sfdx-hardis.cloudity.com/salesforce-monitoring-home/

--- a/defaults/monitoring/Jenkinsfile
+++ b/defaults/monitoring/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
     agent {
         docker {
             // Use sfdx-hardis image - no install step needed. If not working on Jenkins, use ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
+            // Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis:latest
             image 'ghcr.io/hardisgroupcom/sfdx-hardis:latest'
             // Mount Docker socket so MegaLinter can run as a sibling container
             args '-v /var/run/docker.sock:/var/run/docker.sock --user root'

--- a/defaults/monitoring/azure-pipelines.yml
+++ b/defaults/monitoring/azure-pipelines.yml
@@ -36,6 +36,7 @@ jobs:
       vmImage: "ubuntu-latest"
     # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
     # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    # Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
     container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
 
     steps:

--- a/defaults/monitoring/azure-pipelines.yml
+++ b/defaults/monitoring/azure-pipelines.yml
@@ -34,6 +34,9 @@ jobs:
   - job: BackupSfdxHardis
     pool:
       vmImage: "ubuntu-latest"
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
 
     steps:
       - checkout: self
@@ -46,14 +49,6 @@ jobs:
           git config --global user.name "sfdx-hardis monitoring"
         workingDirectory: $(System.DefaultWorkingDirectory)
         displayName: Git config
-
-      - script: |
-          npm install @salesforce/cli -g
-          sf plugins install @salesforce/plugin-packaging
-          echo y | sf plugins install sfdx-hardis
-          sf version --verbose --json
-        workingDirectory: $(System.DefaultWorkingDirectory)
-        displayName: Install @salesforce/cli & sfdx-hardis
 
       - script: |
           git checkout -b "$BRANCH_NAME"
@@ -127,20 +122,14 @@ jobs:
     dependsOn: BackupSfdxHardis
     pool:
       vmImage: "ubuntu-latest"
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
     timeoutInMinutes: "120"
 
     steps:
       - checkout: self
         persistCredentials: "true"
         displayName: Git checkout
-
-      - script: |
-          npm install @salesforce/cli -g
-          sf plugins install @salesforce/plugin-packaging
-          echo y | sf plugins install sfdx-hardis
-          sf version --verbose --json
-        workingDirectory: $(System.DefaultWorkingDirectory)
-        displayName: Install @salesforce/cli & sfdx-hardis
 
       - script: |
           git pull origin "${BRANCH_NAME}" || echo "Issue when pulling latest branch state, but that should be ok"
@@ -245,19 +234,13 @@ jobs:
     dependsOn: BackupSfdxHardis
     pool:
       vmImage: "ubuntu-latest"
+    # Job runs in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+    container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
 
     steps:
       - checkout: self
         persistCredentials: "true"
         displayName: Git checkout
-
-      - script: |
-          npm install @salesforce/cli -g
-          sf plugins install @salesforce/plugin-packaging
-          echo y | sf plugins install sfdx-hardis
-          sf version --verbose --json
-        workingDirectory: $(System.DefaultWorkingDirectory)
-        displayName: Install @salesforce/cli & sfdx-hardis
 
       - script: |
           git config --global user.email "contact@cloudity.com"

--- a/defaults/monitoring/bitbucket-pipelines.yml
+++ b/defaults/monitoring/bitbucket-pipelines.yml
@@ -5,6 +5,7 @@
 
 # Steps run in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
 # You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+# Images are also mirrored on Docker Hub, if your infrastructure can only pull from docker.io: hardisgroupcom/sfdx-hardis-ubuntu:latest
 image: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
 definitions:
   services:

--- a/defaults/monitoring/bitbucket-pipelines.yml
+++ b/defaults/monitoring/bitbucket-pipelines.yml
@@ -3,7 +3,9 @@
 
 # Doc & support: https://sfdx-hardis.cloudity.com/salesforce-monitoring-home/
 
-image: node:24
+# Steps run in sfdx-hardis docker image, that includes Salesforce CLI and all required plugins & dependencies.
+# You can use latest, beta or a version number (ex: v7.23.0), and pin a version if you need reproducible runs.
+image: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest
 definitions:
   services:
     docker:
@@ -19,12 +21,6 @@ pipelines:
         clone:
           depth: full
         script:
-          # Install SF Cli & dependencies
-          - npm install --no-cache @salesforce/cli --global
-          - sf plugins install @salesforce/plugin-packaging
-          - echo 'y' | sf plugins install sfdx-hardis
-          - echo 'y' | sf plugins install sfdx-git-delta
-          - sf version --verbose --json
           - export BRANCH_NAME=$(echo "$BITBUCKET_BRANCH" | sed 's/refs\/heads\///')
           - export CI_COMMIT_REF_NAME=$BRANCH_NAME
           - export CONFIG_BRANCH=$BRANCH_NAME
@@ -49,12 +45,6 @@ pipelines:
         - step:
             name: Apex Tests sfdx-hardis
             script:
-              # Install SF Cli & dependencies
-              - npm install --no-cache @salesforce/cli --global
-              - sf plugins install @salesforce/plugin-packaging
-              - echo 'y' | sf plugins install sfdx-hardis
-              - echo 'y' | sf plugins install sfdx-git-delta
-              - sf version --verbose --json
               - export BRANCH_NAME=$(echo "$BITBUCKET_BRANCH" | sed 's/refs\/heads\///')
               - export CI_COMMIT_REF_NAME=$BRANCH_NAME
               - export CONFIG_BRANCH=$BRANCH_NAME
@@ -88,12 +78,6 @@ pipelines:
         - step:
             name: Other Monitoring checks sfdx-hardis
             script:
-              # Install SF Cli & dependencies
-              - npm install --no-cache @salesforce/cli --global
-              - sf plugins install @salesforce/plugin-packaging
-              - echo 'y' | sf plugins install sfdx-hardis
-              - echo 'y' | sf plugins install sfdx-git-delta
-              - sf version --verbose --json
               - export BRANCH_NAME=$(echo "$BITBUCKET_BRANCH" | sed 's/refs\/heads\///')
               - export CI_COMMIT_REF_NAME=$BRANCH_NAME
               - export CONFIG_BRANCH=$BRANCH_NAME

--- a/docs/hardis/doc/project2markdown.md
+++ b/docs/hardis/doc/project2markdown.md
@@ -40,14 +40,14 @@ To read flow documentation, if your markdown reader doesn't handle MermaidJS syn
 
 Both modes will be tried by default, but you can also force one of them by defining environment variable `MERMAID_MODES=docker` or `MERMAID_MODES=cli`
 
-_sfdx-hardis docker image is alpine-based and does not succeed to run mermaid/puppeteer: if you can help, please submit a PR !_
+_The alpine-based sfdx-hardis docker image does not succeed to run mermaid/puppeteer: use the ubuntu-based image `ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu`, that embeds Chrome and runs mermaid-cli out of the box._
 
 If Flow history doc always display a single state, you probably need to update your workflow configuration:
 
 - on Gitlab: Env variable [`GIT_FETCH_EXTRA_FLAGS: --depth 10000`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.gitlab-ci.yml#L11)
-- on GitHub: [`fetch-depth: 0`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L58)
-- on Azure: [`fetchDepth: "0"`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L39)
-- on Bitbucket: [`step: clone: depth: full`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L18)
+- on GitHub: [`fetch-depth: 0`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L61)
+- on Azure: [`fetchDepth: "0"`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L45)
+- on Bitbucket: [`step: clone: depth: full`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L22)
 
 ![Screenshot flow doc](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/screenshot-flow-doc.jpg)
 

--- a/docs/hardis/doc/project2markdown.md
+++ b/docs/hardis/doc/project2markdown.md
@@ -45,9 +45,9 @@ _The alpine-based sfdx-hardis docker image does not succeed to run mermaid/puppe
 If Flow history doc always display a single state, you probably need to update your workflow configuration:
 
 - on Gitlab: Env variable [`GIT_FETCH_EXTRA_FLAGS: --depth 10000`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.gitlab-ci.yml#L11)
-- on GitHub: [`fetch-depth: 0`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L61)
-- on Azure: [`fetchDepth: "0"`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L45)
-- on Bitbucket: [`step: clone: depth: full`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L22)
+- on GitHub: [`fetch-depth: 0`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L62)
+- on Azure: [`fetchDepth: "0"`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L46)
+- on Bitbucket: [`step: clone: depth: full`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L23)
 
 ![Screenshot flow doc](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/screenshot-flow-doc.jpg)
 

--- a/docs/hardis/org/monitor/backup.md
+++ b/docs/hardis/org/monitor/backup.md
@@ -71,9 +71,9 @@ By default, only changed files are used to generate the documentation (diff-only
 If Flow history doc always display a single state, you probably need to update your workflow configuration:
 
 - on Gitlab: Env variable [`GIT_FETCH_EXTRA_FLAGS: --depth 10000`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.gitlab-ci.yml#L11)
-- on GitHub: [`fetch-depth: 0`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L61)
-- on Azure: [`fetchDepth: "0"`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L45)
-- on Bitbucket: [`step: clone: depth: full`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L22)
+- on GitHub: [`fetch-depth: 0`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L62)
+- on Azure: [`fetchDepth: "0"`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L46)
+- on Bitbucket: [`step: clone: depth: full`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L23)
 
 ### Agent Mode
 

--- a/docs/hardis/org/monitor/backup.md
+++ b/docs/hardis/org/monitor/backup.md
@@ -71,9 +71,9 @@ By default, only changed files are used to generate the documentation (diff-only
 If Flow history doc always display a single state, you probably need to update your workflow configuration:
 
 - on Gitlab: Env variable [`GIT_FETCH_EXTRA_FLAGS: --depth 10000`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.gitlab-ci.yml#L11)
-- on GitHub: [`fetch-depth: 0`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L58)
-- on Azure: [`fetchDepth: "0"`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L39)
-- on Bitbucket: [`step: clone: depth: full`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L18)
+- on GitHub: [`fetch-depth: 0`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L61)
+- on Azure: [`fetchDepth: "0"`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L45)
+- on Bitbucket: [`step: clone: depth: full`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L22)
 
 ### Agent Mode
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,8 @@ You can use sfdx-hardis docker images to run in CI.
 
 > All our Docker images are checked for security issues with [MegaLinter by OX Security](https://megalinter.io/latest/)
 
+> Images are published on **GitHub Container Registry (ghcr.io)**. Publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization, so do not use the `hub.docker.com` images: they are not updated anymore.
+
 Two image flavors are available:
 
 - **Standard images** (`sfdx-hardis`, `sfdx-hardis-ubuntu`): Salesforce CI/CD tooling without coding agent CLIs. Use these for standard deployments.
@@ -129,29 +131,15 @@ Two image flavors are available:
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - Docker Hub
-
-    - [**hardisgroupcom/sfdx-hardis:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with latest @salesforce/cli version)
-    - [**hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
-
-  - GitHub Packages (ghcr.io)
-
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket)
 
-  - Docker Hub
-
-    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
-
-  - GitHub Packages (ghcr.io)
-
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 
@@ -165,15 +153,13 @@ These images include Claude Code, OpenAI Codex, Gemini CLI, and GitHub Copilot p
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - Docker Hub: [**hardisgroupcom/sfdx-hardis-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-with-agents)
-  - GitHub Packages: [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket - recommended for coding agents)
 
-  - Docker Hub: [**hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu-with-agents)
-  - GitHub Packages: [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ You can use sfdx-hardis docker images to run in CI.
 
 > All our Docker images are checked for security issues with [MegaLinter by OX Security](https://megalinter.io/latest/)
 
-> Images are published on **GitHub Container Registry (ghcr.io)**. Publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization, so do not use the `hub.docker.com` images: they are not updated anymore.
+> Images are published on both **GitHub Container Registry (ghcr.io)** and **Docker Hub**. Prefer the **ghcr.io** images: their publication does not rely on any long-lived token (it is secured with the workflow's ephemeral credentials), so they have the most secure supply chain. Use the Docker Hub mirror images when your infrastructure can only pull from `docker.io`.
 
 Two image flavors are available:
 
@@ -131,15 +131,29 @@ Two image flavors are available:
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - GitHub Container Registry (recommended)
+
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+
+  - Docker Hub (mirror)
+
+    - [**hardisgroupcom/sfdx-hardis:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with latest @salesforce/cli version)
+    - [**hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - GitHub Container Registry (recommended)
+
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+
+  - Docker Hub (mirror)
+
+    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 
@@ -153,13 +167,15 @@ These images include Claude Code, OpenAI Codex, Gemini CLI, and GitHub Copilot p
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - GitHub Container Registry (recommended): [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - Docker Hub (mirror): [**hardisgroupcom/sfdx-hardis-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-with-agents)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket - recommended for coding agents)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - GitHub Container Registry (recommended): [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - Docker Hub (mirror): [**hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu-with-agents)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,7 +47,7 @@ You can use sfdx-hardis docker images to run in CI.
 
 > All our Docker images are checked for security issues with [MegaLinter by OX Security](https://megalinter.io/latest/)
 
-> Images are published on **GitHub Container Registry (ghcr.io)**. Publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization, so do not use the `hub.docker.com` images: they are not updated anymore.
+> Images are published on both **GitHub Container Registry (ghcr.io)** and **Docker Hub**. Prefer the **ghcr.io** images: their publication does not rely on any long-lived token (it is secured with the workflow's ephemeral credentials), so they have the most secure supply chain. Use the Docker Hub mirror images when your infrastructure can only pull from `docker.io`.
 
 Two image flavors are available:
 
@@ -61,15 +61,29 @@ Two image flavors are available:
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - GitHub Container Registry (recommended)
+
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+
+  - Docker Hub (mirror)
+
+    - [**hardisgroupcom/sfdx-hardis:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with latest @salesforce/cli version)
+    - [**hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - GitHub Container Registry (recommended)
+
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+
+  - Docker Hub (mirror)
+
+    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 
@@ -83,12 +97,14 @@ These images include Claude Code, OpenAI Codex, Gemini CLI, and GitHub Copilot p
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - GitHub Container Registry (recommended): [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - Docker Hub (mirror): [**hardisgroupcom/sfdx-hardis-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-with-agents)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket - recommended for coding agents)
 
-  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - GitHub Container Registry (recommended): [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - Docker Hub (mirror): [**hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu-with-agents)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,6 +47,8 @@ You can use sfdx-hardis docker images to run in CI.
 
 > All our Docker images are checked for security issues with [MegaLinter by OX Security](https://megalinter.io/latest/)
 
+> Images are published on **GitHub Container Registry (ghcr.io)**. Publication to Docker Hub is paused until OIDC authentication is available for the hardisgroupcom organization, so do not use the `hub.docker.com` images: they are not updated anymore.
+
 Two image flavors are available:
 
 - **Standard images** (`sfdx-hardis`, `sfdx-hardis-ubuntu`): Salesforce CI/CD tooling without coding agent CLIs. Use these for standard deployments.
@@ -59,29 +61,15 @@ Two image flavors are available:
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - Docker Hub
-
-    - [**hardisgroupcom/sfdx-hardis:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with latest @salesforce/cli version)
-    - [**hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
-
-  - GitHub Packages (ghcr.io)
-
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with latest @salesforce/cli version)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket)
 
-  - Docker Hub
-
-    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-    - [**hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
-
-  - GitHub Packages (ghcr.io)
-
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
-    - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with latest @salesforce/cli version)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest-sfdx-recommended**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu) (with recommended @salesforce/cli version, in case the latest version of @salesforce/cli is buggy)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_
 
@@ -95,14 +83,12 @@ These images include Claude Code, OpenAI Codex, Gemini CLI, and GitHub Copilot p
 
 - Linux **Alpine** based images (works on GitLab)
 
-  - Docker Hub: [**hardisgroupcom/sfdx-hardis-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-with-agents)
-  - GitHub Packages: [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-with-agents)
 
 _See [Dockerfile](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile)_
 
 - Linux **Ubuntu** based images (works on GitHub, Azure & Bitbucket - recommended for coding agents)
 
-  - Docker Hub: [**hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://hub.docker.com/r/hardisgroupcom/sfdx-hardis-ubuntu-with-agents)
-  - GitHub Packages: [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
+  - [**ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest**](https://github.com/hardisgroupcom/sfdx-hardis/pkgs/container/sfdx-hardis-ubuntu-with-agents)
 
 _See [Dockerfile-ubuntu](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/Dockerfile-ubuntu)_

--- a/docs/salesforce-agentic-automation.md
+++ b/docs/salesforce-agentic-automation.md
@@ -98,11 +98,14 @@ See [Using AI Coding Agents](salesforce-ci-cd-agent-skills.md) for more detailed
 For CI/CD pipelines that need to run sfdx-hardis **and** an AI agent CLI in the same container:
 
 ```yaml
-# GitHub Actions
-image: hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+# GitHub Actions, Azure Pipelines
+container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
+
+# Bitbucket Pipelines
+image: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest
 
 # GitLab CI
-image: hardisgroupcom/sfdx-hardis-with-agents:latest
+image: ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest
 ```
 
 These images include Claude Code, OpenAI Codex, Gemini CLI, GitHub Copilot, and Cursor pre-installed.

--- a/docs/salesforce-ci-cd-setup-checklist.md
+++ b/docs/salesforce-ci-cd-setup-checklist.md
@@ -217,9 +217,9 @@ _Optional, but it makes deployment errors much faster to solve. See [Setup AI in
 
 _Optional. Only if you want the pipeline to fix deployment errors and push fix branches. See [Coding Agent Auto-Fix](salesforce-deployment-agent-autofix.md)_
 
-The default workflow files already contain the coding agent install lines (commented out), the `git remote set-url` snippet and the `auto-fix/` branch skipping, so only the following is up to you.
+The default workflow files already contain the `git remote set-url` snippet and the `auto-fix/` branch skipping, so only the following is up to you.
 
-- [ ] If you do not use the sfdx-hardis Docker image: the install line of the coding agent CLI you want is **uncommented** in the workflow file.
+- [ ] The workflow uses a **`-with-agents`** sfdx-hardis Docker image variant (ex: `ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest`), or, if your pipeline installs the CLI with npm instead of using the Docker image, the install line of the coding agent CLI you want is added to the workflow file.
 - [ ] Auto-fix is enabled: `codingAgentAutoFix: true` in `.sfdx-hardis.yml`.
 - [ ] The agent is chosen: `codingAgent` in `.sfdx-hardis.yml` (`claude`, `codex-cli`, `gemini-cli`, `copilot-cli`).
 - [ ] The API key of the chosen agent is set as a masked secret (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY` / `CODEX_API_KEY`, `GEMINI_API_KEY`, `COPILOT_GITHUB_TOKEN`), unless it reuses `LANGCHAIN_LLM_MODEL_API_KEY`.

--- a/docs/salesforce-deployment-agent-autofix.md
+++ b/docs/salesforce-deployment-agent-autofix.md
@@ -72,9 +72,12 @@ This loop can run multiple times (`PR-2`, `PR-3`, etc.) until the check deploy j
 
 ### 1. Install a coding agent CLI
 
-If you are using the **sfdx-hardis Docker images**, all agent CLIs are pre-installed.
+If you are using the **sfdx-hardis Docker images** (the default in the CI/CD pipeline templates), switch to a **`-with-agents`** image variant, that has all agent CLIs pre-installed:
 
-If you run your own CI/CD pipeline, install the CLI(s) you want to use:
+- `ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest` (GitHub Actions, Azure Pipelines, Bitbucket Pipelines)
+- `ghcr.io/hardisgroupcom/sfdx-hardis-with-agents:latest` (GitLab CI, alpine-based: some agents may crash on Alpine/musl, prefer the ubuntu variant if so)
+
+If your CI/CD pipeline installs Salesforce CLI with npm instead of using the Docker images, install the CLI(s) you want to use:
 
 ```bash
 # Pick one (or more):
@@ -83,8 +86,6 @@ npm install -g @openai/codex
 npm install -g @google/gemini-cli
 npm install -g @github/copilot
 ```
-
-In the default CI/CD pipeline templates, these lines are present but **commented out**. Uncomment the one(s) you need.
 
 ### 2. Enable auto-fix
 

--- a/src/commands/hardis/doc/project2markdown.ts
+++ b/src/commands/hardis/doc/project2markdown.ts
@@ -102,14 +102,14 @@ To read flow documentation, if your markdown reader doesn't handle MermaidJS syn
 
 Both modes will be tried by default, but you can also force one of them by defining environment variable \`MERMAID_MODES=docker\` or \`MERMAID_MODES=cli\`
 
-_sfdx-hardis docker image is alpine-based and does not succeed to run mermaid/puppeteer: if you can help, please submit a PR !_
+_The alpine-based sfdx-hardis docker image does not succeed to run mermaid/puppeteer: use the ubuntu-based image \`ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu\`, that embeds Chrome and runs mermaid-cli out of the box._
 
 If Flow history doc always display a single state, you probably need to update your workflow configuration:
 
 - on Gitlab: Env variable [\`GIT_FETCH_EXTRA_FLAGS: --depth 10000\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.gitlab-ci.yml#L11)
-- on GitHub: [\`fetch-depth: 0\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L58)
-- on Azure: [\`fetchDepth: "0"\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L39)
-- on Bitbucket: [\`step: clone: depth: full\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L18)
+- on GitHub: [\`fetch-depth: 0\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L61)
+- on Azure: [\`fetchDepth: "0"\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L45)
+- on Bitbucket: [\`step: clone: depth: full\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L22)
 
 ![Screenshot flow doc](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/screenshot-flow-doc.jpg)
 

--- a/src/commands/hardis/doc/project2markdown.ts
+++ b/src/commands/hardis/doc/project2markdown.ts
@@ -107,9 +107,9 @@ _The alpine-based sfdx-hardis docker image does not succeed to run mermaid/puppe
 If Flow history doc always display a single state, you probably need to update your workflow configuration:
 
 - on Gitlab: Env variable [\`GIT_FETCH_EXTRA_FLAGS: --depth 10000\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.gitlab-ci.yml#L11)
-- on GitHub: [\`fetch-depth: 0\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L61)
-- on Azure: [\`fetchDepth: "0"\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L45)
-- on Bitbucket: [\`step: clone: depth: full\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L22)
+- on GitHub: [\`fetch-depth: 0\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L62)
+- on Azure: [\`fetchDepth: "0"\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L46)
+- on Bitbucket: [\`step: clone: depth: full\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L23)
 
 ![Screenshot flow doc](https://github.com/hardisgroupcom/sfdx-hardis/raw/main/docs/assets/images/screenshot-flow-doc.jpg)
 

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -98,9 +98,9 @@ By default, only changed files are used to generate the documentation (diff-only
 If Flow history doc always display a single state, you probably need to update your workflow configuration:
 
 - on Gitlab: Env variable [\`GIT_FETCH_EXTRA_FLAGS: --depth 10000\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.gitlab-ci.yml#L11)
-- on GitHub: [\`fetch-depth: 0\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L58)
-- on Azure: [\`fetchDepth: "0"\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L39)
-- on Bitbucket: [\`step: clone: depth: full\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L18)
+- on GitHub: [\`fetch-depth: 0\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L61)
+- on Azure: [\`fetchDepth: "0"\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L45)
+- on Bitbucket: [\`step: clone: depth: full\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L22)
 
 ### Agent Mode
 

--- a/src/commands/hardis/org/monitor/backup.ts
+++ b/src/commands/hardis/org/monitor/backup.ts
@@ -98,9 +98,9 @@ By default, only changed files are used to generate the documentation (diff-only
 If Flow history doc always display a single state, you probably need to update your workflow configuration:
 
 - on Gitlab: Env variable [\`GIT_FETCH_EXTRA_FLAGS: --depth 10000\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.gitlab-ci.yml#L11)
-- on GitHub: [\`fetch-depth: 0\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L61)
-- on Azure: [\`fetchDepth: "0"\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L45)
-- on Bitbucket: [\`step: clone: depth: full\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L22)
+- on GitHub: [\`fetch-depth: 0\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/.github/workflows/org-monitoring.yml#L62)
+- on Azure: [\`fetchDepth: "0"\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/azure-pipelines.yml#L46)
+- on Bitbucket: [\`step: clone: depth: full\`](https://github.com/hardisgroupcom/sfdx-hardis/blob/main/defaults/monitoring/bitbucket-pipelines.yml#L23)
 
 ### Agent Mode
 

--- a/src/common/aiProvider/codingAgentProvider.ts
+++ b/src/common/aiProvider/codingAgentProvider.ts
@@ -262,7 +262,7 @@ export class CodingAgentProvider {
    */
   private static warnAgentNotInstalledSuggestUbuntu(agent: CodingAgentType): void {
     if (this.isMuslSystem()) {
-      uxLog("warning", this, c.yellow(t("codingAgentNotInstalledSuggestUbuntu", { agent, ubuntuImage: "hardisgroupcom/sfdx-hardis-ubuntu:latest" })));
+      uxLog("warning", this, c.yellow(t("codingAgentNotInstalledSuggestUbuntu", { agent, ubuntuImage: "ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest" })));
     }
   }
 }


### PR DESCRIPTION
## Why

Until now, only the GitLab CI templates ran jobs in the sfdx-hardis docker image; the GitHub Actions, Azure Pipelines and Bitbucket Pipelines templates installed Node.js, Salesforce CLI and its plugins at every run. Since ubuntu-based images are now published (glibc-based, so compatible with GitHub Actions containers, Azure container jobs and Bitbucket step images), all default workflows can run in docker images.

## What changed

### Default workflow templates (`defaults/ci` & `defaults/monitoring`)

- **GitHub Actions** (`check-deploy.yml`, `process-deploy.yml`, `org-monitoring.yml`): jobs now run with `container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest`; the Setup Node + Install SFDX steps are removed. MegaLinter jobs are untouched (they need their own image / docker access).
- **Azure Pipelines** (`azure-pipelines-checks.yml`, `azure-pipelines-deployment.yml`, monitoring `azure-pipelines.yml`): jobs now use `container: ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest`; UseNode + install steps removed. MegaLinter jobs stay on the host VM (they run `docker run`).
- **Bitbucket Pipelines** (CI + monitoring): default `image` switched from `node:24` to `ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu:latest`; install lines removed.
- **GitLab CI** (CI, monitoring, lintonly) and **Jenkinsfiles**: keep the alpine-based image but now pull it from `ghcr.io/hardisgroupcom/sfdx-hardis:latest`, since Docker Hub publication is paused (#2040) and the `hub.docker.com` images are stale.
- Coding-agent auto-fix: instead of uncommenting npm install lines, the comments now direct to the `-with-agents` image variants (`ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest`, alpine variant discouraged due to musl crashes).

### Supporting changes

- `Dockerfile-ubuntu`: add `sudo`, so custom steps added to Azure Pipelines container jobs (which run as a non-root user) can still elevate privileges.
- `codingAgentProvider.ts`: the missing-agent-CLI warning now suggests `ghcr.io/hardisgroupcom/sfdx-hardis-ubuntu-with-agents:latest` (previously suggested the stale Docker Hub base image, which does not contain agent CLIs).
- Docs: installation section (README + docs/index + docs/installation) now presents ghcr.io as the registry and flags Docker Hub images as not updated anymore; agent-autofix setup and CI/CD checklist updated for the new image-based flow; fixed the misleading `fetch-depth: 0` comments and refreshed the line anchors of the doc links pointing into the monitoring templates.
- CHANGELOG entry (existing pipelines keep working — templates are only applied at initialization, or on GitLab monitoring repos that opted into `AUTO_UPDATE_GITLAB_CI_YML`).

## Verification

- All modified YAML templates parse (js-yaml).
- `ghcr.io/hardisgroupcom/sfdx-hardis`, `-ubuntu`, `-with-agents` and `-ubuntu-with-agents` `latest` + `vX.Y.Z` tags verified publicly pullable (anonymous manifest check → 200).
- Plugins resolve regardless of the CI-overridden $HOME thanks to `SF_DATA_DIR=/usr/local/lib` baked into the ubuntu image (#1347) — required for GitHub container jobs where HOME=/github/home.
- Azure container jobs requirements checked: image default user is root (agent can create its step user), no ENTRYPOINT, bash + glibc present.
- Bitbucket clones with git inside the step image: git is present in the ubuntu image.
- `tsc --noEmit` and `eslint` pass on the modified sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)