### PR TITLE
feat(queries): report query start, record count and failure to the VS Code Command Runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [beta] (main)
 
+### Core
+
+- **Queries report their number of records to VS Code**: SOQL, Tooling API, Bulk API and Data Cloud queries now tell the VS Code extension when they start, when they complete (with the number of records retrieved) and when they fail, so the Command Runner can show a record count chip next to each query. A failed query now also logs a `Query failed` line with the error message.
+- Fixed the `Fetching batch X/{{MAX}}` log line of paginated SOQL queries showing a raw placeholder instead of the maximum number of batches.
+
 ### Dependencies
 
 - **Smaller supply-chain attack surface**: 14 more npm dependencies removed (`@actions/github`, `jsdoc-to-markdown`, `inquirer`, `fs-extra`, `ora`, `open`, `sort-array`, `farmhash`, `cross-spawn`, `which`, `debug`, `dotenv`, `form-data`, unused `langchain`), replaced by Node.js built-ins and small internal helpers; `yarn test` now fails when a dependency is unused or the lock file grows past a ceiling. Node.js 22 or more is required (like the Salesforce CLI).

--- a/src/common/utils/apiUtils.ts
+++ b/src/common/utils/apiUtils.ts
@@ -1,8 +1,9 @@
 import { uxLog } from './index.js';
 import c from 'chalk';
+import { randomUUID } from 'crypto';
 import { Connection } from '@salesforce/core';
 import { createSpinner, Spinner } from './spinner.js';
-import { WebSocketClient } from '../websocketClient.js';
+import { CommandLogLineQuery, WebSocketClient } from '../websocketClient.js';
 import { generateCsvFile, generateReportPath } from './filesUtils.js';
 import { parseSoqlAndReapplyLimit } from './workaroundUtils.js';
 import { t } from './i18n.js';
@@ -25,82 +26,103 @@ export function isUnsupportedSObjectError(error: unknown, sObjectName: string): 
   );
 }
 
+// Start tracking a query in the VS Code UI: the returned object is attached to the start line,
+// then to the completion (or failure) line, so the extension can show the query state and its
+// number of records next to the query text.
+export function startQueryLog(type: CommandLogLineQuery['type']): CommandLogLineQuery {
+  return { id: randomUUID(), type, status: 'running' };
+}
+
+// Human readable summary of a completed query, e.g. "Retrieved 12 records in 3 chunks(s)"
+function queryCompletionText(recordCount: number, batchCount: number): string {
+  return batchCount > 1 ? `Retrieved ${recordCount} records in ${batchCount} chunks(s)` : `Retrieved ${recordCount} records`;
+}
+
 // Perform simple SOQL query (max results: 10000)
 export async function soqlQuery(soqlQuery: string, conn: Connection): Promise<any> {
+  const query = startQueryLog('soql');
   uxLog(
     "log",
     this,
     c.grey(
       '[SOQL Query] ' +
       c.italic(soqlQuery.length > 500 ? soqlQuery.substr(0, 500) + '...' : soqlQuery)
-    )
+    ),
+    { query }
   );
