### PR TITLE
Deployment tip: empty custom object committed without label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [beta] (main)
 
+- New [Deployment assistant](https://sfdx-hardis.cloudity.com/salesforce-deployment-agent-error-list/) tip for "Must specify a non-empty label for the CustomObject", telling how to fix a custom object committed without its attributes.
+
 ## [8.4.0] 2026-08-31
 
 - New expert mode: set [SFDX_HARDIS_EXPERT_MODE](https://sfdx-hardis.cloudity.com/all-env-variables/) to `true` and [hardis:work:save](https://sfdx-hardis.cloudity.com/hardis/work/save/) skips its confirmation questions and opens the Merge Request page at the end.

--- a/docs/salesforce-deployment-agent-error-list.md
+++ b/docs/salesforce-deployment-agent-error-list.md
@@ -416,6 +416,23 @@ sf project retrieve start -m EmailTemplate:{1} -o YOUR_ORG_USERNAME
 ```
 
 ---
+## [Empty custom object](sf-deployment-assistant/Empty-custom-object.md)
+
+**Detection**
+
+- RegExp: `Error (.*) Must specify a non-empty label for the CustomObject`
+
+**Resolution**
+
+```shell
+The CustomObject {1} has been committed without its attributes: its .object-meta.xml has no label, so the target org can not create it.
+This usually happens when an object is retrieved empty, for example an object owned by a managed package.
+- Either retrieve {1} again and check that its .object-meta.xml really contains a label and the other object attributes:
+  sf project retrieve start -m CustomObject:{1} -o SOURCE_ORG_USERNAME
+- Or, if {1} does not belong to your project, remove it from the source files (objects/{1} folder) AND from the CustomObject section of manifest/package.xml
+```
+
+---
 ## [Empty source items](sf-deployment-assistant/Empty-source-items.md)
 
 **Detection**

--- a/docs/sf-deployment-assistant/Empty-custom-object.md
+++ b/docs/sf-deployment-assistant/Empty-custom-object.md
@@ -1,0 +1,20 @@
+---
+title: "Empty custom object (Deployment assistant)"
+description: "How to solve Salesforce deployment error \"Error (.*) Must specify a non-empty label for the CustomObject\""
+---
+<!-- markdownlint-disable MD013 -->
+# Empty custom object
+
+## Detection
+
+- RegExp: `Error (.*) Must specify a non-empty label for the CustomObject`
+
+## Resolution
+
+```shell
+The CustomObject {1} has been committed without its attributes: its .object-meta.xml has no label, so the target org can not create it.
+This usually happens when an object is retrieved empty, for example an object owned by a managed package.
+- Either retrieve {1} again and check that its .object-meta.xml really contains a label and the other object attributes:
+  sf project retrieve start -m CustomObject:{1} -o SOURCE_ORG_USERNAME
+- Or, if {1} does not belong to your project, remove it from the source files (objects/{1} folder) AND from the CustomObject section of manifest/package.xml
+```

--- a/src/common/utils/deployTipsList.ts
+++ b/src/common/utils/deployTipsList.ts
@@ -242,6 +242,16 @@ Example of element to delete:
 sf project retrieve start -m EmailTemplate:{1} -o YOUR_ORG_USERNAME`,
     },
     {
+      name: "empty-custom-object",
+      label: "Empty custom object",
+      expressionRegex: [/Error (.*) Must specify a non-empty label for the CustomObject/gm],
+      tip: `The CustomObject {1} has been committed without its attributes: its .object-meta.xml has no label, so the target org can not create it.
+This usually happens when an object is retrieved empty, for example an object owned by a managed package.
+- Either retrieve {1} again and check that its .object-meta.xml really contains a label and the other object attributes:
+  sf project retrieve start -m CustomObject:{1} -o SOURCE_ORG_USERNAME
+- Or, if {1} does not belong to your project, remove it from the source files (objects/{1} folder) AND from the CustomObject section of manifest/package.xml`,
+    },
+    {
       name: "empty-item",
       label: "Empty source items",
       expressionString: [


### PR DESCRIPTION
## What

Adds a Deployment Assistant tip for the error `Must specify a non-empty label for the CustomObject`, which previously fell into "No tip found for error".

Example of the unhandled error:

```
CustomObject dsfs__DocuSign_Status__c: Must specify a non-empty label for the CustomObject
No tip found for error. Try asking ChatGPT, Google or a Release Manager
```

## Tip content

The object has been committed without its attributes: its `.object-meta.xml` has no label, so the target org can not create it. That usually happens when an object is retrieved empty, for example an object owned by a managed package.

Two fixes are proposed:

- Retrieve the object again and check its `.object-meta.xml` really contains a label and the other object attributes
- Or, if the object does not belong to the project, remove it from the source files AND from the `CustomObject` section of `manifest/package.xml`

## Changes

- `src/common/utils/deployTipsList.ts`: new `empty-custom-object` tip, regex `Error (.*) Must specify a non-empty label for the CustomObject`
- `docs/sf-deployment-assistant/Empty-custom-object.md`: new assistant page
- `docs/salesforce-deployment-agent-error-list.md`: new entry
- `CHANGELOG.md`: beta entry