### PR TITLE
perf: switch the VS Code Command Runner to Running several seconds earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [hardis:work:save](https://sfdx-hardis.cloudity.com/hardis/work/save/) now cleans Flow positions only on the Flows of the git delta, instead of scanning all Flows of the repository.
 - [hardis:project:clean:references](https://sfdx-hardis.cloudity.com/hardis/project/clean/references/) now runs its cleanings without starting a new Salesforce CLI process for each one, saving several seconds per cleaning.
 - Salesforce CLI commands started by sfdx-hardis skip telemetry, log file, version and autoupdate checks, and `sf org display` / `sf config get` / `sf config set` run in-process: several seconds saved per call. Set [SFDX_HARDIS_ENHANCE_PERFORMANCE](https://sfdx-hardis.cloudity.com/all-env-variables/) to `false` to disable.
+- The VS Code Command Runner panel switches from "Starting" to "Running" several seconds earlier: commands like [hardis:work:new](https://sfdx-hardis.cloudity.com/hardis/work/new/) and [hardis:work:save](https://sfdx-hardis.cloudity.com/hardis/work/save/) announced themselves to the extension only after loading their whole implementation (measured: 5.1 s and 3.8 s from launch, now 0.7 s for both).
 
 ## [8.2.0] 2026-08-25
 

--- a/src/commands/hardis/cache/clear.ts
+++ b/src/commands/hardis/cache/clear.ts
@@ -47,6 +47,7 @@ In agent mode, all interactive prompts are skipped and default values are used.
   public static examples = ['$ sf hardis:cache:clear',
     '$ sf hardis:cache:clear --agent',];
 
+  // Keep in sync with HIDDEN_PANEL_COMMANDS in common/websocketClient.ts (enforced by a unit test)
   public static uiConfig = { hide: true };
   public static disableWebsocket = true;
 

--- a/src/commands/hardis/work/ws.ts
+++ b/src/commands/hardis/work/ws.ts
@@ -35,6 +35,7 @@ The command's technical implementation involves:
 </details>
 `;
 
+  // Keep in sync with HIDDEN_PANEL_COMMANDS in common/websocketClient.ts (enforced by a unit test)
   public static uiConfig = { hide: true };
 
   public static examples = ['$ sf hardis:work:ws --event refreshStatus'];

--- a/src/common/websocketClient.ts
+++ b/src/common/websocketClient.ts
@@ -391,24 +391,27 @@ static sendMessage(data: any) {
         else if (HIDDEN_PANEL_COMMANDS.has(this.wsContext.command)) {
           message.uiConfig = { hide: true };
         }
-        else if (!this.wsContext.command.startsWith('hardis:')) {
-          try {
-            const commandParts = this.wsContext.command.split(':');
-            // Plugin root provided by the init hook (third-party plugins).
-            const pluginRoot = (this.wsContext as any).commandPluginRoot as string | undefined;
-            const commandsBase = pluginRoot
-              ? path.resolve(pluginRoot, 'lib/commands')
-              : path.resolve(__dirname, '../../lib/commands');
-            const commandPath = path.resolve(commandsBase, ...commandParts) + '.js';
-            const fileUrl = 'file://' + commandPath.replace(/\\/g, '/');
-            const imported = await import(fileUrl);
-            const CommandClass = imported.default;
-            if (CommandClass && CommandClass.uiConfig) {
-              message.uiConfig = CommandClass.uiConfig;
+        else {
+          // Plugin root provided by the init hook. A command of another plugin
+          // (even one contributed under the hardis topic) still loads its class
+          // to read uiConfig; sfdx-hardis's own commands never do.
+          const pluginRoot = (this.wsContext as any).commandPluginRoot as string | undefined;
+          const ownRoot = path.resolve(__dirname, '../..');
+          if (pluginRoot && path.resolve(pluginRoot) !== ownRoot) {
+            try {
+              const commandParts = this.wsContext.command.split(':');
+              const commandsBase = path.resolve(pluginRoot, 'lib/commands');
+              const commandPath = path.resolve(commandsBase, ...commandParts) + '.js';
+              const fileUrl = 'file://' + commandPath.replace(/\\/g, '/');
+              const imported = await import(fileUrl);
+              const CommandClass = imported.default;
+              if (CommandClass && CommandClass.uiConfig) {
+                message.uiConfig = CommandClass.uiConfig;
+              }
+            } catch {
+              // External plugins are not expected to expose a command class
+              // file at the resolved path: uiConfig is best-effort for them.
             }
-          } catch {
-            // External plugins are not expected to expose a command class
-            // file at the resolved path: uiConfig is best-effort for them.
           }
         }
       }

--- a/src/common/websocketClient.ts
+++ b/src/common/websocketClient.ts
@@ -23,6 +23,15 @@ const PORT = process.env.SFDX_HARDIS_WEBSOCKET_PORT || 2702;
 // Max wait for the extension to answer the initClient message
 const INIT_TIMEOUT_MS = 10000;
 
+// sfdx-hardis commands whose class declares `public static uiConfig = { hide: true }`.
+// Keep in sync with those classes (a unit test enforces it). Listing them here
+// lets initClient be sent without importing any command class: importing a
+// heavy one used to delay the VS Code "Running" status by several seconds.
+export const HIDDEN_PANEL_COMMANDS = new Set([
+  'hardis:cache:clear',
+  'hardis:work:ws',
+]);
+
 // Define allowed log types and type alias outside the class
 export const LOG_TYPES = ['log', 'action', 'warning', 'error', 'success', 'table', "other"] as const;
 export type LogType = typeof LOG_TYPES[number];
@@ -113,13 +122,6 @@ export class WebSocketClient {
     }
   }
 
-  // Logs through uxLog without statically importing the heavy utils barrel
-  // (see the PERF note at the top of this file). Falls back to console.log.
-  private uxLogDeferred(logType: string, text: string): void {
-    void import('./utils/index.js')
-      .then(({ uxLog }) => uxLog(logType as any, this, text))
-      .catch(() => console.log(text));
-  }
 
   static async isInitialized(): Promise<boolean> {
     const instance = WebSocketClient.activeInstance;
@@ -375,31 +377,38 @@ static sendMessage(data: any) {
       if (commandDocUrl) {
         message.commandDocUrl = commandDocUrl;
       }
-      // Dynamically import command class and send static uiConfig if present
+      // Attach the command's static uiConfig when it has one.
+      // PERF: never import an sfdx-hardis command class here. The initClient
+      // message is what flips the VS Code panel from "Starting" to "Running",
+      // and importing a heavy command class (hardis:work:new pulls the whole
+      // utils tree) used to delay it by several seconds. sfdx-hardis's own
+      // uiConfig values are known statically (HIDDEN_PANEL_COMMANDS below);
+      // only third-party plugin commands still load their class to read it.
       if (this.wsContext?.command) {
-        try {
-          const commandParts = this.wsContext.command.split(':');
-          // Use the plugin root provided by the init hook when available (works for
-          // third-party plugins), otherwise fall back to sfdx-hardis's own lib/commands.
-          const pluginRoot = (this.wsContext as any).commandPluginRoot as string | undefined;
-          const commandsBase = pluginRoot
-            ? path.resolve(pluginRoot, 'lib/commands')
-            : path.resolve(__dirname, '../../lib/commands');
-          const commandPath = path.resolve(commandsBase, ...commandParts) + '.js';
-          const fileUrl = 'file://' + commandPath.replace(/\\/g, '/');
-          const imported = await import(fileUrl);
-          const CommandClass = imported.default;
-          if (process.env.NO_NEW_COMMAND_TAB === "true") {
-            message.uiConfig = { hide: true };
-          }
-          else if (CommandClass && CommandClass.uiConfig) {
-            message.uiConfig = CommandClass.uiConfig;
-          }
-        } catch (e) {
-          // Only warn for sfdx-hardis own commands – external plugins are not
-          // expected to expose a command class file at the resolved path.
-          if (this.wsContext.command.startsWith('hardis:')) {
-            this.uxLogDeferred("warning", c.yellow(t('unableToImportCommandClassFor', { wsContext: this.wsContext.command, instanceof: e instanceof Error ? e.message : String(e) })));
+        if (process.env.NO_NEW_COMMAND_TAB === "true") {
+          message.uiConfig = { hide: true };
+        }
+        else if (HIDDEN_PANEL_COMMANDS.has(this.wsContext.command)) {
+          message.uiConfig = { hide: true };
+        }
+        else if (!this.wsContext.command.startsWith('hardis:')) {
+          try {
+            const commandParts = this.wsContext.command.split(':');
+            // Plugin root provided by the init hook (third-party plugins).
+            const pluginRoot = (this.wsContext as any).commandPluginRoot as string | undefined;
+            const commandsBase = pluginRoot
+              ? path.resolve(pluginRoot, 'lib/commands')
+              : path.resolve(__dirname, '../../lib/commands');
+            const commandPath = path.resolve(commandsBase, ...commandParts) + '.js';
+            const fileUrl = 'file://' + commandPath.replace(/\\/g, '/');
+            const imported = await import(fileUrl);
+            const CommandClass = imported.default;
+            if (CommandClass && CommandClass.uiConfig) {
+              message.uiConfig = CommandClass.uiConfig;
+            }
+          } catch {
+            // External plugins are not expected to expose a command class
+            // file at the resolved path: uiConfig is best-effort for them.
           }
         }
       }

--- a/test/common/websocketClient.test.ts
+++ b/test/common/websocketClient.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+// HIDDEN_PANEL_COMMANDS lets websocketClient send the initClient message
+// without importing any sfdx-hardis command class (importing a heavy one used
+// to delay the VS Code "Running" status by several seconds). This test keeps
+// the set in sync with the `public static uiConfig = { hide: true }`
+// declarations of the command classes.
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import { HIDDEN_PANEL_COMMANDS } from '../../src/common/websocketClient.js';
+
+function listCommandFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return listCommandFiles(fullPath);
+    }
+    return entry.name.endsWith('.ts') ? [fullPath] : [];
+  });
+}
+
+describe('websocketClient HIDDEN_PANEL_COMMANDS', () => {
+  it('matches the command classes declaring uiConfig with hide: true', () => {
+    const commandsDir = path.join(process.cwd(), 'src', 'commands');
+    const hiddenFromSources = new Set<string>();
+    for (const file of listCommandFiles(commandsDir)) {
+      const source = fs.readFileSync(file, 'utf8');
+      const uiConfigMatch = source.match(/static\s+uiConfig\s*=\s*(\{[^}]*\})/);
+      if (uiConfigMatch && /hide\s*:\s*true/.test(uiConfigMatch[1])) {
+        const commandId = path
+          .relative(commandsDir, file)
+          .replace(/\.ts$/, '')
+          .split(path.sep)
+          .join(':');
+        hiddenFromSources.add(commandId);
+      }
+    }
+    expect([...hiddenFromSources].sort()).to.deep.equal([...HIDDEN_PANEL_COMMANDS].sort());
+  });
+});

--- a/test/common/websocketClient.test.ts
+++ b/test/common/websocketClient.test.ts
@@ -26,7 +26,8 @@ describe('websocketClient HIDDEN_PANEL_COMMANDS', () => {
     const hiddenFromSources = new Set<string>();
     for (const file of listCommandFiles(commandsDir)) {
       const source = fs.readFileSync(file, 'utf8');
-      const uiConfigMatch = source.match(/static\s+uiConfig\s*=\s*(\{[^}]*\})/);
+      // Anchored to the line start so a commented-out declaration never matches
+      const uiConfigMatch = source.match(/^[ \t]*(?:public\s+)?static\s+uiConfig\s*=\s*(\{[^}]*\})/m);
       if (uiConfigMatch && /hide\s*:\s*true/.test(uiConfigMatch[1])) {
         const commandId = path
           .relative(commandsDir, file)


### PR DESCRIPTION
## Why

Users report that clicking **New User Story** or **Save / publish my current task** in the VS Code extension opens the Command Runner panel immediately, but the status stays on **Starting** for up to 5 seconds before switching to **Running**.

The status switches on the `initClient` WebSocket message. Measured on a real project (spawn of `sf hardis:work:new` → `initClient`), the WebSocket **connects after ~0.8 s**, but `initClient` only left **after ~5 s**: the `open` handler of `WebSocketClient` awaited a dynamic import of the whole command class, just to read its static `uiConfig` — and `hardis:work:new` pulls the entire utils tree with it.

Only 2 commands declare a `uiConfig`, both `{ hide: true }` (`hardis:cache:clear`, `hardis:work:ws`).

## What

- `initClient` is now sent without importing any sfdx-hardis command class: the commands with `uiConfig = { hide: true }` are listed in a static `HIDDEN_PANEL_COMMANDS` set (same pattern as `DISABLE_WEBSOCKET_COMMANDS` in the init hook).
- A unit test scans `src/commands` for `static uiConfig` declarations with `hide: true` and fails when the set is out of sync.
- Third-party plugin commands (via `SFDX_HARDIS_PLUGIN_PREFIXES`) keep the previous behavior: their class is loaded to read `uiConfig`, best-effort.
- The now-unused `uxLogDeferred` helper is removed.

## Code review

Reviewed (agent pass over the diff), follow-up applied:

- A third-party plugin command contributed under the `hardis` topic still loads its class to read `uiConfig` (the fast path is keyed on the plugin root, not the command prefix).
- The sync test regex is anchored to the line start so a commented-out `uiConfig` declaration can not keep a command hidden.

## Measured (spawn → initClient, real project, warm compile cache)

| command | before | after |
|---|---:|---:|
| `sf hardis:work:new` | 5074 ms | 749 ms |
| `sf hardis:work:save` | 3844 ms | 754 ms |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