-  // First query
-  const res = await conn.query(soqlQuery);
-  let pageRes = Object.assign({}, res);
-  let batchCount = 1;
+  try {
+    // First query
+    const res = await conn.query(soqlQuery);
+    let pageRes = Object.assign({}, res);
+    let batchCount = 1;
 
-  // Get all page results
-  while (pageRes.done === false && pageRes.nextRecordsUrl && batchCount < MAX_CHUNKS) {
-    uxLog("log", this, c.grey(t('fetchingBatch', { batchCount: batchCount + 1, MAX_CHUNKS })));
-    pageRes = await conn.queryMore(pageRes.nextRecordsUrl);
-    res.records.push(...pageRes.records);
-    batchCount++;
+    // Get all page results
+    while (pageRes.done === false && pageRes.nextRecordsUrl && batchCount < MAX_CHUNKS) {
+      uxLog("log", this, c.grey(t('fetchingBatch', { batchCount: batchCount + 1, MAX: MAX_CHUNKS })));
+      pageRes = await conn.queryMore(pageRes.nextRecordsUrl);
+      res.records.push(...pageRes.records);
+      batchCount++;
+    }
+    if (!pageRes.done) {
+      uxLog("warning", this, c.yellow(t('warningQueryLimitOfRecordsReachedSome', { MAX_RECORDS })));
+      uxLog("warning", this, c.yellow(`Consider using bulkQuery for larger datasets.`));
+    }
+    uxLog("log", this, c.grey(`[SOQL Query] ${queryCompletionText(res.records.length, batchCount)}`), {
+      query: { ...query, status: 'completed', recordCount: res.records.length, batchCount },
+    });
+    return res;
+  } catch (e: any) {
+    uxLog("log", this, c.grey(`[SOQL Query] Query failed: ${e?.message || e}`), { query: { ...query, status: 'error' } });
+    throw e;
   }
-  if (!pageRes.done) {
-    uxLog("warning", this, c.yellow(t('warningQueryLimitOfRecordsReachedSome', { MAX_RECORDS })));
-    uxLog("warning", this, c.yellow(`Consider using bulkQuery for larger datasets.`));
-  }
-  if (batchCount > 1) {
-    uxLog("log", this, c.grey(`[SOQL Query] Retrieved ${res.records.length} records in ${batchCount} chunks(s)`));
-  }
-  else {
-    uxLog("log", this, c.grey(`[SOQL Query] Retrieved ${res.records.length} records`));
-  }
-  return res;
 }
 
 // Perform simple SOQL query with Tooling API
 // Uses Sforce-Query-Options: batchSize=2000 to avoid default 100-record limit (Tooling API can return fewer by default)
 export async function soqlQueryTooling(soqlQuery: string, conn: Connection): Promise<any> {
+  const query = startQueryLog('tooling');
   uxLog(
     "log",
     this,
     c.grey(
       '[SOQL Query Tooling] ' +
       c.italic(soqlQuery.length > 500 ? soqlQuery.substr(0, 500) + '...' : soqlQuery)
-    )
+    ),
+    { query }
   );
