### PR TITLE
fix(deploy): scope the validation job of a feature branch to its own Pull Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Core
 
+- **Validation job of a feature Pull Request scoped to that Pull Request**: the check deployment collected the deployment actions, manual actions and Apex test classes of every Pull Request ever merged upstream (341 on one project), because the promotion window has no meaning for a branch that was never merged into its target. The validation job now applies the same rule as the deployment job: a feature branch carries only its own Pull Request, a major or retrofit branch carries the whole promotion window. The check comment no longer lists manual actions belonging to other Pull Requests.
 - **Queries report their number of records to VS Code**: SOQL, Tooling API, Bulk API and Data Cloud queries now tell the VS Code extension when they start, when they complete (with the number of records retrieved) and when they fail, so the Command Runner can show a record count chip next to each query. A failed query now also logs a `Query failed` line with the error message.
 - Fixed the `Fetching batch X/{{MAX}}` log line of paginated SOQL queries showing a raw placeholder instead of the maximum number of batches.
 - Fixed the VS Code UI looking stuck after an org selection prompt: the org connection check now logs its action before running `sf org display`.

--- a/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
+++ b/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
@@ -136,7 +136,7 @@ Opt out by adding `runOnlyOnceByOrg: false` explicitly on any action that should
 
 **Which Pull Requests are in scope**
 
-The actions collected for a deployment depend on the branch the merged Pull Request comes from.
+The actions collected for a deployment depend on the branch the merged Pull Request comes from. The validation job of a Pull Request applies the same rule to the Pull Request being checked, so the check comment of a feature Pull Request lists only its own actions.
 
 | Merge                                                              | Scope                                              |
 |--------------------------------------------------------------------|----------------------------------------------------|

