### PR TITLE
fix(doc): generate valid page metadata for deployment assistant error pages

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -18,6 +18,7 @@ CHANGELOG.md entries are read by **end users** (Salesforce admins, devs, ops) de
 - **Skip implementation details** unless they directly affect the user: file paths, function names, i18n keys, internal flags, refactor mechanics.
 - **Link the command** when the entry applies to a specific command, using the standard format `[hardis:topic:action](https://sfdx-hardis.cloudity.com/hardis/topic/action/)`.
 - **Always group updates by command.** A command must appear at most once in a section. If it already has an entry (or you are adding several changes to the same command), write the command link once and put each change as a nested bullet under it - never repeat the same command link on multiple top-level lines. A single change stays on one line: `[command](url): <change>.`
+- **Group with bullets, never with headers.** The command link is a top-level bullet and its changes are nested bullets under it. Do not open a `###` (or any other) header per command, and do not add a header per category. A version section (`## [beta] (main)`, `## [8.4.2] 2026-09-02`) is the only header a section holds.
 - **Add entries under `## [beta] (main)`** at the top of the file. Do not create version sections - releases set those.
 
 ## Pattern
@@ -38,3 +39,12 @@ Multiple changes for the same command - group them under one command link:
 ```
 
 Each nested bullet must be end-user relevant (a new flag, a new channel, a new default, a fixed behavior). Never use sub-bullets to list affected files or locales.
+
+Never do this, even when a command has many changes:
+
+```markdown
+### [hardis:topic:action](https://sfdx-hardis.cloudity.com/hardis/topic/action/)
+
+- <change>.
+- <change>.
+```

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -18,7 +18,7 @@ CHANGELOG.md entries are read by **end users** (Salesforce admins, devs, ops) de
 - **Skip implementation details** unless they directly affect the user: file paths, function names, i18n keys, internal flags, refactor mechanics.
 - **Link the command** when the entry applies to a specific command, using the standard format `[hardis:topic:action](https://sfdx-hardis.cloudity.com/hardis/topic/action/)`.
 - **Always group updates by command.** A command must appear at most once in a section. If it already has an entry (or you are adding several changes to the same command), write the command link once and put each change as a nested bullet under it - never repeat the same command link on multiple top-level lines. A single change stays on one line: `[command](url): <change>.`
-- **Group with bullets, never with headers.** The command link is a top-level bullet and its changes are nested bullets under it. Do not open a `###` (or any other) header per command, and do not add a header per category. A version section (`## [beta] (main)`, `## [8.4.2] 2026-09-02`) is the only header a section holds.
+- **Group with bullets, never with a header.** The command link is a top-level bullet and its changes are nested bullets under it. Never open a `###` (or any other) header for a command, however many changes it has.
 - **Add entries under `## [beta] (main)`** at the top of the file. Do not create version sections - releases set those.
 
 ## Pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [beta] (main)
 
+- Fixed the [deployment assistant error pages](https://sfdx-hardis.cloudity.com/salesforce-deployment-agent-error-list/) whose error message contains a quote or a regular expression: their page metadata was invalid, so they were missing from the site and their links were dead.
+
 ### [hardis:ticket:get](https://sfdx-hardis.cloudity.com/hardis/ticket/get/)
 
 - **New command** that reads a **single ticket in full** from JIRA, Azure Boards or ServiceNow and returns it as structured JSON, or as a markdown extract with `--output-file`. Where the Pull Request flows collect a one-line summary of every referenced ticket, this one gives you the whole requirement: description, acceptance criteria, all comments, subtasks, linked items and attachments, without opening the ticketing system.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,37 +3,34 @@
 ## [beta] (main)
 
 - Fixed the [deployment assistant error pages](https://sfdx-hardis.cloudity.com/salesforce-deployment-agent-error-list/) whose error message contains a quote or a regular expression: their page metadata was invalid, so they were missing from the site and their links were dead.
-
-### [hardis:ticket:get](https://sfdx-hardis.cloudity.com/hardis/ticket/get/)
-
-- **New command** that reads a **single ticket in full** from JIRA, Azure Boards or ServiceNow and returns it as structured JSON, or as a markdown extract with `--output-file`. Where the Pull Request flows collect a one-line summary of every referenced ticket, this one gives you the whole requirement: description, acceptance criteria, all comments, subtasks, linked items and attachments, without opening the ticketing system.
-- The ticketing system is **deduced from the identifier**: `ACME-4567` is JIRA, `1234` / `AB-4567` is Azure Boards, `INC0012345` is ServiceNow. `--provider` forces one when you need to.
-- **Attachments are downloaded** next to the extract, so screenshots and wireframes can be looked at and PDF or Office documents opened. Text attachments come back inline in the JSON.
-- The extract highlights the lines of the ticket that mention an operation deployable metadata will not carry (permission set assignment, org setting, scheduled job, data load), so they can be registered as [deployment actions](https://sfdx-hardis.cloudity.com/hardis/project/action/create/) rather than discovered at promotion time.
-- Reuses the ticketing variables you already configure (`JIRA_HOST` / `JIRA_TOKEN`..., `SERVICENOW_URL`...), from CI/CD variables or a local `.env`, and works outside of a Salesforce project.
-- **Azure Boards needs a token and nothing else.** The organization and the project are read from the git remote of the repository you are standing in, so `SYSTEM_COLLECTIONURI` and `SYSTEM_TEAMPROJECT` are only needed to override that. `AZURE_DEVOPS_EXT_PAT` - the variable the Azure CLI uses, so one you probably already have - is accepted alongside `CI_SFDX_HARDIS_AZURE_TOKEN` and `SYSTEM_ACCESSTOKEN`.
-- **New ServiceNow ticketing connector**, using the same `SERVICENOW_URL` / `SERVICENOW_USERNAME` / `SERVICENOW_PASSWORD` variables as `hardis:misc:servicenow-report`. It is only used by this command: the content of your Pull Request comments and release notes is unchanged. When `sys_journal_field` is ACL-restricted (ServiceNow answers a denied read with an empty result rather than an error, so a ticket full of comments would otherwise look like a ticket with none), the comments are read from the record's own `comments` / `work_notes` / `close_notes` fields instead, and the log says so.
+- [hardis:ticket:get](https://sfdx-hardis.cloudity.com/hardis/ticket/get/):
+  - **New command** that reads a **single ticket in full** from JIRA, Azure Boards or ServiceNow and returns it as structured JSON, or as a markdown extract with `--output-file`. Where the Pull Request flows collect a one-line summary of every referenced ticket, this one gives you the whole requirement: description, acceptance criteria, all comments, subtasks, linked items and attachments, without opening the ticketing system.
+  - The ticketing system is **deduced from the identifier**: `ACME-4567` is JIRA, `1234` / `AB-4567` is Azure Boards, `INC0012345` is ServiceNow. `--provider` forces one when you need to.
+  - **Attachments are downloaded** next to the extract, so screenshots and wireframes can be looked at and PDF or Office documents opened. Text attachments come back inline in the JSON.
+  - The extract highlights the lines of the ticket that mention an operation deployable metadata will not carry (permission set assignment, org setting, scheduled job, data load), so they can be registered as [deployment actions](https://sfdx-hardis.cloudity.com/hardis/project/action/create/) rather than discovered at promotion time.
+  - Reuses the ticketing variables you already configure (`JIRA_HOST` / `JIRA_TOKEN`..., `SERVICENOW_URL`...), from CI/CD variables or a local `.env`, and works outside of a Salesforce project.
+  - **Azure Boards needs a token and nothing else.** The organization and the project are read from the git remote of the repository you are standing in, so `SYSTEM_COLLECTIONURI` and `SYSTEM_TEAMPROJECT` are only needed to override that. `AZURE_DEVOPS_EXT_PAT` - the variable the Azure CLI uses, so one you probably already have - is accepted alongside `CI_SFDX_HARDIS_AZURE_TOKEN` and `SYSTEM_ACCESSTOKEN`.
+  - **New ServiceNow ticketing connector**, using the same `SERVICENOW_URL` / `SERVICENOW_USERNAME` / `SERVICENOW_PASSWORD` variables as `hardis:misc:servicenow-report`. It is only used by this command: the content of your Pull Request comments and release notes is unchanged. When `sys_journal_field` is ACL-restricted (ServiceNow answers a denied read with an empty result rather than an error, so a ticket full of comments would otherwise look like a ticket with none), the comments are read from the record's own `comments` / `work_notes` / `close_notes` fields instead, and the log says so.
 
 ## [8.4.2] 2026-09-02
 
-### [hardis:doc:project2markdown](https://sfdx-hardis.cloudity.com/hardis/doc/project2markdown/)
-
-- The **home page** is now a grid of cards, one per section, saying in plain language what the section holds and how many pages are behind it. Only the sections your project actually has are listed, instead of links to pages that were never generated.
-- `DO_NOT_OVERWRITE_INDEX_MD=true` no longer freezes your home page on the version that first generated it: as long as `docs/index.md` is still exactly what a previous run wrote, it is refreshed with the latest home page. The first edit you make to it keeps the page yours for good.
-- A section that documents nothing, and a section whose metadata is gone since the last run, no longer leave behind an index page listing nothing, absent from the menu but still built into the site.
-- An **object page** now lists the assignment rules, auto-response rules, escalation rules, approval processes, workflow rules and Lightning Web Components that touch it: building those tables raised an error the documentation swallowed, which silently dropped the sections from every object page.
-- Fixed the **validation rules table** of an object breaking apart when a rule description or a formula spans several lines, and formulas no longer lose the `||` of their OR conditions.
-- **Wide tables** now fit the page instead of hiding their last column behind a horizontal scrollbar, and a table longer than **15 rows** gets a **filter box**, so a 500 field object can be searched instead of scrolled.
-- Every page now carries its **own title**, so section pages are no longer all called "Index" in the browser tab and in search results.
-- Documentation pages ship about **30 times less navigation markup**, which is what made a large project's site slow to open.
-- Fixed the site title, the repository link and the whole **footer** being written in near-black on the navy bar, and added **breadcrumbs** and a **back to top** button.
-- Fields without a description no longer display the text **"undefined"**, and user licenses are no longer mangled into "B2 B M A Integration User".
-- **Process Builders** now have their own section title instead of appearing as a second "Flows" list, and every index table is **sorted by name**.
-- An object whose page **fails to generate** is now reported, instead of leaving the page short of a few sections with nothing said about it.
-- The **manifest pages** now carry a title too, instead of being called "Package.Xml" and "Destructivechanges.Xml" after their file name.
-- The links inside a **mermaid diagram** are now relative, so they still work on a site that is not served from the root of a domain, such as a Salesforce static resource or a GitHub Pages project site.
-- `docs/javascripts/gtag.js` is refreshed while it still holds the placeholder measurement id, so an existing documentation stops calling googletagmanager on every page load. A **real id you configured is never touched**.
-- Documentation styling and behavior moved to **`docs/stylesheets/sfdx-hardis-doc.css`** and **`docs/javascripts/sfdx-hardis-doc.js`**, rewritten on every run, so an existing documentation receives the fixes. Your own customizations stay in `extra.css` and `tables.js`.
+- [hardis:doc:project2markdown](https://sfdx-hardis.cloudity.com/hardis/doc/project2markdown/):
+  - The **home page** is now a grid of cards, one per section, saying in plain language what the section holds and how many pages are behind it. Only the sections your project actually has are listed, instead of links to pages that were never generated.
+  - `DO_NOT_OVERWRITE_INDEX_MD=true` no longer freezes your home page on the version that first generated it: as long as `docs/index.md` is still exactly what a previous run wrote, it is refreshed with the latest home page. The first edit you make to it keeps the page yours for good.
+  - A section that documents nothing, and a section whose metadata is gone since the last run, no longer leave behind an index page listing nothing, absent from the menu but still built into the site.
+  - An **object page** now lists the assignment rules, auto-response rules, escalation rules, approval processes, workflow rules and Lightning Web Components that touch it: building those tables raised an error the documentation swallowed, which silently dropped the sections from every object page.
+  - Fixed the **validation rules table** of an object breaking apart when a rule description or a formula spans several lines, and formulas no longer lose the `||` of their OR conditions.
+  - **Wide tables** now fit the page instead of hiding their last column behind a horizontal scrollbar, and a table longer than **15 rows** gets a **filter box**, so a 500 field object can be searched instead of scrolled.
+  - Every page now carries its **own title**, so section pages are no longer all called "Index" in the browser tab and in search results.
+  - Documentation pages ship about **30 times less navigation markup**, which is what made a large project's site slow to open.
+  - Fixed the site title, the repository link and the whole **footer** being written in near-black on the navy bar, and added **breadcrumbs** and a **back to top** button.
+  - Fields without a description no longer display the text **"undefined"**, and user licenses are no longer mangled into "B2 B M A Integration User".
+  - **Process Builders** now have their own section title instead of appearing as a second "Flows" list, and every index table is **sorted by name**.
+  - An object whose page **fails to generate** is now reported, instead of leaving the page short of a few sections with nothing said about it.
+  - The **manifest pages** now carry a title too, instead of being called "Package.Xml" and "Destructivechanges.Xml" after their file name.
+  - The links inside a **mermaid diagram** are now relative, so they still work on a site that is not served from the root of a domain, such as a Salesforce static resource or a GitHub Pages project site.
+  - `docs/javascripts/gtag.js` is refreshed while it still holds the placeholder measurement id, so an existing documentation stops calling googletagmanager on every page load. A **real id you configured is never touched**.
+  - Documentation styling and behavior moved to **`docs/stylesheets/sfdx-hardis-doc.css`** and **`docs/javascripts/sfdx-hardis-doc.js`**, rewritten on every run, so an existing documentation receives the fixes. Your own customizations stay in `extra.css` and `tables.js`.
 
 ## [8.4.1] 2026-09-02
 

--- a/build.cjs
+++ b/build.cjs
@@ -179,6 +179,19 @@ class SfdxHardisBuilder {
     return `'${escapedValue}'`;
   }
 
+  // A YAML double-quoted scalar only accepts a fixed set of escape sequences, so a raw backslash
+  // coming from a regex (\(, \), \.) or a raw double quote coming from a label or an error message
+  // makes the front matter unparseable and breaks the documentation build.
+  toYamlDoubleQuotedString(value) {
+    const escapedValue = String(value)
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\r/g, "\\r")
+      .replace(/\n/g, "\\n")
+      .replace(/\t/g, "\\t");
+    return `"${escapedValue}"`;
+  }
+
   async buildDeployTipsDoc() {
     console.log("Building salesforce-deployment-agent-error-list.md doc...");
     const deployTipsDocFile = "./docs/salesforce-deployment-agent-error-list.md";
@@ -240,11 +253,11 @@ class SfdxHardisBuilder {
   buildIndividualMarkdownPageForTip(tip, tipFile) {
     const errorDescription = tip?.examples?.length > 0 ? tip.examples[0] :
       tip?.expressionString?.length > 0 ? tip?.expressionString[0] :
-        tip.expressionRegex[0].toString().replace("/Error", "Error").replace("/gm", "").replace(/\"/gm, '\\\"');
+        tip.expressionRegex[0].toString().replace("/Error", "Error").replace("/gm", "");
     const tipFileMd = [
       "---",
-      `title: "${tip.label} (Deployment assistant)"`,
-      `description: "How to solve Salesforce deployment error \\\"${errorDescription}\\\""`,
+      `title: ${this.toYamlDoubleQuotedString(`${tip.label} (Deployment assistant)`)}`,
+      `description: ${this.toYamlDoubleQuotedString(`How to solve Salesforce deployment error "${errorDescription}"`)}`,
       "---",
       "<!-- markdownlint-disable MD013 -->"
     ];

--- a/docs/sf-deployment-assistant/Campaign-can-not-be-updated.md
+++ b/docs/sf-deployment-assistant/Campaign-can-not-be-updated.md
@@ -1,6 +1,6 @@
 ---
 title: "Campaign can not be updated (Deployment assistant)"
-description: "How to solve Salesforce deployment error \"The object "Campaign" can't be updated\""
+description: "How to solve Salesforce deployment error \"The object \"Campaign\" can't be updated\""
 ---
 <!-- markdownlint-disable MD013 -->
 # Campaign can not be updated

--- a/docs/sf-deployment-assistant/Condition-missing-reference.md
+++ b/docs/sf-deployment-assistant/Condition-missing-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Condition missing reference (Deployment assistant)"
-description: "How to solve Salesforce deployment error \"Error (.*) field integrity exception: unknown \(A condition has a reference to (.*), which doesn't exist.\)\""
+description: "How to solve Salesforce deployment error \"Error (.*) field integrity exception: unknown \\(A condition has a reference to (.*), which doesn't exist.\\)\""
 ---
 <!-- markdownlint-disable MD013 -->
 # Condition missing reference

--- a/docs/sf-deployment-assistant/Couldn-t-retrieve-or-load-information-on-the-field.md
+++ b/docs/sf-deployment-assistant/Couldn-t-retrieve-or-load-information-on-the-field.md
@@ -1,6 +1,6 @@
 ---
 title: "Couldn't retrieve or load information on the field (Deployment assistant)"
-description: "How to solve Salesforce deployment error \"Error (.*) Something went wrong. We couldn't retrieve or load the information on the field: (.*)\.\""
+description: "How to solve Salesforce deployment error \"Error (.*) Something went wrong. We couldn't retrieve or load the information on the field: (.*)\\.\""
 ---
 <!-- markdownlint-disable MD013 -->
 # Couldn't retrieve or load information on the field

--- a/docs/sf-deployment-assistant/Invalid-field-for-upsert.md
+++ b/docs/sf-deployment-assistant/Invalid-field-for-upsert.md
@@ -1,6 +1,6 @@
 ---
 title: "Invalid field for upsert (Deployment assistant)"
-description: "How to solve Salesforce deployment error \"Error (.*) Invalid field for upsert, must be an External Id custom or standard indexed field: (.*) \((.*)\)\""
+description: "How to solve Salesforce deployment error \"Error (.*) Invalid field for upsert, must be an External Id custom or standard indexed field: (.*) \\((.*)\\)\""
 ---
 <!-- markdownlint-disable MD013 -->
 # Invalid field for upsert

--- a/docs/sf-deployment-assistant/Invalid-type.md
+++ b/docs/sf-deployment-assistant/Invalid-type.md
@@ -1,6 +1,6 @@
 ---
 title: "Invalid type (Deployment assistant)"
-description: "How to solve Salesforce deployment error \"Error (.*) Invalid type: (.*) \((.*)\)\""
+description: "How to solve Salesforce deployment error \"Error (.*) Invalid type: (.*) \\((.*)\\)\""
 ---
 <!-- markdownlint-disable MD013 -->
 # Invalid type

--- a/docs/sf-deployment-assistant/Variable-does-not-exist.md
+++ b/docs/sf-deployment-assistant/Variable-does-not-exist.md
@@ -1,6 +1,6 @@
 ---
 title: "Variable does not exist (Deployment assistant)"
-description: "How to solve Salesforce deployment error \"Error (.*) Variable does not exist: (.*) \((.*)\)\""
+description: "How to solve Salesforce deployment error \"Error (.*) Variable does not exist: (.*) \\((.*)\\)\""
 ---
 <!-- markdownlint-disable MD013 -->
 # Variable does not exist


### PR DESCRIPTION
## Problem

The doc build job fails on `zensical build`:

```
RuntimeError: error reading page metadata 'sf-deployment-assistant/Couldn-t-retrieve-or-load-information-on-the-field.md':
while parsing a quoted scalar, found unknown escape character at byte 96 line 2 column 14
```

Plus 6 `page does not exist` warnings on links from `salesforce-deployment-agent-error-list.md`.

## Cause

`build.cjs` writes the `title` and `description` front matter of every `docs/sf-deployment-assistant/*.md` page by interpolating the tip label and its error message directly into a YAML double-quoted scalar.

A YAML double-quoted scalar only accepts a fixed set of escape sequences. Six tips whose error message is a regular expression or contains a quote produced invalid YAML:

- `\(`, `\)`, `\.` coming from `expressionRegex` are read as unknown escape characters
- the raw `"` in `The object "Campaign" can't be updated` closes the scalar early

Those 6 pages therefore failed metadata parsing, which is what made Zensical treat them as non-existent (the 6 dead-link warnings) and then abort the build.

## Fix

Added `toYamlDoubleQuotedString()` in `build.cjs`, which escapes backslashes, double quotes and control characters before the value goes into the front matter, and used it for both `title` and `description`. Removed the partial `"` escaping that was applied to the regex branch only.

Regenerated the docs, so the 6 affected pages are fixed in this PR and stay correct on every future `yarn build`.

## Affected pages

- `Campaign-can-not-be-updated.md`
- `Condition-missing-reference.md`
- `Couldn-t-retrieve-or-load-information-on-the-field.md`
- `Invalid-field-for-upsert.md`
- `Invalid-type.md`
- `Variable-does-not-exist.md`

## Checks

- `zensical build` locally: `No issues found` (was 6 issues + `RuntimeError`)
- Every `docs/**/*.md` front matter block parses as YAML (was 6 failures, now 0)
- `node build.cjs` run twice in a row leaves the tree clean, so the generation is idempotent