-  const apiVersion = `v${conn.getApiVersion() || '65.0'}`;
-  const queryPath = `/services/data/${apiVersion}/tooling/query/?q=${encodeURIComponent(soqlQuery)}`;
-  const headers: Record<string, string> = {
-    'Sforce-Query-Options': 'batchSize=2000',
-  };
-  const res = await conn.request<{ records: any[]; done: boolean; nextRecordsUrl?: string }>({
-    method: 'GET',
-    url: queryPath,
-    headers,
-  });
-  const result = { records: res.records || [], done: res.done, nextRecordsUrl: res.nextRecordsUrl };
-  let batchCount = 1;
-  while (result.done === false && result.nextRecordsUrl) {
-    const nextPath = result.nextRecordsUrl.startsWith('/') ? result.nextRecordsUrl : `/${result.nextRecordsUrl}`;
-    const pageRes = await conn.request<{ records: any[]; done: boolean; nextRecordsUrl?: string }>({
+  try {
+    const apiVersion = `v${conn.getApiVersion() || '65.0'}`;
+    const queryPath = `/services/data/${apiVersion}/tooling/query/?q=${encodeURIComponent(soqlQuery)}`;
+    const headers: Record<string, string> = {
+      'Sforce-Query-Options': 'batchSize=2000',
+    };
+    const res = await conn.request<{ records: any[]; done: boolean; nextRecordsUrl?: string }>({
       method: 'GET',
-      url: nextPath,
+      url: queryPath,
       headers,
     });
-    result.records.push(...(pageRes.records || []));
-    result.done = pageRes.done;
-    result.nextRecordsUrl = pageRes.nextRecordsUrl;
-    batchCount++;
+    const result = { records: res.records || [], done: res.done, nextRecordsUrl: res.nextRecordsUrl };
+    let batchCount = 1;
+    while (result.done === false && result.nextRecordsUrl) {
+      const nextPath = result.nextRecordsUrl.startsWith('/') ? result.nextRecordsUrl : `/${result.nextRecordsUrl}`;
+      const pageRes = await conn.request<{ records: any[]; done: boolean; nextRecordsUrl?: string }>({
+        method: 'GET',
+        url: nextPath,
+        headers,
+      });
+      result.records.push(...(pageRes.records || []));
+      result.done = pageRes.done;
+      result.nextRecordsUrl = pageRes.nextRecordsUrl;
+      batchCount++;
+    }
+    uxLog("log", this, c.grey(`[SOQL Query Tooling] ${queryCompletionText(result.records.length, batchCount)}`), {
+      query: { ...query, status: 'completed', recordCount: result.records.length, batchCount },
+    });
+    return result;
+  } catch (e: any) {
+    uxLog("log", this, c.grey(`[SOQL Query Tooling] Query failed: ${e?.message || e}`), { query: { ...query, status: 'error' } });
+    throw e;
   }
-  if (batchCount > 1) {
-    uxLog("log", this, c.grey(`[SOQL Query Tooling] Retrieved ${result.records.length} records in ${batchCount} chunks(s)`));
-  } else {
-    uxLog("log", this, c.grey(`[SOQL Query Tooling] Retrieved ${result.records.length} records`));
-  }
-  return result;
 }
 
 let spinnerQ;
@@ -108,7 +130,8 @@ const maxRetry = Number(process.env.BULK_QUERY_RETRY || 5);
 // Same than soqlQuery but using bulk. Do not use if there will be too many results for javascript to handle in memory
 export async function bulkQuery(soqlQuery: string, conn: Connection, retries = 3): Promise<any> {
   const queryLabel = soqlQuery.length > 500 ? soqlQuery.substr(0, 500) + '...' : soqlQuery;
-  uxLog("log", this, c.grey('[BulkApiV2] ' + c.italic(queryLabel)));
+  const query = startQueryLog('bulk');
+  uxLog("log", this, c.grey('[BulkApiV2] ' + c.italic(queryLabel)), { query });
   conn.bulk2.pollInterval = process.env.BULKAPIV2_POLL_INTERVAL ? Number(process.env.BULKAPIV2_POLL_INTERVAL) : 5000; // 5 sec
   conn.bulk2.pollTimeout = process.env.BULKAPIV2_POLL_TIMEOUT ? Number(process.env.BULKAPIV2_POLL_TIMEOUT) : 60000; // 60 sec
   // Start query
@@ -124,11 +147,16 @@ export async function bulkQuery(soqlQuery: string, conn: Connection, retries = 3
     const records = await recordStream.toArray();
     spinnerQ.succeed(`[BulkApiV2] Bulk Query completed with ${records.length} results.`);
     if (WebSocketClient.isAliveWithLwcUI()) {
-      uxLog("log", this, c.grey(`[BulkApiV2] Bulk Query completed with ${records.length} results.`));
+      uxLog("log", this, c.grey(`[BulkApiV2] Bulk Query completed with ${records.length} results.`), {
+        query: { ...query, status: 'completed', recordCount: records.length },
+      });
     }
     return { records: records };
   } catch (e: any) {
     spinnerQ.fail(`[BulkApiV2] Bulk query error: ${e.message}`);
+    if (WebSocketClient.isAliveWithLwcUI()) {
+      uxLog("log", this, c.grey(`[BulkApiV2] Bulk query error: ${e.message}`), { query: { ...query, status: 'error' } });
+    }
     // Try again if the reason is a timeout and max number of retries is not reached yet
     const eStr = e + '';
     if ((eStr.includes('ETIMEDOUT') || eStr.includes('Polling timed out')) && retries < maxRetry) {

--- a/src/common/utils/dataCloudUtils.ts
+++ b/src/common/utils/dataCloudUtils.ts
@@ -1,6 +1,8 @@
 import { Connection, SfError } from "@salesforce/core";
 import { AnyJson } from "@salesforce/ts-types";
 import { uxLog } from "./index.js";
+import { startQueryLog } from "./apiUtils.js";
+import { CommandLogLineQuery } from "../websocketClient.js";
 import fs from './fsUtils.js';
 import path from "path";
 
@@ -204,9 +206,10 @@ export async function dataCloudSqlQuery(
   }
 
   const settings = resolveOptions(options);
+  const queryLog = startQueryLog('datacloud');
 
   try {
-    const initialChunk = await submitInitialQuery(query.trim(), conn, settings);
+    const initialChunk = await submitInitialQuery(query.trim(), conn, settings, queryLog);
     if (!initialChunk.metadata.length) {
       throw new SfError(`[DataCloudSqlQuery] Data Cloud SQL query did not return column metadata.\n${JSON.stringify(initialChunk)}`);
     }
@@ -238,7 +241,9 @@ export async function dataCloudSqlQuery(
       rawData.push(...pagination.rawData);
     }
 
-    uxLog("log", this, `[DataCloudSqlQuery] Retrieved ${records.length} records.`);
+    uxLog("log", this, `[DataCloudSqlQuery] Retrieved ${records.length} records.`, {
+      query: { ...queryLog, status: 'completed', recordCount: records.length },
+    });
 
     return {
       queryId: status.queryId,
@@ -253,7 +258,9 @@ export async function dataCloudSqlQuery(
       hasMoreRows: false,
     };
   } catch (error) {
-    throw wrapQueryError(error);
+    const wrappedError = wrapQueryError(error);
+    uxLog("log", this, `[DataCloudSqlQuery] Query failed: ${wrappedError.message}`, { query: { ...queryLog, status: 'error' } });
+    throw wrappedError;
   }
 }
 
@@ -261,9 +268,10 @@ async function submitInitialQuery(
   query: string,
   conn: Connection,
   options: RequiredQueryOptions,
+  queryLog: CommandLogLineQuery,
 ): Promise<DataCloudSqlQueryResult> {
   const endpoint = buildQueryConnectUrl(conn, options);
-  uxLog("log", this, `[DataCloudSqlQuery] Submitting initial query to ${endpoint}:\n${query}`);
+  uxLog("log", this, `[DataCloudSqlQuery] Submitting initial query to ${endpoint}:\n${query}`, { query: queryLog });
   const response = await conn.request<QueryConnectResponse>({
     method: "POST",
     url: endpoint,

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -17,7 +17,7 @@ import { prompts } from './prompts.js';
 import { encryptFile } from '../cryptoUtils.js';
 import { deployMetadatas, shortenLogLines } from './deployUtils.js';
 import { isProductionOrg, promptProfiles, promptUserEmail } from './orgUtils.js';
-import { LogType, WebSocketClient } from '../websocketClient.js';
+import { CommandLogLineQuery, LogType, WebSocketClient } from '../websocketClient.js';
 import { formatElapsedMs } from './dateHelper.js';
 import { buildXmlString, parseXmlString, writeXmlFile } from './xmlUtils.js';
 import { SfCommand } from '@salesforce/sf-plugins-core';
@@ -1420,10 +1420,13 @@ export async function generateReports(
 }
 
 // Options for uxLog. `sensitive` obfuscates the value in log files; `alwaysVisible` keeps the
-// enclosing VS Code UI section expanded by default.
+// enclosing VS Code UI section expanded by default; `query` describes the query this line is
+// about (start, completion with its record count, or failure) so the VS Code extension can show
+// its state next to the query text.
 export interface UxLogOptions {
   sensitive?: boolean;
   alwaysVisible?: boolean;
+  query?: CommandLogLineQuery;
 }
 
 export function uxLog(logType: LogType, commandThis: any, textInit: string, optionsOrSensitive: boolean | UxLogOptions = {}): void {
@@ -1466,7 +1469,7 @@ export function uxLog(logType: LogType, commandThis: any, textInit: string, opti
 
       // Send message to WebSocket client
       if (logType !== "other") {
-        WebSocketClient.sendCommandLogLineMessage(textToSend, logType, isQuestion, alwaysVisible);
+        WebSocketClient.sendCommandLogLineMessage(textToSend, logType, isQuestion, alwaysVisible, options.query);
       }
     }
   }

--- a/src/common/websocketClient.ts
+++ b/src/common/websocketClient.ts
@@ -27,6 +27,19 @@ const INIT_TIMEOUT_MS = 10000;
 export const LOG_TYPES = ['log', 'action', 'warning', 'error', 'success', 'table', "other"] as const;
 export type LogType = typeof LOG_TYPES[number];
 
+/**
+ * Structured description of a query attached to a command log line, so the VS Code extension can
+ * follow the query state (running, completed with its number of records, failed) without parsing
+ * the log text. The same `id` links the start line to the completion (or failure) line.
+ */
+export interface CommandLogLineQuery {
+  id: string;
+  type: 'soql' | 'tooling' | 'bulk' | 'datacloud';
+  status: 'running' | 'completed' | 'error';
+  recordCount?: number;
+  batchCount?: number;
+}
+
 /** One entry in a vscodeDiff message - describes a single file pair to open in a side-by-side diff editor. */
 export interface OrgDiffItem {
   leftPath: string;
@@ -257,13 +270,15 @@ static sendMessage(data: any) {
   }
 
   // Send command log line message
-  static sendCommandLogLineMessage(message: string, logType?: LogType, isQuestion?: boolean, alwaysVisible?: boolean) {
+  static sendCommandLogLineMessage(message: string, logType?: LogType, isQuestion?: boolean, alwaysVisible?: boolean, query?: CommandLogLineQuery) {
     WebSocketClient.sendMessage({
       event: 'commandLogLine',
       logType: logType,
       message: message,
       isQuestion: isQuestion,
       alwaysVisible: alwaysVisible,
+      // Only present on the log lines that describe a query start / completion / failure
+      ...(query ? { query } : {}),
     });
   }
 

--- a/test/common/utils/apiUtils.test.ts
+++ b/test/common/utils/apiUtils.test.ts
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import { expect } from 'chai';
+import { soqlQuery, soqlQueryTooling, startQueryLog } from '../../../src/common/utils/apiUtils.js';
+import { WebSocketClient } from '../../../src/common/websocketClient.js';
+
+// Captures what uxLog writes to the log file (plain text, ANSI codes stripped)
+function captureLogFile(): string[] {
+  const lines: string[] = [];
+  (globalThis as any).hardisLogFileStream = {
+    write: (text: string) => {
+      lines.push(text.trim());
+    },
+  };
+  return lines;
+}
+
+describe('apiUtils queries', () => {
+  let previousLogStream: any;
+
+  beforeEach(() => {
+    previousLogStream = (globalThis as any).hardisLogFileStream;
+  });
+
+  afterEach(() => {
+    (globalThis as any).hardisLogFileStream = previousLogStream;
+  });
+
+  describe('startQueryLog', () => {
+    it('creates a running query with a unique id', () => {
+      const first = startQueryLog('soql');
+      const second = startQueryLog('tooling');
+      expect(first.status).to.equal('running');
+      expect(first.type).to.equal('soql');
+      expect(second.type).to.equal('tooling');
+      expect(first.id).to.be.a('string').and.not.equal(second.id);
+    });
+  });
+
+  describe('soqlQuery', () => {
+    it('logs the query then the number of records retrieved across batches', async () => {
+      const lines = captureLogFile();
+      const conn: any = {
+        query: async () => ({ done: false, nextRecordsUrl: '/next/1', records: [{ Id: '1' }, { Id: '2' }] }),
+        queryMore: async () => ({ done: true, records: [{ Id: '3' }] }),
+      };
+      const res = await soqlQuery('SELECT Id FROM Account', conn);
+      expect(res.records).to.have.length(3);
+      expect(lines[0]).to.include('[SOQL Query] SELECT Id FROM Account');
+      expect(lines[lines.length - 1]).to.include('[SOQL Query] Retrieved 3 records in 2 chunks(s)');
+    });
+
+    it('logs the failure then rethrows the error', async () => {
+      const lines = captureLogFile();
+      const conn: any = {
+        query: async () => {
+          throw new Error('INVALID_FIELD: No such column');
+        },
+      };
+      let thrown: any = null;
+      try {
+        await soqlQuery('SELECT Nope FROM Account', conn);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown?.message).to.equal('INVALID_FIELD: No such column');
+      expect(lines[lines.length - 1]).to.include('[SOQL Query] Query failed: INVALID_FIELD: No such column');
+    });
+  });
+
+  describe('soqlQueryTooling', () => {
+    it('logs the number of records retrieved', async () => {
+      const lines = captureLogFile();
+      const conn: any = {
+        getApiVersion: () => '65.0',
+        request: async () => ({ done: true, records: [{ Id: '1' }] }),
+      };
+      const res = await soqlQueryTooling('SELECT Id FROM ApexClass', conn);
+      expect(res.records).to.have.length(1);
+      expect(lines[lines.length - 1]).to.include('[SOQL Query Tooling] Retrieved 1 records');
+    });
+  });
+
+  describe('WebSocketClient.sendCommandLogLineMessage', () => {
+    let sent: any[];
+    const originalSendMessage = WebSocketClient.sendMessage;
+
+    beforeEach(() => {
+      sent = [];
+      WebSocketClient.sendMessage = (data: any) => {
+        sent.push(data);
+      };
+    });
+
+    afterEach(() => {
+      WebSocketClient.sendMessage = originalSendMessage;
+    });
+
+    it('attaches the query description only when one is given', () => {
+      WebSocketClient.sendCommandLogLineMessage('plain line', 'log');
+      const query = { ...startQueryLog('soql'), status: 'completed' as const, recordCount: 12, batchCount: 1 };
+      WebSocketClient.sendCommandLogLineMessage('[SOQL Query] Retrieved 12 records', 'log', false, false, query);
+      expect(sent).to.have.length(2);
+      expect(sent[0].event).to.equal('commandLogLine');
+      expect(sent[0]).to.not.have.property('query');
+      expect(sent[1].query).to.deep.equal(query);
+      expect(sent[1].message).to.equal('[SOQL Query] Retrieved 12 records');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- SOQL, Tooling API, Bulk API and Data Cloud queries now attach a structured `query` description (`{ id, type, status: running|completed|error, recordCount, batchCount }`) to the log lines sent over the WebSocket (`commandLogLine` event), so the VS Code extension can show the **number of records next to each query** without parsing the log text.
- `uxLog` accepts a `query` option (new `CommandLogLineQuery` type in `websocketClient.ts`), only sent when present: the message shape is unchanged for every other log line.
- A failed query now logs a grey `Query failed: <message>` line before rethrowing, so the UI can mark the query as failed instead of merging the next query into it.
- Fixed the `Fetching batch X/{{MAX}}` log line showing a raw placeholder (the code passed `MAX_CHUNKS`, the translations expect `MAX`).

Backward compatible: older VS Code extension versions ignore the extra field and keep working with the text of the log lines. The matching extension change (record count chip in the Command Runner) is in vscode-sfdx-hardis, and does not require upgrading sfdx-hardis.

## Test plan

- [x] `tsc --noEmit`, ESLint
- [x] New `test/common/utils/apiUtils.test.ts`: record count across batches, failure logging + rethrow, Tooling query, WebSocket payload with/without `query`
- [x] Verified end to end with the vscode-sfdx-hardis branch `feat/command-runner-query-record-count` (chip rendered in light and dark themes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
