### PR TITLE
Prevents Azure report publish task failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [beta] (main)
 
+- Fixed Azure Pipelines check and deployment jobs failing on the publish artifact step when there is nothing to deploy (missing hardis-report folder).
 - Fix GitLab validation jobs scanning thousands of historical Merge Requests during the Deployment Actions phase, making pipelines exceed their timeout
 - New [disableDeploymentActions](https://sfdx-hardis.cloudity.com/salesforce-ci-cd-work-on-task-deployment-actions/#disable-deployment-actions) config property (or SFDX_HARDIS_DISABLE_DEPLOYMENT_ACTIONS env var) to fully disable the deployment actions feature.
 - The major orgs list (config/branches files) is now read once per command instead of being re-globbed and re-parsed at every call.

--- a/defaults/ci/azure-pipelines-checks.yml
+++ b/defaults/ci/azure-pipelines-checks.yml
@@ -108,8 +108,11 @@ jobs:
           SFDX_DISABLE_FLOW_DIFF: false # Set to true to disable Flow doc during CI/CD setup
         displayName: "Simulate deploy to org"
       # Publish sfdx-hardis reports, including the complete deployment result JSON
+      # continueOnError: the folder is not created when there is nothing to deploy
+      # (empty delta package.xml), and the publish task hard-fails on a missing path
       - publish: $(System.DefaultWorkingDirectory)/hardis-report/
         condition: succeededOrFailed()
+        continueOnError: true
         artifact: hardis-report
         displayName: Publish sfdx-hardis reports
 

--- a/defaults/ci/azure-pipelines-deployment.yml
+++ b/defaults/ci/azure-pipelines-deployment.yml
@@ -93,7 +93,10 @@ jobs:
           BUILD_BUILD_ID: $(Build.BuildId)
         displayName: "Deploy sources to related SF Org"
       # Publish sfdx-hardis reports, including the complete deployment result JSON
+      # continueOnError: the folder is not created when there is nothing to deploy
+      # (empty delta package.xml), and the publish task hard-fails on a missing path
       - publish: $(System.DefaultWorkingDirectory)/hardis-report/
         condition: succeededOrFailed()
+        continueOnError: true
         artifact: hardis-report
         displayName: Publish sfdx-hardis reports


### PR DESCRIPTION
Addresses an issue where Azure Pipelines (both check and deployment jobs) would fail on the 'Publish sfdx-hardis reports' step.

This failure occurred because the `hardis-report` folder is not created when there are no changes to deploy (e.g., an empty delta package.xml), causing the publish task to hard-fail on a missing path.

Adds `continueOnError: true` to the `publish` task for `hardis-report` in both the `azure-pipelines-checks.yml` and `azure-pipelines-deployment.yml` templates. This ensures that pipelines can complete successfully even if the report folder is absent.