### PR TITLE
fix(schema): show Jira Host only when the ticketing provider is Jira

### DIFF
--- a/config/sfdx-hardis.jsonschema.json
+++ b/config/sfdx-hardis.jsonschema.json
@@ -2172,7 +2172,14 @@
         "hardisgroup.atlassian.net"
       ],
       "title": "Jira Host",
-      "type": "string"
+      "type": "string",
+      "visible-conditions": [
+        {
+          "property": "ticketingProvider",
+          "operator": "equals",
+          "value": "JIRA"
+        }
+      ]
     },
     "jiraTicketRegex": {
       "$id": "#/properties/jiraTicketRegex",


### PR DESCRIPTION
The `jiraHost` config property was always displayed in the sfdx-hardis settings UI, whatever the selected ticketing provider.

Add the same `visible-conditions` block already used by `jiraTicketRegex` and the ServiceNow properties, so Jira Host only shows when `ticketingProvider` is `JIRA`.