### PR TITLE
fix(deploy): report a deployment action allowed to fail as a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Core
 
+- **Deployment action allowed to fail reported as a warning**: an action with `allowFailure: true` that fails now shows `warning` (⚠️) in the Pull Request comments instead of `failed`, and no longer turns the Deployment Actions comment banner red, since the deployment went on. The action still runs again on the next deployment.
 - **Validation job of a feature Pull Request scoped to that Pull Request**: the check deployment collected the deployment actions, manual actions and Apex test classes of every Pull Request ever merged upstream (341 on one project), because the promotion window has no meaning for a branch that was never merged into its target. The validation job now applies the same rule as the deployment job: a feature branch carries only its own Pull Request, a major or retrofit branch carries the whole promotion window. The check comment no longer lists manual actions belonging to other Pull Requests.
 - **Queries report their number of records to VS Code**: SOQL, Tooling API, Bulk API and Data Cloud queries now tell the VS Code extension when they start, when they complete (with the number of records retrieved) and when they fail, so the Command Runner can show a record count chip next to each query. A failed query now also logs a `Query failed` line with the error message.
 - Fixed the `Fetching batch X/{{MAX}}` log line of paginated SOQL queries showing a raw placeholder instead of the maximum number of batches.

--- a/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
+++ b/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
@@ -99,7 +99,7 @@ Each action is an object with the following required and optional properties.
 | `customUsername`        | string  |    No     | Run the action with a specific username instead of the default target org.                                                                                                                       |
 | `includeTargetBranches` | array   |    No     | Run the action only when the deployment targets one of these branches. See [Choose the target orgs](#choose-the-target-orgs).                                                                    |
 | `excludeTargetBranches` | array   |    No     | Run the action on every target branch except these ones. See [Choose the target orgs](#choose-the-target-orgs).                                                                                  |
-| `allowFailure`          | boolean |    No     | If true and the action fails, the deployment continues but the result is marked failed/allowed.                                                                                                  |
+| `allowFailure`          | boolean |    No     | If true and the action fails, the deployment continues and the action is reported as a warning (⚠️) instead of a failure. It runs again on the next deployment, like a failed action.                                                                                                  |
 | `runOnlyOnceByOrg`      | boolean |    No     | Default: `true`. If true, the action runs only once per target org. Execution state is tracked in a dedicated "Deployment Actions" PR comment (see below), no Salesforce custom object required. |
 
 </details>

--- a/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
+++ b/docs/salesforce-ci-cd-work-on-task-deployment-actions.md
@@ -99,7 +99,7 @@ Each action is an object with the following required and optional properties.
 | `customUsername`        | string  |    No     | Run the action with a specific username instead of the default target org.                                                                                                                       |
 | `includeTargetBranches` | array   |    No     | Run the action only when the deployment targets one of these branches. See [Choose the target orgs](#choose-the-target-orgs).                                                                    |
 | `excludeTargetBranches` | array   |    No     | Run the action on every target branch except these ones. See [Choose the target orgs](#choose-the-target-orgs).                                                                                  |
-| `allowFailure`          | boolean |    No     | If true and the action fails, the deployment continues and the action is reported as a warning (⚠️) instead of a failure. It runs again on the next deployment, like a failed action.                                                                                                  |
+| `allowFailure`          | boolean |    No     | If true and the action fails, the deployment continues and the action is reported as a warning (⚠️) instead of a failure. It runs again on the next deployment, like a failed action.            |
 | `runOnlyOnceByOrg`      | boolean |    No     | Default: `true`. If true, the action runs only once per target org. Execution state is tracked in a dedicated "Deployment Actions" PR comment (see below), no Salesforce custom object required. |
 
 </details>

--- a/src/common/utils/backpromoteUtils.ts
+++ b/src/common/utils/backpromoteUtils.ts
@@ -1372,7 +1372,7 @@ export interface BackpromoteActionEntry {
   actionId: string;
   actionLabel: string;
   prId: number;
-  status: 'success' | 'failed' | 'manual' | 'skipped';
+  status: 'success' | 'failed' | 'warning' | 'manual' | 'skipped';
   date: string;
 }
 

--- a/src/common/utils/deploymentActionsStateUtils.ts
+++ b/src/common/utils/deploymentActionsStateUtils.ts
@@ -25,7 +25,9 @@ export interface DeploymentActionStateEntry {
   orgBranch: string;
   when: ActionWhen;
   executionOrder: number;
-  status: 'success' | 'failed' | 'manual' | 'skipped';
+  // 'warning' is a failed action whose definition allows failure: the deployment went on, so the
+  // outcome must not read as an error in the comment, but the action did not succeed either.
+  status: 'success' | 'failed' | 'warning' | 'manual' | 'skipped';
   jobId: string;
   jobUrl: string;
   date: string;
@@ -288,8 +290,9 @@ function unsanitizeCellText(text: string): string {
 function statusFromIcon(cell: string): DeploymentActionStateEntry['status'] {
   return cell.includes('\u2705') ? 'success' :
     cell.includes('\u274c') ? 'failed' :
-      cell.includes('\ud83d\udc4b') ? 'manual' :
-        cell.includes('\u26aa') ? 'skipped' : 'failed';
+      cell.includes('\u26a0') ? 'warning' :
+        cell.includes('\ud83d\udc4b') ? 'manual' :
+          cell.includes('\u26aa') ? 'skipped' : 'failed';
 }
 
 function parseMatrixDeploymentActionsCommentBody(body: string): DeploymentActionStateEntry[] {
@@ -368,6 +371,7 @@ function parseLegacyDeploymentActionsCommentBody(body: string): DeploymentAction
 const MATRIX_STATUS_LEGEND: { icon: string; label: string }[] = [
   { icon: '✅', label: 'done' },              // ✅
   { icon: '❌', label: 'failed' },            // ❌
+  { icon: '⚠️', label: 'warning (failed, allowed to fail)' }, // ⚠️
   { icon: '👋', label: 'waiting for manual execution' }, // 👋
   { icon: '⚪', label: 'skipped' },           // ⚪
   { icon: '❓', label: 'unknown' },           // ❓
@@ -388,6 +392,7 @@ function getStatusIcon(status: DeploymentActionStateEntry['status']): string {
   switch (status) {
     case 'success': return '\u2705';   // ✅
     case 'failed': return '\u274c';   // ❌
+    case 'warning': return '\u26a0\ufe0f'; // ⚠️
     case 'manual': return '\ud83d\udc4b'; // 👋
     case 'skipped': return '\u26aa';   // ⚪
     default: return '\u2753';   // ❓
@@ -416,6 +421,8 @@ function getActionsBannerKey(entries: DeploymentActionStateEntry[]): PrCommentBa
   if (entries.length === 0) {
     return null;
   }
+  // A 'warning' entry (failed, allowed to fail) did not block the deployment: it must not turn the
+  // comment red, so it is not an error here and falls through to pending / completed.
   if (entries.some((e) => e.status === 'failed')) {
     return 'actions-error';
   }

--- a/src/common/utils/prePostCommandUtils.ts
+++ b/src/common/utils/prePostCommandUtils.ts
@@ -222,7 +222,7 @@ export async function executePrePostCommands(property: 'commandsPreDeploy' | 'co
         orgBranch: orgBranchName,
         when: deployWhen,
         executionOrder: cmdIndex,
-        status: cmd.result.statusCode as 'success' | 'failed' | 'manual' | 'skipped',
+        status: getReportedActionStatus(cmd),
         jobId,
         jobUrl,
         date: new Date().toISOString(),
@@ -523,10 +523,23 @@ function buildManualActionsSection(commands: PrePostCommand[], isPreDeploy: bool
   return section;
 }
 
+/**
+ * Status of an action as reported to the user (results table, state comment).
+ * The internal statusCode stays 'failed' for an action allowed to fail, because it drives the
+ * "stop further actions" and "fail the job" decisions; what is reported is a warning, since the
+ * deployment went on.
+ */
+export function getReportedActionStatus(cmd: PrePostCommand): 'success' | 'failed' | 'warning' | 'manual' | 'skipped' {
+  if (cmd.result?.statusCode === "failed" && cmd.allowFailure === true) {
+    return 'warning';
+  }
+  return cmd.result?.statusCode as 'success' | 'failed' | 'manual' | 'skipped';
+}
+
 // Status icons of the actions results table, in the order they are listed in the legend
 const ACTION_STATUS_LEGEND: { icon: string; label: string }[] = [
   { icon: '✅', label: 'success' },
-  { icon: '⚠️', label: 'failed (allowed to fail)' },
+  { icon: '⚠️', label: 'warning (failed, allowed to fail)' },
   { icon: '❌', label: 'failed' },
   { icon: '👋', label: 'waiting for manual execution' },
   { icon: '⚪', label: 'skipped' },
@@ -584,7 +597,7 @@ export function buildActionsResultMarkdown(property: 'commandsPreDeploy' | 'comm
     usedStatusIcons.push(statusIcon);
     const statusCol = cmd.result?.statusCode === "manual" ?
       'waiting for manual execution' :
-      `${cmd.result?.statusCode || 'not run'}`;
+      `${getReportedActionStatus(cmd) || 'not run'}`;
     const detailCol = (cmd.result?.statusCode === "skipped" || cmd.result?.statusCode === "not-run") ?
       (cmd.result?.skippedReason || '<!-- -->') :
       (cmd.result?.statusCode === "failed" && cmd.allowFailure === true) ?

--- a/test/common/utils/deploymentActionsState.test.ts
+++ b/test/common/utils/deploymentActionsState.test.ts
@@ -96,6 +96,30 @@ describe('Deployment Actions state comment (matrix format)', () => {
     expect(reparsed[0].jobUrl).to.equal('https://ci.example.com/builds/2026-08-14/1234');
   });
 
+  it('round-trips a warning entry (failed, allowed to fail) through build and parse', () => {
+    const entries = [entry({ status: 'warning' })];
+    const body = buildDeploymentActionsCommentBody(entries, undefined, 42);
+    expect(body).to.contain('⚠️');
+    expect(body).to.contain('⚠️ warning (failed, allowed to fail)');
+
+    const parsed = parseDeploymentActionsCommentBody(body);
+    expect(parsed).to.have.length(1);
+    expect(parsed[0].status).to.equal('warning');
+  });
+
+  // A failure allowed to fail did not block the deployment: the comment must not turn red
+  it('does not show the error banner for a warning entry', () => {
+    const warningBody = buildDeploymentActionsCommentBody([entry({ status: 'warning' })], undefined, 42);
+    expect(warningBody).to.contain('pr-banner-actions-completed');
+    expect(warningBody).to.not.contain('pr-banner-actions-error');
+
+    const failedBody = buildDeploymentActionsCommentBody([entry({ status: 'failed' })], undefined, 42);
+    expect(failedBody).to.contain('pr-banner-actions-error');
+
+    const mixedBody = buildDeploymentActionsCommentBody([entry({ status: 'warning' }), entry({ actionId: 'action-2', status: 'manual' })], undefined, 42);
+    expect(mixedBody).to.contain('pr-banner-actions-pending');
+  });
+
   it('shows the banner in place of the title heading, with the title as alt text', () => {
     const body = buildDeploymentActionsCommentBody([entry({})], undefined, 42);
     expect(body).to.contain('![🛠️ Deployment Actions](');

--- a/test/common/utils/prePostCommandUtils.test.ts
+++ b/test/common/utils/prePostCommandUtils.test.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import type { ActionResult, PrePostCommand } from '../../../src/common/actionsProvider/actionsProvider.js';
 import { buildActionOutput } from '../../../src/common/actionsProvider/actionsProvider.js';
-import { buildActionsResultMarkdown, buildDeploymentScopeSubjects } from '../../../src/common/utils/prePostCommandUtils.js';
+import { buildActionsResultMarkdown, buildDeploymentScopeSubjects, getReportedActionStatus } from '../../../src/common/utils/prePostCommandUtils.js';
 
 function action(overrides: Partial<PrePostCommand>): PrePostCommand {
   return {
@@ -176,11 +176,32 @@ describe('buildActionsResultMarkdown()', () => {
   it('distinguishes a failure allowed to fail from a blocking one in the legend', () => {
     const allowed = [action({ allowFailure: true, result: { statusCode: 'failed' } })];
     expect(buildActionsResultMarkdown('commandsPostDeploy', allowed, false))
-      .to.contain('*Legend: ⚠️ failed (allowed to fail)*');
+      .to.contain('*Legend: ⚠️ warning (failed, allowed to fail)*');
 
     const blocking = [action({ result: { statusCode: 'failed' } })];
     expect(buildActionsResultMarkdown('commandsPostDeploy', blocking, false))
       .to.contain('*Legend: ❌ failed*');
+  });
+
+  // The deployment went on, so the comment must not say the action "failed": a reader scanning
+  // the status column would take it for a blocking error.
+  it('reports a failure allowed to fail as a warning, not as failed', () => {
+    const allowed = action({ label: 'Optional step', allowFailure: true, result: { statusCode: 'failed' } });
+    expect(getReportedActionStatus(allowed)).to.equal('warning');
+
+    const markdown = buildActionsResultMarkdown('commandsPostDeploy', [allowed], false);
+    expect(markdown).to.contain('| ⚠️ | Optional step | command | warning | (Allowed to fail) |');
+    expect(markdown).to.not.contain('| failed |');
+
+    // The internal status code is untouched: it still drives the allow-failure decision
+    expect(allowed.result?.statusCode).to.equal('failed');
+  });
+
+  it('keeps reporting a blocking failure as failed', () => {
+    const blocking = action({ label: 'Required step', result: { statusCode: 'failed' } });
+    expect(getReportedActionStatus(blocking)).to.equal('failed');
+    expect(buildActionsResultMarkdown('commandsPostDeploy', [blocking], false))
+      .to.contain('| ❌ | Required step | command | failed | See details below |');
   });
 
   it('does not render an empty code block for a whitespace-only output', () => {


### PR DESCRIPTION
## Problem

An action with `allowFailure: true` that fails is reported as **failed** in the Pull Request comments, in three places:

- the results table of the validation / deployment comment: `| ⚠️ | … | command | failed | (Allowed to fail) |` (the icon says warning, the status column says failed);
- the **Deployment Actions** state comment: the status matrix shows ❌, and the comment **banner turns to the error one**;
- the legend: `⚠️ failed (allowed to fail)`.

A reader cannot tell it apart from a blocking failure, although the deployment went on. Observed on a validation MR carrying a deliberately failing `allowFailure` action next to successful ones: the whole Deployment Actions comment was red.

## Fix

Add a `'warning'` **reported** status for a failed action allowed to fail.

- `prePostCommandUtils.ts`: new `getReportedActionStatus(cmd)` (`failed` + `allowFailure` → `warning`, anything else unchanged), used for the results table status column and for the state entry written to the Deployment Actions comment. The legend reads `⚠️ warning (failed, allowed to fail)`.
- `deploymentActionsStateUtils.ts`: `'warning'` added to the entry status, rendered as ⚠️ in the matrix and parsed back from it; the matrix legend gets the same label; `getActionsBannerKey()` no longer treats it as an error, so the comment shows the pending or completed banner.
- `backpromoteUtils.ts`: same status union.

The **internal** `statusCode` stays `'failed'`: it drives the "stop further actions" and "fail the job" decisions, and nothing there changes. A warning entry still does not count as "already run" for `runOnlyOnceByOrg`, like a failed one: the action runs again on the next deployment.

No dedicated warning banner: banners are generated images (`scripts/generate-pr-banners.mjs`), and a failure that did not block the deployment fits the pending / completed ones.

## Tests

- `prePostCommandUtils.test.ts`: status column reads `warning` with `(Allowed to fail)` in the details and no `| failed |` cell; a blocking failure still reads `failed`; the internal status code is untouched; legend label updated.
- `deploymentActionsState.test.ts`: a warning entry round-trips through build and parse; a warning entry gets the completed banner, a failed one the error banner, warning + manual the pending banner.

`yarn compile`, eslint on the touched files, and the three deployment-actions test suites (57 passing) run locally.

Docs: `allowFailure` row of the actions reference updated; CHANGELOG entry under beta / Core.