### PR TITLE
fix(org): log an action before checking org connection status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Queries report their number of records to VS Code**: SOQL, Tooling API, Bulk API and Data Cloud queries now tell the VS Code extension when they start, when they complete (with the number of records retrieved) and when they fail, so the Command Runner can show a record count chip next to each query. A failed query now also logs a `Query failed` line with the error message.
 - Fixed the `Fetching batch X/{{MAX}}` log line of paginated SOQL queries showing a raw placeholder instead of the maximum number of batches.
+- Fixed the VS Code UI looking stuck after an org selection prompt: the org connection check now logs its action before running `sf org display`.
 
 ### Dependencies
 

--- a/src/common/utils/orgUtils.ts
+++ b/src/common/utils/orgUtils.ts
@@ -347,6 +347,8 @@ export async function makeSureOrgIsConnected(targetOrg: string | any) {
     targetOrg = targetOrg.username;
   }
   else {
+    // Always log an action before running sf org display, so the VS Code UI does not look stuck after a prompt
+    uxLog("action", this, c.cyan(t('checkingOrgConnectionStatus', { org: c.green(targetOrg) })));
     const displayOrgCommand = `sf org display --target-org ${targetOrg}`;
     const displayResult = await execSfdxJson(displayOrgCommand, this, {
       fail: false,

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -363,6 +363,7 @@
   "checkingForUnusedLabels": "Suche nach ungenutzten Labels...",
   "checkingIfTheOrgUsernameHasChanged": "Prüfung, ob sich der Org-Benutzername gegenüber {{prevUserName}} geändert hat...",
   "checkingMetadataTypesEligibleForDecomposition": "Suche nach Metadatentypen, die für die Zerlegung geeignet sind (Beta-Funktion)",
+  "checkingOrgConnectionStatus": "Prüfung des Verbindungsstatus der Org {{org}} ...",
   "checkingOutGitBranch": "Git-Branch {{branchName}} wird ausgecheckt...",
   "checkingOutLatestVersionOfBranch": "Neueste Version von Branch {{branch}} aus {{repoUrl}} wird ausgecheckt...",
   "checkingSobjectsForRecords": "SObjects werden auf Datensätze überprüft...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -363,6 +363,7 @@
   "checkingForUnusedLabels": "Checking for unused labels...",
   "checkingIfTheOrgUsernameHasChanged": "Checking if the org username has changed from {{prevUserName}}...",
   "checkingMetadataTypesEligibleForDecomposition": "Checking for metadata types eligible for decomposition (Beta feature)",
+  "checkingOrgConnectionStatus": "Checking connection status of org {{org}} ...",
   "checkingOutGitBranch": "Checking out git branch {{branchName}}...",
   "checkingOutLatestVersionOfBranch": "Checking out latest version of branch {{branch}} from {{repoUrl}}...",
   "checkingSobjectsForRecords": "Checking SObjects for records...",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -363,6 +363,7 @@
   "checkingForUnusedLabels": "Buscando etiquetas sin uso...",
   "checkingIfTheOrgUsernameHasChanged": "Verificando si el nombre de usuario de la org cambió desde {{prevUserName}}...",
   "checkingMetadataTypesEligibleForDecomposition": "Buscando tipos de metadatos elegibles para descomposición (característica Beta)",
+  "checkingOrgConnectionStatus": "Verificando el estado de conexión de la org {{org}} ...",
   "checkingOutGitBranch": "Haciendo checkout de la branch git {{branchName}}...",
   "checkingOutLatestVersionOfBranch": "Obteniendo la última versión de la branch {{branch}} desde {{repoUrl}}...",
   "checkingSobjectsForRecords": "Verificando SObjects para buscar registros...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -363,6 +363,7 @@
   "checkingForUnusedLabels": "Vérification des labels inutilisés...",
   "checkingIfTheOrgUsernameHasChanged": "Vérification si le nom d'utilisateur de l'org a changé depuis {{prevUserName}}...",
   "checkingMetadataTypesEligibleForDecomposition": "Vérification des types de métadonnées éligibles à la décomposition (fonctionnalité Beta)",
+  "checkingOrgConnectionStatus": "Vérification du statut de connexion de l'org {{org}} ...",
   "checkingOutGitBranch": "Checkout de la branche git {{branchName}}...",
   "checkingOutLatestVersionOfBranch": "Récupération de la dernière version de la branche {{branch}} depuis {{repoUrl}}...",
   "checkingSobjectsForRecords": "Vérification des SObjects pour les enregistrements...",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -363,6 +363,7 @@
   "checkingForUnusedLabels": "Verifica delle etichette non utilizzate...",
   "checkingIfTheOrgUsernameHasChanged": "Verifica se il nome utente dell'org è cambiato rispetto a {{prevUserName}}...",
   "checkingMetadataTypesEligibleForDecomposition": "Verifica dei tipi di metadati idonei alla decomposizione (funzionalità Beta)",
+  "checkingOrgConnectionStatus": "Verifica dello stato di connessione dell'org {{org}} ...",
   "checkingOutGitBranch": "Checkout della branch git {{branchName}}...",
   "checkingOutLatestVersionOfBranch": "Checkout dell'ultima versione del branch {{branch}} da {{repoUrl}}...",
   "checkingSobjectsForRecords": "Verifica dei SObject per i record...",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -363,6 +363,7 @@
   "checkingForUnusedLabels": "未使用のカスタム表示ラベルを確認しています...",
   "checkingIfTheOrgUsernameHasChanged": "組織のユーザー名が {{prevUserName}} から変更されたかどうかを確認しています...",
   "checkingMetadataTypesEligibleForDecomposition": "分解対象のメタデータタイプを確認しています（ベータ機能）",
+  "checkingOrgConnectionStatus": "組織 {{org}} の接続状態を確認しています...",
   "checkingOutGitBranch": "git ブランチ {{branchName}} をチェックアウトしています...",
   "checkingOutLatestVersionOfBranch": "{{repoUrl}} から branch {{branch}} の最新バージョンをチェックアウトしています...",
   "checkingSobjectsForRecords": "SObject のレコードを確認しています...",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -363,6 +363,7 @@
   "checkingForUnusedLabels": "Controleren op ongebruikte labels...",
   "checkingIfTheOrgUsernameHasChanged": "Controleren of de org-gebruikersnaam is gewijzigd van {{prevUserName}}...",
   "checkingMetadataTypesEligibleForDecomposition": "Controleren op metadatatypes die in aanmerking komen voor decompositie (Beta-functie)",
+  "checkingOrgConnectionStatus": "Verbindingsstatus van org {{org}} controleren ...",
   "checkingOutGitBranch": "Git branch {{branchName}} uitchecken...",
   "checkingOutLatestVersionOfBranch": "Nieuwste versie van branch {{branch}} uitchecken van {{repoUrl}}...",
   "checkingSobjectsForRecords": "SObjects controleren op records...",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -363,6 +363,7 @@
   "checkingForUnusedLabels": "Sprawdzanie nieużywanych Custom Labels...",
   "checkingIfTheOrgUsernameHasChanged": "Sprawdzanie, czy nazwa użytkownika org zmieniła się od {{prevUserName}}...",
   "checkingMetadataTypesEligibleForDecomposition": "Sprawdzanie typów metadanych kwalifikujących się do rozłożenia (funkcja Beta)",
+  "checkingOrgConnectionStatus": "Sprawdzanie statusu połączenia z org {{org}} ...",
   "checkingOutGitBranch": "Przełączanie na branch git {{branchName}}...",
   "checkingOutLatestVersionOfBranch": "Pobieranie najnowszej wersji branch {{branch}} z {{repoUrl}}...",
   "checkingSobjectsForRecords": "Sprawdzanie SObjects pod kątem rekordów...",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -358,6 +358,7 @@
   "checkingForUnusedLabels": "Verificando rótulos não utilizados...",
   "checkingIfTheOrgUsernameHasChanged": "Verificando se o nome de usuário da org mudou de {{prevUserName}}...",
   "checkingMetadataTypesEligibleForDecomposition": "Verificando tipos de metadados elegíveis para decomposição (funcionalidade Beta)",
+  "checkingOrgConnectionStatus": "Verificando o status de conexão da org {{org}} ...",
   "checkingOutGitBranch": "Fazendo checkout da branch git {{branchName}}...",
   "checkingOutLatestVersionOfBranch": "Ativando a versão mais recente da branch {{branch}} de {{repoUrl}}...",
   "checkingSobjectsForRecords": "Verificando SObjects em busca de registros...",


### PR DESCRIPTION
## Problem

In `hardis:work:new`, right after answering the "Which Salesforce org do you want to work in?" prompt, the command ran `sf org display --target-org <user> --json` with no `uxLog("action", ...)` before it.

The VS Code UI hides everything that is not an action right after a prompt answer, so the command looked stuck for the ~20s the call took, while it was actually working.

## Fix

`makeSureOrgIsConnected()` (`src/common/utils/orgUtils.ts`) now logs an action before running `sf org display`, in the branch where it receives a username string. The branch receiving an org object runs no command and is untouched, so `hardis:org:select` (which already logs its own action and passes an object) does not get a duplicate message.

New i18n key `checkingOrgConnectionStatus` added to the 9 locale files.

## Test

- `tsc --noEmit` and `eslint` pass on the changed file.