--- a/src/common/utils/pullRequestUtils.ts
+++ b/src/common/utils/pullRequestUtils.ts
@@ -117,6 +117,29 @@ export function isSinglePullRequestScope(sourceBranch: string, majorBranchNames:
 }
 
 /**
+ * Resolves the scope kind of a job whose source branch carries a single Pull Request, on both
+ * sides of the merge: 'check' on the validation job, 'single-pr' on the deployment job.
+ *
+ * Returns null when the source is a major or retrofit branch: the job then collects the whole
+ * promotion window, and the caller decides how to bound it.
+ *
+ * The rule is the same on both sides on purpose. When the validation job of a feature branch
+ * collected the promotion window, its comment listed the manual actions of every other Pull
+ * Request merged upstream, and a user could tick them as done from a Pull Request they did not
+ * belong to.
+ */
+export function getSinglePullRequestScopeKind(
+  checkOnly: boolean,
+  sourceBranch: string,
+  majorBranchNames: string[],
+): Extract<PullRequestScopeKind, 'check' | 'single-pr'> | null {
+  if (!isSinglePullRequestScope(sourceBranch, majorBranchNames)) {
+    return null;
+  }
+  return checkOnly ? 'check' : 'single-pr';
+}
+
+/**
  * Build the list of branches whose merged Pull Requests are candidates for a scope window.
  *
  * On top of the recursive child branches of the window's target branch, every major branch is
@@ -158,9 +181,25 @@ export async function listAllPullRequestsForCurrentScope(checkOnly: boolean): Pr
   let sourceBranchToUse = '';
   let targetBranchToUse = '';
   if (checkOnly) {
-    // ex: feature/my-feature
-    sourceBranchToUse = pullRequestInfo.sourceBranch;
+    // Validation of a feature branch: the checked Pull Request is the whole scope, exactly like
+    // on its deployment job. The window computed below has no meaning for a feature branch
+    // (it was never merged into the target, so "since the last merge" is its whole history,
+    // which contains every Pull Request ever merged upstream).
+    if (getSinglePullRequestScopeKind(true, pullRequestInfo.sourceBranch, majorOrgs.map(o => o.branchName)) === 'check') {
+      uxLog("log", this, c.grey(`[GitProvider] ${t('pullRequestScopeFeatureBranchCheck', {
+        sourceBranch: pullRequestInfo.sourceBranch,
+        pr: pullRequestInfo.idStr,
+      })}`));
+      _cachedPullRequests = [pullRequestInfo];
+      _scopeKind = 'check';
+      logResolvedScope(_cachedPullRequests);
+      return _cachedPullRequests;
+    }
+    // Validation of a major or retrofit branch (ex: integration -> uat): the window is every
+    // Pull Request merged into the source since its last merge into the target.
     // ex: integration
+    sourceBranchToUse = pullRequestInfo.sourceBranch;
+    // ex: uat
     targetBranchToUse = pullRequestInfo.targetBranch;
   }
   else {
@@ -172,7 +211,7 @@ export async function listAllPullRequestsForCurrentScope(checkOnly: boolean): Pr
     }
     // Merge from a feature branch: the Pull Request that has just been merged is the whole scope.
     // No merge window is needed here, so this does not depend on mergeTargets being configured.
-    if (isSinglePullRequestScope(pullRequestInfo.sourceBranch, majorOrgs.map(o => o.branchName))) {
+    if (getSinglePullRequestScopeKind(false, pullRequestInfo.sourceBranch, majorOrgs.map(o => o.branchName)) === 'single-pr') {
       uxLog("log", this, c.grey(`[GitProvider] ${t('pullRequestScopeFeatureBranchMerge', {
         sourceBranch: pullRequestInfo.sourceBranch,
         pr: pullRequestInfo.idStr,

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -2608,6 +2608,7 @@
   "pullCommandDidNotReturnExpectedResults": "Pull-Befehl hat keine erwarteten Ergebnisse zurückgegeben\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Neueste Änderungen aus der Org abrufen, um Dateien zu stagen und Ihren commit zu erstellen",
   "pullRequestScopeBatchMerge": "Merge vom Branch {{sourceBranch}}: die Deployment-Aktionen und Apex-Testklassen jedes Pull Requests, der seit dem letzten Merge von {{windowBranch}} nach {{nextBranch}} in {{windowBranch}} gemergt wurde, werden verarbeitet",
+  "pullRequestScopeFeatureBranchCheck": "Validierung des Feature-Branch {{sourceBranch}}: es werden nur die Deployment-Aktionen und Apex-Testklassen verarbeitet, die im Pull Request {{pr}} definiert sind",
   "pullRequestScopeFeatureBranchMerge": "Merge vom Feature-Branch {{sourceBranch}}: es werden nur die Deployment-Aktionen und Apex-Testklassen verarbeitet, die im Pull Request {{pr}} definiert sind",
   "pullRequestScopeGoLiveMerge": "Merge vom Branch {{sourceBranch}} in den obersten Branch {{targetBranch}}: die Deployment-Aktionen und Apex-Testklassen jedes von diesem Merge getragenen Pull Requests werden verarbeitet",
   "pullRequestScopeGoLiveNoMergeCommit": "Kein Merge-Commit für den in {{targetBranch}} gemergten Pull Request {{pr}} gefunden: es werden nur die Deployment-Aktionen und Apex-Testklassen dieses Pull Requests verarbeitet",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2613,6 +2613,7 @@
   "pullCommandDidNotReturnExpectedResults": "Pull command did not return expected results\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Pull latest updates from org so you can stage files and create your commit",
   "pullRequestScopeBatchMerge": "Merge from branch {{sourceBranch}}: the deployment actions and Apex test classes of every Pull Request merged into {{windowBranch}} since its last merge into {{nextBranch}} will be processed",
+  "pullRequestScopeFeatureBranchCheck": "Validation of feature branch {{sourceBranch}}: only the deployment actions and Apex test classes defined on Pull Request {{pr}} will be processed",
   "pullRequestScopeFeatureBranchMerge": "Merge from feature branch {{sourceBranch}}: only the deployment actions and Apex test classes defined on Pull Request {{pr}} will be processed",
   "pullRequestScopeGoLiveMerge": "Merge from branch {{sourceBranch}} into topmost branch {{targetBranch}}: the deployment actions and Apex test classes of every Pull Request carried by this merge will be processed",
   "pullRequestScopeGoLiveNoMergeCommit": "No merge commit found for Pull Request {{pr}} merged into {{targetBranch}}: only this Pull Request's deployment actions and Apex test classes will be processed",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2609,6 +2609,7 @@
   "pullCommandDidNotReturnExpectedResults": "El comando pull no devolvió los resultados esperados\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Obtenga las últimas actualizaciones de la org para preparar los archivos (stage) y crear el commit",
   "pullRequestScopeBatchMerge": "Merge desde la branch {{sourceBranch}}: se procesarán las acciones de despliegue y las clases de test Apex de todas las Pull Requests fusionadas en {{windowBranch}} desde su último merge a {{nextBranch}}",
+  "pullRequestScopeFeatureBranchCheck": "Validación de la branch de funcionalidad {{sourceBranch}}: solo se procesarán las acciones de despliegue y las clases de test Apex definidas en la Pull Request {{pr}}",
   "pullRequestScopeFeatureBranchMerge": "Merge desde la branch de funcionalidad {{sourceBranch}}: solo se procesarán las acciones de despliegue y las clases de test Apex definidas en la Pull Request {{pr}}",
   "pullRequestScopeGoLiveMerge": "Merge desde la branch {{sourceBranch}} a la branch final {{targetBranch}}: se procesarán las acciones de despliegue y las clases de test Apex de cada Pull Request incluida en este merge",
   "pullRequestScopeGoLiveNoMergeCommit": "No se ha encontrado el commit de merge de la Pull Request {{pr}} fusionada en {{targetBranch}}: solo se procesarán las acciones de despliegue y las clases de test Apex de esta Pull Request",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2609,6 +2609,7 @@
   "pullCommandDidNotReturnExpectedResults": "La commande pull n'a pas retourné les résultats attendus\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Récupérez les dernières mises à jour de l'org pour pouvoir staged les fichiers et créer votre commit",
   "pullRequestScopeBatchMerge": "Merge depuis la branche {{sourceBranch}} : les actions de déploiement et les classes de test Apex de toutes les Pull Requests fusionnées dans {{windowBranch}} depuis son dernier merge vers {{nextBranch}} seront traitées",
+  "pullRequestScopeFeatureBranchCheck": "Validation de la branche de fonctionnalité {{sourceBranch}} : seules les actions de déploiement et les classes de test Apex définies sur la Pull Request {{pr}} seront traitées",
   "pullRequestScopeFeatureBranchMerge": "Merge depuis la branche de fonctionnalité {{sourceBranch}} : seules les actions de déploiement et les classes de test Apex définies sur la Pull Request {{pr}} seront traitées",
   "pullRequestScopeGoLiveMerge": "Merge depuis la branche {{sourceBranch}} vers la branche finale {{targetBranch}} : les actions de déploiement et les classes de test Apex de chaque Pull Request incluse dans ce merge seront traitées",
   "pullRequestScopeGoLiveNoMergeCommit": "Aucun commit de merge trouvé pour la Pull Request {{pr}} fusionnée dans {{targetBranch}} : seules les actions de déploiement et les classes de test Apex de cette Pull Request seront traitées",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -2609,6 +2609,7 @@
   "pullCommandDidNotReturnExpectedResults": "Il comando pull non ha restituito i risultati attesi\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Recupera gli ultimi aggiornamenti dalla org per poter mettere in stage i file e creare il tuo commit",
   "pullRequestScopeBatchMerge": "Merge dal branch {{sourceBranch}}: verranno elaborate le azioni di distribuzione e le classi di test Apex di ogni Pull Request unita in {{windowBranch}} dall'ultimo merge verso {{nextBranch}}",
+  "pullRequestScopeFeatureBranchCheck": "Validazione del branch di funzionalità {{sourceBranch}}: verranno elaborate solo le azioni di distribuzione e le classi di test Apex definite sulla Pull Request {{pr}}",
   "pullRequestScopeFeatureBranchMerge": "Merge dal branch di funzionalità {{sourceBranch}}: verranno elaborate solo le azioni di distribuzione e le classi di test Apex definite sulla Pull Request {{pr}}",
   "pullRequestScopeGoLiveMerge": "Merge dal branch {{sourceBranch}} al branch finale {{targetBranch}}: verranno elaborate le azioni di distribuzione e le classi di test Apex di ogni Pull Request inclusa in questo merge",
   "pullRequestScopeGoLiveNoMergeCommit": "Nessun commit di merge trovato per la Pull Request {{pr}} unita in {{targetBranch}}: verranno elaborate solo le azioni di distribuzione e le classi di test Apex di questa Pull Request",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -2607,6 +2607,7 @@
   "pullCommandDidNotReturnExpectedResults": "pullコマンドが期待された結果を返しませんでした\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "組織から最新の更新をpullして、ファイルをステージしてcommitを作成してください",
   "pullRequestScopeBatchMerge": "branch {{sourceBranch}} からの merge です。{{windowBranch}} から {{nextBranch}} への前回の merge 以降に {{windowBranch}} にマージされたすべての Pull Request のデプロイアクションと Apex テストクラスが処理されます",
+  "pullRequestScopeFeatureBranchCheck": "機能 branch {{sourceBranch}} の検証です。Pull Request {{pr}} で定義されたデプロイアクションと Apex テストクラスのみが処理されます",
   "pullRequestScopeFeatureBranchMerge": "機能 branch {{sourceBranch}} からの merge です。Pull Request {{pr}} で定義されたデプロイアクションと Apex テストクラスのみが処理されます",
   "pullRequestScopeGoLiveMerge": "branch {{sourceBranch}} から最上位 branch {{targetBranch}} への merge です。この merge に含まれるすべての Pull Request のデプロイアクションと Apex テストクラスが処理されます",
   "pullRequestScopeGoLiveNoMergeCommit": "{{targetBranch}} にマージされた Pull Request {{pr}} の merge コミットが見つかりません。この Pull Request のデプロイアクションと Apex テストクラスのみが処理されます",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -2609,6 +2609,7 @@
   "pullCommandDidNotReturnExpectedResults": "Pull-commando heeft geen verwachte resultaten teruggegeven\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Haal de nieuwste updates op uit de org zodat je bestanden kunt stagen en je commit kunt aanmaken",
   "pullRequestScopeBatchMerge": "Merge vanaf branch {{sourceBranch}}: de deploy-acties en Apex-testklassen van elke Pull Request die sinds de laatste merge van {{windowBranch}} naar {{nextBranch}} in {{windowBranch}} is gemerged worden verwerkt",
+  "pullRequestScopeFeatureBranchCheck": "Validatie van feature branch {{sourceBranch}}: alleen de deploy-acties en Apex-testklassen die op Pull Request {{pr}} zijn gedefinieerd worden verwerkt",
   "pullRequestScopeFeatureBranchMerge": "Merge vanaf feature branch {{sourceBranch}}: alleen de deploy-acties en Apex-testklassen die op Pull Request {{pr}} zijn gedefinieerd worden verwerkt",
   "pullRequestScopeGoLiveMerge": "Merge vanaf branch {{sourceBranch}} naar de hoogste branch {{targetBranch}}: de deploy-acties en Apex-testklassen van elke Pull Request in deze merge worden verwerkt",
   "pullRequestScopeGoLiveNoMergeCommit": "Geen merge-commit gevonden voor Pull Request {{pr}} gemerged in {{targetBranch}}: alleen de deploy-acties en Apex-testklassen van deze Pull Request worden verwerkt",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -2609,6 +2609,7 @@
   "pullCommandDidNotReturnExpectedResults": "Polecenie pull nie zwróciło oczekiwanych wyników\n{{JSON}}",
   "pullLatestUpdatesFromOrgToStageAndCommit": "Pobierz najnowsze aktualizacje z org, aby móc przygotować pliki i utworzyć commit",
   "pullRequestScopeBatchMerge": "Merge z branch {{sourceBranch}}: przetworzone zostaną akcje wdrożeniowe i klasy testowe Apex każdego Pull Requesta scalonego do {{windowBranch}} od jego ostatniego merge do {{nextBranch}}",
+  "pullRequestScopeFeatureBranchCheck": "Walidacja branch funkcjonalności {{sourceBranch}}: przetworzone zostaną wyłącznie akcje wdrożeniowe i klasy testowe Apex zdefiniowane w Pull Request {{pr}}",
   "pullRequestScopeFeatureBranchMerge": "Merge z branch funkcjonalności {{sourceBranch}}: przetworzone zostaną wyłącznie akcje wdrożeniowe i klasy testowe Apex zdefiniowane w Pull Request {{pr}}",
   "pullRequestScopeGoLiveMerge": "Merge z branch {{sourceBranch}} do najwyższego branch {{targetBranch}}: przetworzone zostaną akcje wdrożeniowe i klasy testowe Apex każdego Pull Requesta objętego tym merge",
   "pullRequestScopeGoLiveNoMergeCommit": "Nie znaleziono commita merge dla Pull Requesta {{pr}} scalonego do {{targetBranch}}: przetworzone zostaną wyłącznie akcje wdrożeniowe i klasy testowe Apex tego Pull Requesta",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -2576,6 +2576,7 @@
   "publishingPagesToConfluence": "Publicando {{count}} páginas no Confluence...",
   "pullCommandDidNotReturnExpectedResults": "O comando pull não retornou os resultados esperados\n{{JSON}}",
   "pullRequestScopeBatchMerge": "Merge a partir da branch {{sourceBranch}}: as ações de deploy e as classes de teste Apex de cada Pull Request mesclado em {{windowBranch}} desde o seu último merge para {{nextBranch}} serão processadas",
+  "pullRequestScopeFeatureBranchCheck": "Validação da branch de funcionalidade {{sourceBranch}}: somente as ações de deploy e as classes de teste Apex definidas no Pull Request {{pr}} serão processadas",
   "pullRequestScopeFeatureBranchMerge": "Merge a partir da branch de funcionalidade {{sourceBranch}}: somente as ações de deploy e as classes de teste Apex definidas no Pull Request {{pr}} serão processadas",
   "pullRequestScopeGoLiveMerge": "Merge a partir da branch {{sourceBranch}} para a branch final {{targetBranch}}: as ações de deploy e as classes de teste Apex de cada Pull Request incluído neste merge serão processadas",
   "pullRequestScopeGoLiveNoMergeCommit": "Nenhum commit de merge encontrado para o Pull Request {{pr}} mesclado em {{targetBranch}}: somente as ações de deploy e as classes de teste Apex deste Pull Request serão processadas",

--- a/test/common/utils/pullRequestScope.test.ts
+++ b/test/common/utils/pullRequestScope.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { expect } from 'chai';
 import { isRetrofit } from '../../../src/common/utils/orgConfigUtils.js';
-import { buildPrSearchBranches, isSinglePullRequestScope } from '../../../src/common/utils/pullRequestUtils.js';
+import { buildPrSearchBranches, getSinglePullRequestScopeKind, isSinglePullRequestScope } from '../../../src/common/utils/pullRequestUtils.js';
 
 const MAJOR_BRANCHES = ['main', 'preprod', 'uat', 'integration'];
 
@@ -74,6 +74,37 @@ describe('isSinglePullRequestScope()', () => {
   it('treats every named branch as a feature branch when no major branch is configured', () => {
     expect(isSinglePullRequestScope('integration', [])).to.equal(true);
     expect(isSinglePullRequestScope('retrofit/from-main', [])).to.equal(false);
+  });
+});
+
+describe('getSinglePullRequestScopeKind()', () => {
+  // The validation job of a feature branch used to collect the whole promotion window: the
+  // feature branch had never been merged into the target, so "since the last merge" was its
+  // entire history, and the check comment listed the manual actions of every Pull Request ever
+  // merged upstream (341 of them on one real project).
+  it('scopes the validation job of a feature branch to the checked Pull Request', () => {
+    expect(getSinglePullRequestScopeKind(true, 'feature/my-feature', MAJOR_BRANCHES)).to.equal('check');
+    expect(getSinglePullRequestScopeKind(true, 'fix/my-fix', MAJOR_BRANCHES)).to.equal('check');
+  });
+
+  it('scopes the deployment job of a feature branch to the merged Pull Request', () => {
+    expect(getSinglePullRequestScopeKind(false, 'feature/my-feature', MAJOR_BRANCHES)).to.equal('single-pr');
+  });
+
+  // Checking integration -> uat must list what the promotion will replay, on both jobs.
+  it('keeps the whole batch for a major branch, on the validation job as on the deployment job', () => {
+    expect(getSinglePullRequestScopeKind(true, 'integration', MAJOR_BRANCHES)).to.equal(null);
+    expect(getSinglePullRequestScopeKind(false, 'integration', MAJOR_BRANCHES)).to.equal(null);
+  });
+
+  it('keeps the whole batch for a retrofit branch, on the validation job as on the deployment job', () => {
+    expect(getSinglePullRequestScopeKind(true, 'retrofit/from-main', MAJOR_BRANCHES)).to.equal(null);
+    expect(getSinglePullRequestScopeKind(false, 'retrofit/from-main', MAJOR_BRANCHES)).to.equal(null);
+  });
+
+  it('keeps the whole batch when the source branch is unknown', () => {
+    expect(getSinglePullRequestScopeKind(true, '', MAJOR_BRANCHES)).to.equal(null);
+    expect(getSinglePullRequestScopeKind(false, '', MAJOR_BRANCHES)).to.equal(null);
   });
 });
 


### PR DESCRIPTION
## Problem

The check deployment of a feature Pull Request collects the deployment actions, manual actions and Apex test classes of **every Pull Request ever merged upstream**. On one project the validation job of a feature branch resolved a scope of **341 Pull Requests**:

```
[Gitlab Integration] Finding last merged MR from feature/SFBUTECH-164-Test-all-pipeline to integration
[Gitlab Integration] Fetching merged MRs for branch feature/SFBUTECH-164-Test-all-pipeline
[Gitlab Integration] Fetching merged MRs for branch uat
[Gitlab Integration] Fetching merged MRs for branch main
[Gitlab Integration] Fetching merged MRs for branch integration
[Gitlab Integration] Fetching merged MRs for branch preprod
[GitProvider] Pull Request scope: 341 Pull Request(s) (#230, #232, #233, ...)
[DeploymentActions] Found 26 Pre-deployment actions to run
[DeploymentActions] Found 40 Post-deployment actions to run
```

The deployment job of the same Pull Request, after merge, was correct:

```
[GitProvider] Merge from feature branch feature/SFBUTECH-164-Test-all-pipeline: only the deployment actions and Apex test classes defined on Pull Request 483 will be processed
[GitProvider] Pull Request scope: 1 Pull Request(s) (#483)
```

## Cause

#2054 introduced `isSinglePullRequestScope()` (a feature branch carries only its own Pull Request, a major or retrofit branch carries the promotion window) but applied it only on the deployment side of `listAllPullRequestsForCurrentScope()`. On the validation side the window was computed as `listPullRequestsInBranchSinceLastMerge(feature/x, integration, ...)`: a feature branch has never been merged into its target, so "commits since the last merge" is its whole history, which contains every merge commit of every major branch, and every merged Pull Request matches.

## Consequences of the old behaviour

- The check comment of a feature Pull Request listed the **pending manual actions of other Pull Requests**, with tickable checkboxes. A user ticking everything from that comment marked actions of five unrelated Pull Requests as done in the org (observed on a real project).
- Apex test classes selected from Pull Requests (`enableDeploymentApexTestClasses`) were collected from the same 341 Pull Requests.
- The job loaded the `runOnlyOnceByOrg` state of 19 Pull Requests only to skip their actions, and that cost grows with every merged Pull Request.

## Fix

Apply the same rule on both sides, through a small pure helper `getSinglePullRequestScopeKind(checkOnly, sourceBranch, majorBranchNames)` that returns `'check'` on the validation job, `'single-pr'` on the deployment job, or `null` when the source is a major or retrofit branch (the window logic is kept untouched for those: checking `integration -> uat` still lists the whole promotion window, and `findLastMergedMR(integration, uat)` is well defined there).

- `src/common/utils/pullRequestUtils.ts`: the helper, and its use in the `checkOnly` branch. The deployment branch now calls the same helper for symmetry.
- `src/i18n/*.json`: new key `pullRequestScopeFeatureBranchCheck` in the 9 languages.
- `test/common/utils/pullRequestScope.test.ts`: 5 tests on the helper covering feature, major, retrofit and unknown source branches on both jobs.
- `docs/salesforce-ci-cd-work-on-task-deployment-actions.md`: one sentence stating the validation job follows the same scope rule.
- `CHANGELOG.md`: entry under beta / Core.

The check comment builder in `prePostCommandUtils.ts` already branches on `isSinglePullRequestScope()` to decide whether to add the "after the merge, the deployment job will also process..." note, so it needs no change: for a feature branch the comment now says the actions are collected from the content of this Pull Request, and for a major branch it keeps the promotion-window note.

## Verification

- `yarn compile`, eslint on the touched files, and `pullRequestScope.test.ts` (20 passing) run locally.
- The 341-scope job log above is from the project where the issue was found; after this fix the validation job should log `Pull Request scope: 1 Pull Request(s)` like its deployment job.