### PR TITLE
docs(v8): update dependency reduction statistics after batch 2

### DIFF
--- a/docs/sfdx-hardis-v8.md
+++ b/docs/sfdx-hardis-v8.md
@@ -201,13 +201,16 @@ Two new pages help you check your setup: the [CI/CD Setup Checklist](salesforce-
 
 Both projects went on a diet, for the same reason: every third-party package is code you have to trust.
 
-|                                        | Before | v8                                                                                 |
-|----------------------------------------|--------|------------------------------------------------------------------------------------|
-| **Plugin** dependency tree             | 100%   | **~20% smaller** (axios, xml2js, openai, cloudflare, md-to-pdf and others removed) |
-| **Extension** direct dependencies      | 28     | **14**                                                                             |
-| **Extension** total packages installed | 327    | **287**                                                                            |
+|                                        | Before (v7.23) | v8                                                                                                                                 |
+|----------------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------|
+| **Plugin** direct dependencies         | 65             | **42** (axios, xml2js, openai, cloudflare, md-to-pdf, fs-extra, inquirer, octokit, farmhash, ora, open, dotenv and others removed) |
+| **Plugin** total packages installed    | 1091           | **518** (**-53%**)                                                                                                                 |
+| **Extension** direct dependencies      | 28             | **14**                                                                                                                             |
+| **Extension** total packages installed | 327            | **287**                                                                                                                            |
 
 Widely used but replaceable packages were replaced by capabilities already built into Node.js and VS Code, with no change in behavior. Fewer packages means a **smaller supply-chain attack surface**, less exposure to a compromised or vulnerable dependency, and a **faster install** of the plugin, the extension and the Docker images.
+
+A guardrail keeps it that way: the plugin test suite fails when a dependency is declared but never imported, or when the lock file grows past a ceiling.
 
 ---
 
@@ -222,6 +225,7 @@ A few behaviors changed on purpose. Check these if they apply to your project.
 | **A Flow in destructive changes is deleted outside the deployment transaction.**                                                                                                                                                                              | A failed deployment leaves the Flow deactivated or deleted instead of rolling it back. Every step is re-runnable, so retrying the pipeline converges.         |
 | **`--check` no longer validates Flow destructive members against the org.**                                                                                                                                                                                   | A Flow missing from the target org is reported as `FLOW_DELETE_NOOP` and passes, because the same destructive changes are replayed along the promotion chain. |
 | **Connected Apps can no longer be restored after a sandbox refresh.**                                                                                                                                                                                         | Convert them to External Client Apps before your next refresh.                                                                                                |
+| **The plugin requires Node.js 22 or more**, like the Salesforce CLI.                                                                                                                                                                                          | Upgrade Node.js on machines and CI runners that still use Node.js 20.                                                                                         |
 
 ---
 


### PR DESCRIPTION
## What

Update the "Lighter, and safer" section of `docs/sfdx-hardis-v8.md` after the second dependency reduction batch (#2085).

- Replace the vague "dependency tree ~20% smaller" row with figures measured against v7.23.0 (last v7 release):
  - Plugin direct dependencies: 65 -> 42
  - Plugin installed runtime packages (unique name@version reachable from `dependencies` in `yarn.lock`): 1091 -> 518 (-53%)
- List the main removed packages (fs-extra, inquirer, octokit, farmhash, ora, open, dotenv, ...)
- Mention the dependency guardrail that now runs with `yarn test`
- Add the Node.js 22 requirement to the "Before you upgrade" table

## How the numbers were computed

Walked the `yarn.lock` dependency graph from `package.json` `dependencies` at `v7.23.0`, `v8.0.0` and `main`. The `main` figure (518) matches the count given in the #2085 commit message.